### PR TITLE
Print offending field name on unification failure.

### DIFF
--- a/unify.ml
+++ b/unify.ml
@@ -1179,7 +1179,8 @@ and unify_rows' : unify_env -> ((row * row) -> unit) =
                                  ("Rows\n "^ string_of_row rigid_row
                                   ^"\nand\n "^ string_of_row open_row
                                   ^"\n could not be unified because the former is rigid"
-                                  ^" and the latter contains fields not present in the former")))
+                                  ^" and the latter contains fields not present in the former, namely `"
+                                  ^ label ^"'.")))
           ) open_field_env';
 
         let rec_env' =


### PR DESCRIPTION
Types involving database tables tend to be pretty verbose. Diffs on types would be great, and pretty printing, but for now I propose to at least print the offending field's name when unification fails.
