### PR TITLE
Add basic recursive types.

### DIFF
--- a/examples/sessions/smtp.links
+++ b/examples/sessions/smtp.links
@@ -5,34 +5,32 @@ typename MessageBody = String;
 
 typename Message = (sender:Address, recipients:[Address], subject:Subject, body:MessageBody);
 
-typename ReceiveMail =
-  mu mail.[&|MAIL:?Address.
-              [+|REJECT:mail,
-                 ACCEPT:mu first.[&|RCPT:?Address.
-                                     [+|REJECT:first,
-                                        ACCEPT:mu body.
-                                          [&|RCPT:?Address.[+|REJECT:body, ACCEPT:body|+],
-                                             DATA:?Subject.?MessageBody.mail|&]
-                                     |+]
-                                 |&]
-              |+],
-             QUIT:EndBang
-          |&];
-
 typename SMTPServer =
-  mu greet.[&|HELO:?Domain.[+|ACCEPT:ReceiveMail, REJECT:greet|+],
-              QUIT:EndBang
-           |&];
+  [&|
+    HELO: ?Domain . [+| ACCEPT: ReceiveMail, REJECT: SMTPServer |+],
+    QUIT: EndBang
+  |&];
 
-typename ReceiveBody = 
-  mu body.[&|RCPT:?Address.[+|REJECT:body, ACCEPT:body|+],
-             DATA:?Subject.?MessageBody.ReceiveMail
-          |&];
+typename ReceiveMail =
+  [&|
+    MAIL:?Address.
+      [+|
+        REJECT: ReceiveMail,
+        ACCEPT: ReceiveRecipient
+      |+],
+    QUIT:EndBang
+  |&];
+
+typename ReceiveBody =
+  [&|
+    RCPT: ?Address . [+| REJECT: ReceiveBody, ACCEPT: ReceiveBody |+],
+    DATA: ?Subject . ?MessageBody . ReceiveMail
+  |&];
 
 typename ReceiveRecipient =
-  mu recipient.[&|RCPT:?Address.
-                   [+|REJECT:recipient, ACCEPT:ReceiveBody|+]
-               |&];
+  [&|
+    RCPT:?Address . [+| REJECT: ReceiveRecipient, ACCEPT:ReceiveBody |+]
+  |&];
 
 ### the server
 sig mailServer : (SMTPServer) ~> EndBang
@@ -42,7 +40,7 @@ fun mailServer(s) {
   var welcomeMessage = read(socket);
   print("S: " ^^ welcomeMessage);
   offer(s) {
-    case HELO(s) ->             
+    case HELO(s) ->
       var (domain, s) = receive(s);
       write("HELO " ^^ domain ^^ "\n", socket);
       var smtpAnswer = read(socket);
@@ -101,7 +99,7 @@ fun receiveRecipient(s, socket) {
         var s = select REJECT s;
         print("S: " ^^ smtpAnswer);
         receiveRecipient(s, socket)
-      } else {    
+      } else {
         var s = select ACCEPT s;
         receiveBody(s, socket)
       }
@@ -121,7 +119,7 @@ fun receiveBody(s, socket) {
         var s = select REJECT s;
         print("S: " ^^ smtpAnswer);
         receiveBody(s, socket)
-      } else {    
+      } else {
         var s = select ACCEPT s;
         receiveBody(s, socket)
       }
@@ -130,7 +128,7 @@ fun receiveBody(s, socket) {
       var (message, s) = receive(s);
       write("DATA\n", socket);
       var smtpAnswer = read(socket);
-      print("S: " ^^ smtpAnswer);   
+      print("S: " ^^ smtpAnswer);
       write("SUBJECT: " ^^ subject ^^ "\n", socket);
       print("C: SUBJECT: " ^^ subject);
       write(message ^^ "\n", socket);
@@ -243,6 +241,6 @@ fun startCommunication(message) {
   mailClient(fork(mailServer), message)
 }
 
-startCommunication((sender="foo@bar.com", recipients=[ # fill in some recipients...
-                                                     ],
-                    subject="Links SMTP test", body="Hello ABCD.\nHow are you?"))
+startCommunication((sender="foo@bar.com",
+  recipients= [ "simon.fowler@ed.ac.uk", "simon@simonjf.com" ],
+  subject="Links SMTP test", body="Hello ABCD.\nHow are you?"))


### PR DESCRIPTION
This commit adds basic recursive types to Links. This means that when
writing a recursive type, it is no longer necessary to add explicit Mu
annotations, as this will be performed automatically during the binding
refinement stage.

Types within the same group (ie, immediately following each other upon
declaration, uninterrupted by other declarations such as functions) will
be checked for mutual recursion, and inlined if this is necessary.

Currently, this does not work on recursive types with type arguments --
but that will be fixed in a subsequent commit.

The commit also modifies the SMTP example to reflect and illustrate the
new changes.
