### PR TITLE
Look for prelude in the Links executables directory.

### DIFF
--- a/basicsettings.ml
+++ b/basicsettings.ml
@@ -12,9 +12,10 @@ let printing_types = Settings.add_bool ("printing_types", true, `User)
 
 (** Name of the file containing the prelude code. *)
 let prelude_file = 
-    match Utility.getenv "LINKS_LIB" with 
-      None -> Settings.add_string ("prelude", "prelude.links", `System)
-    | Some path -> Settings.add_string ("prelude", path ^ "/" ^ "prelude.links", `System)
+  let prelude_dir = match Utility.getenv "LINKS_LIB" with
+      None -> Filename.dirname Sys.executable_name
+    | Some path -> path
+  in Settings.add_string ("prelude", Filename.concat prelude_dir "prelude.links", `System)
 
 (** The banner *)
 let welcome_note = Settings.add_string ("welcome_note", 


### PR DESCRIPTION
This should also fix the trailing slash issue with the LINKS_LIB environment variable.

I wrote and tested this in the shredding branch. Not sure what the process is for getting this kind of stuff merged to some place where every interested party can pick it up from...
