### PR TITLE
Fix #6

### DIFF
--- a/examples/sessions/smtp.links
+++ b/examples/sessions/smtp.links
@@ -242,5 +242,5 @@ fun startCommunication(message) {
 }
 
 startCommunication((sender="foo@bar.com",
-  recipients= [ "simon.fowler@ed.ac.uk", "simon@simonjf.com" ],
+  recipients= [ ]
   subject="Links SMTP test", body="Hello ABCD.\nHow are you?"))


### PR DESCRIPTION
Mutually-recursive types weren't being inlined properly. This is
probably a little overzealous now, as every type within a
strongly-connected component of size > is now Mu-ified, so I might
optimise this a bit later.
