### PR TITLE
Multi-file Modules

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -88,6 +88,8 @@ SOURCES = $(OPC)                                \
           closures.ml                           \
           parse.mli parse.ml                    \
           sugarTraversals.mli  sugarTraversals.ml       \
+					moduleUtils.mli moduleUtils.ml \
+					chaser.mli chaser.ml \
 					desugarModules.mli desugarModules.ml \
           desugarDatatypes.mli desugarDatatypes.ml      \
           defaultAliases.ml                     \

--- a/chaser.ml
+++ b/chaser.ml
@@ -1,0 +1,148 @@
+open Utility
+open Sugartypes
+open Printf
+open ModuleUtils
+
+type prog_map = program StringMap.t
+type filename = string
+
+let module_file_name module_name =
+  match (Str.split (Str.regexp module_sep) module_name) with
+    | [] -> failwith "Internal error: empty list in module_file_name"
+    | (x::_xs) -> x
+
+(* Traversal to find module import references in the current file *)
+let rec find_module_refs prefix init_seen_modules init_import_candidates init_binding_stack =
+object(self)
+  inherit SugarTraversals.fold as super
+  (* Module definitions we've seen in the file *)
+  val seen_modules = init_seen_modules
+  val binding_stack = init_binding_stack
+  method add_seen_module x = {< seen_modules = StringSet.add x seen_modules >}
+  method get_seen_modules = seen_modules
+
+  method push_module name =
+    {< binding_stack = (`OpenStatement name) :: binding_stack >}
+
+
+  (* Imports that are not resolvable in the current file *)
+  val import_candidates = init_import_candidates
+  method add_import_candidate x =
+    {< import_candidates = StringSet.add x import_candidates >}
+  method get_import_candidates = import_candidates
+
+  method bindingnode = function
+    | `Module (module_name, block) ->
+        let new_prefix = prefixWith module_name prefix in
+        (* Add fully-qualified module to seen module list *)
+        (* Add fully-qualified module to module stack *)
+        let o = self#add_seen_module new_prefix in
+        let o1 =
+          (find_module_refs new_prefix o#get_seen_modules o#get_import_candidates
+            ((`OpenStatement new_prefix)::binding_stack))#phrase block in
+        {< seen_modules = o1#get_seen_modules; import_candidates = o1#get_import_candidates >}
+    | `Import name ->
+        let scope_res = moduleInScope seen_modules binding_stack name in
+        (match scope_res with
+          | Some(fully_qual) ->
+              self#push_module fully_qual
+          | None ->
+              (* If we can't resolve it internally, assume that it
+               * is an external dependency *)
+              self#add_import_candidate (module_file_name name))
+    | b -> super#bindingnode b
+
+  method phrasenode = function
+    | `Block (bs, p) ->
+        (* Recursively process bindings / phrase *)
+        let o1 =
+          List.fold_left (fun o_acc binding ->
+            o_acc#binding binding) self bs in
+        (* Restore the previous binding stack by making a copy of this object w/ new
+         * seen modules / bindings *)
+        let o2 = o1#phrase p in
+        {< seen_modules = o2#get_seen_modules; import_candidates = o2#get_import_candidates >}
+    | p -> super#phrasenode p
+end
+
+
+let find_external_refs prog =
+  StringSet.elements ((find_module_refs "" StringSet.empty StringSet.empty [])#program prog)#get_import_candidates
+
+let assert_no_cycles = function
+  | [] -> ()
+  | [x]::ys -> ()
+  | (x::xs)::ys -> failwith ("Error -- cyclic dependencies: " ^ (String.concat ", " (x :: xs)))
+
+let print_sorted_deps xs =
+  print_list (List.map print_list xs)
+
+let rec add_module_bindings deps dep_map =
+  match deps with
+    | [] -> []
+    (* Don't re-inline bindings of base module *)
+    | [""]::ys -> add_module_bindings ys dep_map
+    | [module_name]::ys ->
+      let (bindings, _) = StringMap.find module_name dep_map in
+      (* TODO: Fix dummy position to be more meaningful, if necessary *)
+      (`Module (module_name,
+        (`Block (bindings, (`RecordLit ([], None), Sugartypes.dummy_position)),
+        Sugartypes.dummy_position)
+        ), Sugartypes.dummy_position) :: (add_module_bindings ys dep_map)
+    | _ -> failwith "Internal error: impossible pattern in add_module_bindings"
+
+let module_filename module_name =
+  (String.uncapitalize module_name) ^ ".links"
+
+let parse_file module_name =
+  let filename = module_filename module_name in
+  let (prog, _) = Parse.parse_file Parse.program filename in
+  prog
+
+let print_external_deps prog =
+  let external_deps = find_external_refs prog in
+  printf "External dependencies:\n%s\n" (print_list external_deps)
+
+let rec add_dependencies_inner module_name module_prog visited deps dep_map =
+  if StringSet.mem module_name visited then (visited, [], dep_map) else
+  let visited1 = StringSet.add module_name visited in
+  let dep_map1 = StringMap.add module_name module_prog dep_map in
+
+  (* Fistly, get import candidates *)
+  let ics = find_external_refs module_prog in
+  (* Next, run the dependency analysis on each one to get us an adjacency list *)
+  List.fold_right (
+    fun name (visited_acc, deps_acc, dep_map_acc) ->
+      let prog = parse_file name in
+      let (visited_acc', deps_acc', dep_map_acc') = add_dependencies_inner name prog visited_acc deps_acc dep_map_acc in
+      (visited_acc', deps_acc @ deps_acc', dep_map_acc')
+  ) ics (visited1, (module_name, ics) :: deps, dep_map1)
+
+
+let unique_list xs =
+  StringSet.elements (StringSet.of_list xs)
+
+(* Top-level function: given a module name + program, return a program with
+ * all necessary files added to the binding list as top-level modules. *)
+let add_dependencies module_name module_prog =
+  let (bindings, phrase) = module_prog in
+  (* Firstly, get the dependency graph *)
+  let (_, deps, dep_binding_map) =
+    add_dependencies_inner module_name module_prog (StringSet.empty) [] (StringMap.empty) in
+  (* Next, do a topological sort to get the dependency graph and identify cyclic dependencies *)
+  let sorted_deps = Graph.topo_sort_sccs deps in
+  (* Each entry should be *precisely* one element (otherwise we have cycles) *)
+  assert_no_cycles sorted_deps;
+  (* printf "Sorted deps: %s\n" (print_sorted_deps sorted_deps); *)
+
+  (* Now, build up binding list where each opened dependency is mapped to a `Module containing
+   * its list of inner bindings. *)
+  (* FIXME: This isn't reassigning positions! What we'll want is to retain the positions, but modify
+   * the position data type to keep track of the module filename we're importing from. *)
+  let module_bindings = add_module_bindings sorted_deps dep_binding_map in
+  let transformed_prog = (module_bindings @ bindings, phrase) in
+  (* printf "After chaser transformation: \n%s\n" (Sugartypes.Show_program.show transformed_prog); *)
+  (* Finally, add this to the start of the original list of bindings *)
+  transformed_prog
+
+

--- a/chaser.mli
+++ b/chaser.mli
@@ -1,0 +1,4 @@
+(* val print_external_deps : Sugartypes.program -> unit *)
+type filename = string
+val add_dependencies : filename -> Sugartypes.program -> Sugartypes.program
+val add_module_bindings : string list list -> Sugartypes.program Utility.StringMap.t -> Sugartypes.binding list

--- a/desugarModules.ml
+++ b/desugarModules.ml
@@ -14,13 +14,13 @@
  *      }
  *    }
  * }
- * val X = ...;
+ * val x = ...;
  *
  *  --->
  *
  * val Foo:::bobsleigh = ...;
  * fun Foo:::x() { ...}
- * fun Foo:::Bar.y() { ... }
+ * fun Foo:::Bar:::y() { ... }
  * val x = ...;
  *
 *)
@@ -28,28 +28,31 @@ open Utility
 open Sugartypes
 open Printf
 
-(* Reference tree node: name of module, set of names in the module, list of
- * submodules *)
-type reference_tree_node =
-    ReferenceTreeNode of (name * stringset * (name, reference_tree_node) Hashtbl.t)
-
-let empty_tree name = `ReferenceTreeNode(name, StringSet.empty, Hashtbl.create 50)
-
 let module_sep = ":::"
 
-let rec print_tree = function
-  | `ReferenceTreeNode(n, ss, ht) ->
-      (* printf "Module Name: %s\n, variable names: %s\n"
-          n (StringSet.fold (fun x acc -> acc ^ " " ^ x) ss ""); *)
-      Hashtbl.iter(fun x y -> print_tree y) ht
+(* Only `Module and `Import don't preserve structure. We can just do a map on everything
+ * else... *)
+let rec flatten_simple = fun () ->
+object(self)
+  inherit SugarTraversals.map as super
 
+  method phrasenode : phrasenode -> phrasenode = function
+    | `Block (bs, phr) ->
+        let flattened_bindings =
+          List.concat (
+            List.map (fun b -> ((flatten_bindings ())#binding b)#get_bindings) bs
+          ) in
+        let flattened_phrase = self#phrase phr in
+        `Block (flattened_bindings, flattened_phrase)
+    | x -> super#phrasenode x
+end
 
 (* Flatten modules out. By this point the renaming will already have
  * happened.
  * Also, remove import statements (as they will have been used by the renaming
  * pass already, and we won't need them any more)
  *)
-let flatten_modules =
+and flatten_bindings = fun () ->
 object(self)
   inherit SugarTraversals.fold as super
 
@@ -61,64 +64,19 @@ object(self)
     | (`Module (_, (`Block (bindings, _), _)), _) ->
         List.fold_left (fun acc binding -> acc#binding binding) self bindings
     | (`Import _, _) -> self
-    | (x, pos) -> self#add_binding (x, pos)
+    | b -> self#add_binding ((flatten_simple ())#binding b)
 
   method program = function
     | (bindings, _body) -> self#list (fun o -> o#binding) bindings
 
 end
 
-
 let performFlattening : program -> program =
   fun programToFlatten ->
     let (bindings, phrase) = programToFlatten in
     let flattened_bindings =
-      (flatten_modules#program programToFlatten)#get_bindings in
+      ((flatten_bindings ())#program programToFlatten)#get_bindings in
     (flattened_bindings, phrase)
-
-
-(* Build an environment mapping module prefixes to (Plain |-> Qualified)
- * environments.
- *
- * Needs to be a separate pass as we need to collect all names within the
- * module prior to the renaming pass.
- *
- *)
-let rec build_env module_name node =
-object(self)
-  inherit SugarTraversals.fold as super
-  val tree_node = node
-
-  method add plain_name =
-    let `ReferenceTreeNode (module_name, names, children) = tree_node in
-    {< tree_node = `ReferenceTreeNode (module_name, StringSet.add plain_name names, children) >}
-
-  method add_child child_name new_child =
-    let `ReferenceTreeNode (module_name, names, children) = tree_node in
-    Hashtbl.add children child_name new_child;
-    self
-
-  method get_tree = tree_node
-
-  method phrasenode = function
-    | `Var name -> self (* self#add name *)
-    | x -> super#phrasenode x
-
-  method binder = function
-    | (name, dt, pos) -> self#add name
-
-  method bindingnode = function
-    | `Module (child_name, block) ->
-        let child_node =
-          (* Recursive step: generate a reference tree node for module *)
-          ((build_env child_name (empty_tree child_name))#phrase block)#get_tree in
-        self#add_child child_name child_node
-    | `Fun (b, _, _, _, _) -> self#binder b
-    | x -> super#bindingnode x
-end
-
-let generateReferenceTree prog =
-  ((build_env "" (empty_tree ""))#program prog)#get_tree
 
 let print_list xs =
   let rec print_list_inner = function
@@ -128,138 +86,104 @@ let print_list xs =
   "[" ^ print_list_inner xs ^ "]"
 
 
-let checkSubsts plain_var_name poss_substs pos =
-  (* TODO: Is there a "proper" way to report errors when not in typeSugar? *)
+let prefixWith name prefix =
+  if prefix = "" then name else prefix ^ module_sep ^ name
 
-  match poss_substs with
-    | [] -> plain_var_name
-    | [subst_name] -> subst_name
-    | xs -> failwith ("Name " ^ plain_var_name ^
-      " is ambiguous. Possible options: " ^ (print_list xs) ^ ".")
+(* Given a plain module name, checks whether it is in scope according to the
+ * current stack of open modules *)
+let rec moduleInScope seen_modules module_scope_stack module_name =
+  match module_scope_stack with
+    | [] ->
+        if StringSet.mem module_name seen_modules then Some(module_name) else None
+    | x::xs ->
+        let fully_qual = prefixWith module_name x in
+        if StringSet.mem fully_qual seen_modules then
+          Some(fully_qual)
+        else
+          moduleInScope seen_modules xs module_name
 
-(*
- * Given a reference tree, the name of the current module, a list of open
- * modules, and a variable name, find all relevant entries in the reference tree
- * and find a substitution. If none exist, leave the variable alone; if more
- * than one exists, then report an ambiguity error.
- *
- * module_name: The name of the module
- * open_modules: The list of modules that are open (currently unused)
- * reference_tree: The current reference tree allowing us to look up current
- *                 qualified variables
- * plain_var_name: the variable name we wish to qualify with module info
- * var_pos: the position of the variable
- *
- * *)
-let getSubstFor module_name open_modules reference_tree var_name var_pos =
-  let splitPath path = Str.split (Str.regexp module_sep) path in
-  (* Given a possibly-qualified variable, returns a tuple of list of module
-   * names, and the plain variable.
-   * As an example, splitVariable A.B.foo --> (["A", "B"], foo)
-   *)
-  let splitVariable var =
-    let splitList = Str.split (Str.regexp module_sep) var in
-    let revSplitList = List.rev splitList in
-    (List.hd revSplitList, List.rev (List.tl revSplitList))
-  in
+(* Given a module stack, a reference tree, and a plain variable name, resolves
+ * the fully-qualified name according to the priority of the stack.
+ * If there are no matches, leave it as it is (either FQ already or erroneous) *)
+let rec substituteVar seen_bindings module_scope_stack current_module_prefix var_name =
+  match module_scope_stack with
+    | [] -> var_name
+    | x::xs ->
+        let fully_qual = prefixWith var_name x in
+        if StringSet.mem fully_qual seen_bindings then
+          fully_qual
+        else
+          substituteVar seen_bindings xs current_module_prefix var_name
 
-  let (plain_var_name, qual_var_path) = splitVariable var_name in
-  (* Checks whether the module at the given path contains plain_var_name *)
-  let rec isContainedIn ((`ReferenceTreeNode (_, vars, tbl)) as rtn) split_path = (
-
-     match split_path with
-       | [] ->
-           (* At this point, we've traversed the entire path (including
-            * qualified variables) in the reference tree. We can now check
-            * whether there's a viable substitution we can make. *)
-           StringSet.mem plain_var_name vars
-       | m::ms ->
-           let child_node = Hashtbl.find tbl m in
-           isContainedIn child_node ms) in
-  (* For the current module, and all open modules, check whether the
-   * plain name is contained there. *)
-  let substs = ListUtils.filter_map (fun p ->
-    let split_p = splitPath p in
-    (*
-    (printf "calling isContainedIn with PVN: %s, path: %s\n" plain_var_name
-      (print_list (split_p @ qual_var_path)));
-    *)
-    isContainedIn reference_tree (split_p @ qual_var_path))
-      (fun p -> if p = "" then var_name else p ^ module_sep ^ var_name)
-      (module_name::open_modules) in
-  checkSubsts var_name substs var_pos
 
 
 (* Add module prefix to all internal binder names and variables *)
-let rec add_module_prefix prefix reference_tree init_open_modules
-  init_seen_modules =
+let rec add_module_prefix prefix init_seen_modules init_seen_bindings init_module_scope_stack =
 object(self)
   inherit SugarTraversals.fold_map as super
 
-  val cur_open_modules = init_open_modules
-  val cur_seen_modules = init_seen_modules
+  val seen_modules = init_seen_modules
+  val seen_bindings = init_seen_bindings
+  val module_scope_stack = init_module_scope_stack
 
-  method get_open_modules = cur_open_modules
-  method get_seen_modules = cur_seen_modules
+  method add_seen_module name =
+    {< seen_modules = StringSet.add name seen_modules >}
 
-  method add_open_module x =
-    {< cur_open_modules = StringSet.add x cur_open_modules >}
-  method add_seen_module x =
-    {< cur_seen_modules = StringSet.add x cur_seen_modules >}
+  method push_module name =
+    {< module_scope_stack = name :: module_scope_stack >}
 
-  method prefixWith name =
-    if prefix = "" then name else prefix ^ module_sep ^ name
+  method add_seen_binding name =
+    {< seen_bindings = StringSet.add name seen_bindings >}
+
+  method get_module_stack = module_scope_stack
+  method get_seen_modules = seen_modules
+  method get_seen_bindings = seen_bindings
+
+  method set_stack s = {< module_scope_stack = s >}
 
   method phrase = function
     | (`Var old_name, pos) ->
         (* Add prefix onto var name*)
-        let new_name =
-          (* TEMP until we get Open working *)
-          getSubstFor prefix (StringSet.elements cur_open_modules) reference_tree old_name pos in
+        let new_name = substituteVar seen_bindings module_scope_stack prefix old_name in
         (self, (`Var new_name, pos))
     | x -> super#phrase x
 
 
   method binder = function
     | (old_name, dt, pos) ->
-        let new_name =
-          if prefix = "" then old_name else prefix ^ module_sep ^ old_name in
-        (self, (new_name, dt, pos))
+        let new_name = prefixWith old_name prefix in
+        (self#add_seen_binding new_name, (new_name, dt, pos))
 
   method bindingnode = function
     | `Import name ->
         (* Check to see whether module is in our seen list. If so, we're golden,
-         * add to the open module list (qualified with our current prefix).
+         * push onto open module stack (fully-qualified).
          * If not, throw an error. *)
-        let prefixed_name = self#prefixWith name in
-        (*
-        printf "Seen names: ";
-        List.iter (printf "%s, ") (StringSet.elements cur_seen_modules);
-        printf "\n";
-        *)
-
-        if StringSet.mem prefixed_name cur_seen_modules then
-          (self#add_open_module prefixed_name, `Import name)
-        else
-          (* FIXME: It would be much better to do this as a binding, and
-           * report the position... *)
-          failwith ("Trying to import unknown module " ^ prefixed_name)
+        (match moduleInScope seen_modules module_scope_stack name with
+           | Some(fully_qualified_name) ->
+               (self#push_module fully_qualified_name, `Import name)
+           | None ->
+               failwith ("Trying to import unknown module " ^ name))
     | `Module (name, (`Block (bindings, dummy_phrase), pos)) ->
-        let new_prefix = self#prefixWith name in
+        let new_prefix = prefixWith name prefix in
         (* Add fully-qualified module to seen module list *)
-        let new_obj = self#add_seen_module new_prefix in
-        (* Recursive step: change current path, recursively rename modules *)
-        let (o, reversed_renamed_bindings) =
-          List.fold_left (fun (o, bs) binding ->
-            let (o1, new_binding) =
-              (add_module_prefix new_prefix reference_tree o#get_open_modules
-               o#get_seen_modules)#binding binding in
-            let o2 = {< cur_seen_modules = o1#get_seen_modules >} in
-               (o2, new_binding :: bs)
-          ) (new_obj, []) bindings in
+        (* Add fully-qualified module to module stack *)
+        let o = (add_module_prefix new_prefix (StringSet.add new_prefix seen_modules)
+          seen_bindings (new_prefix :: module_scope_stack)) in
+        let (o1, reversed_renamed_bindings) =
+          List.fold_left (fun (o_acc, bs_acc) binding ->
+            let (o_acc1, new_binding) = o_acc#binding binding in
+            (o_acc1, new_binding :: bs_acc)
+          ) (o, []) bindings in
         (* printf "Renamed bindings for module %s: %s\n" name (print_list
          * (List.map (Sugartypes.Show_binding.show)  (List.rev reversed_renamed_bindings))); *)
-        (o, `Module (new_prefix, (`Block (List.rev reversed_renamed_bindings, dummy_phrase), pos)))
+        let o2 = {< seen_modules = o1#get_seen_modules; seen_bindings = o1#get_seen_bindings >} in
+        (o2, `Module (new_prefix, (`Block (List.rev reversed_renamed_bindings, dummy_phrase), pos)))
+        (* let (o1, renamed_bindings) = o#list (fun o -> o#binding) bindings in *)
+        (* Restore old stack *)
+        (* printf "Renamed bindings for module %s: %s\n" name (print_list
+         * (List.map (Sugartypes.Show_binding.show)  (List.rev reversed_renamed_bindings))); *)
+        (* (o2, `Module (new_prefix, (`Block (renamed_bindings, dummy_phrase), pos))) *)
     | x -> super#bindingnode x
 
 
@@ -272,9 +196,7 @@ object(self)
 end
 
 let performRenaming prog =
-  let ref_tree = generateReferenceTree prog in
-  (* print_tree ref_tree; *)
-  snd ((add_module_prefix "" ref_tree (StringSet.empty) (StringSet.empty))#program prog)
+  snd ((add_module_prefix "" (StringSet.empty) (StringSet.empty) [""])#program prog)
 
 (* 1) Perform a renaming pass to expand names in modules to qualified names
  * 2) Peform a flattening pass to flatten modules to lists of bindings

--- a/desugarModules.ml
+++ b/desugarModules.ml
@@ -184,14 +184,6 @@ object(self)
         let o2 = {< seen_modules = o2#get_seen_modules; seen_bindings = o2#get_seen_bindings >} in
         (o2, `Block (List.rev reversed_renamed_bindings, new_phrase))
     | p -> super#phrasenode p
-
-    (*
-  method program = function
-    | (bindings, body) ->
-        let (o1, renamed_bindings) = self#list (fun o -> o#binding) bindings in
-        let (o2, renamed_body) = o1#option (fun o -> o#phrase) body in
-        (o2, (renamed_bindings, renamed_body))
-*)
 end
 
 let performRenaming prog =

--- a/desugarModules.ml
+++ b/desugarModules.ml
@@ -30,6 +30,15 @@ open Printf
 
 let module_sep = ":::"
 
+(* Renaming stack. We either have a variable binding or an "open" statement.
+ * If we have a variable binding after an "open" statement, then this should
+ * take priority over the variables contained within the opened module.
+ * Stack frames persist for a single scope (i.e. `Block) *)
+type binding_stack_node = [
+  | `OpenStatement of string
+  | `LocalVarBinding of string
+]
+
 (* Only `Module and `Import don't preserve structure. We can just do a map on everything
  * else... *)
 let rec flatten_simple = fun () ->
@@ -86,16 +95,21 @@ let print_list xs =
   "[" ^ print_list_inner xs ^ "]"
 
 
-let prefixWith name prefix =
-  if prefix = "" then name else prefix ^ module_sep ^ name
+let print_stack_node = function
+  | `OpenStatement mn -> "module: " ^ mn
+  | `LocalVarBinding lvb -> "var: " ^ lvb
+
+let print_stack s = print_list (List.map print_stack_node s)
+let prefixWith name prefix = if prefix = "" then name else prefix ^ module_sep ^ name
 
 (* Given a plain module name, checks whether it is in scope according to the
  * current stack of open modules *)
-let rec moduleInScope seen_modules module_scope_stack module_name =
-  match module_scope_stack with
+let rec moduleInScope seen_modules binding_stack module_name =
+  match binding_stack with
     | [] ->
         if StringSet.mem module_name seen_modules then Some(module_name) else None
-    | x::xs ->
+    | (`LocalVarBinding _)::xs -> moduleInScope seen_modules xs module_name
+    | (`OpenStatement x)::xs ->
         let fully_qual = prefixWith module_name x in
         if StringSet.mem fully_qual seen_modules then
           Some(fully_qual)
@@ -105,10 +119,21 @@ let rec moduleInScope seen_modules module_scope_stack module_name =
 (* Given a module stack, a reference tree, and a plain variable name, resolves
  * the fully-qualified name according to the priority of the stack.
  * If there are no matches, leave it as it is (either FQ already or erroneous) *)
-let rec substituteVar seen_bindings module_scope_stack current_module_prefix var_name =
-  match module_scope_stack with
+let rec substituteVar seen_bindings binding_stack current_module_prefix var_name =
+  (*
+  printf "Trying to substitute for %s in module %s. Seen: %s; Binding stack: %s\n"
+    var_name current_module_prefix (print_list (StringSet.elements seen_bindings)) (print_stack binding_stack);
+ *)
+  (* printf "Trying to substitute for %s in module %s; Binding stack: %s\n"
+    var_name current_module_prefix (print_stack binding_stack); *)
+  match binding_stack with
     | [] -> var_name
-    | x::xs ->
+    | (`LocalVarBinding x)::xs ->
+        if x = var_name then
+          prefixWith x current_module_prefix
+        else
+          substituteVar seen_bindings xs current_module_prefix var_name
+    | (`OpenStatement x)::xs ->
         let fully_qual = prefixWith var_name x in
         if StringSet.mem fully_qual seen_bindings then
           fully_qual
@@ -118,33 +143,36 @@ let rec substituteVar seen_bindings module_scope_stack current_module_prefix var
 
 
 (* Add module prefix to all internal binder names and variables *)
-let rec add_module_prefix prefix init_seen_modules init_seen_bindings init_module_scope_stack =
+let rec add_module_prefix prefix init_seen_modules init_seen_bindings init_binding_stack =
 object(self)
   inherit SugarTraversals.fold_map as super
 
   val seen_modules = init_seen_modules
   val seen_bindings = init_seen_bindings
-  val module_scope_stack = init_module_scope_stack
+  val binding_stack = init_binding_stack
 
   method add_seen_module name =
     {< seen_modules = StringSet.add name seen_modules >}
 
   method push_module name =
-    {< module_scope_stack = name :: module_scope_stack >}
+    {< binding_stack = (`OpenStatement name) :: binding_stack >}
+
+  method push_var_binding name =
+    {< binding_stack = (`LocalVarBinding name) :: binding_stack >}
 
   method add_seen_binding name =
     {< seen_bindings = StringSet.add name seen_bindings >}
 
-  method get_module_stack = module_scope_stack
+  method get_binding_stack = binding_stack
   method get_seen_modules = seen_modules
   method get_seen_bindings = seen_bindings
 
-  method set_stack s = {< module_scope_stack = s >}
+  method set_stack s = {< binding_stack = s >}
 
   method phrase = function
     | (`Var old_name, pos) ->
         (* Add prefix onto var name*)
-        let new_name = substituteVar seen_bindings module_scope_stack prefix old_name in
+        let new_name = substituteVar seen_bindings binding_stack prefix old_name in
         (self, (`Var new_name, pos))
     | x -> super#phrase x
 
@@ -152,40 +180,48 @@ object(self)
   method binder = function
     | (old_name, dt, pos) ->
         let new_name = prefixWith old_name prefix in
-        (self#add_seen_binding new_name, (new_name, dt, pos))
+        let o = (self#push_var_binding old_name) in
+        (o#add_seen_binding new_name, (new_name, dt, pos))
 
   method bindingnode = function
     | `Import name ->
         (* Check to see whether module is in our seen list. If so, we're golden,
          * push onto open module stack (fully-qualified).
          * If not, throw an error. *)
-        (match moduleInScope seen_modules module_scope_stack name with
+        (match moduleInScope seen_modules binding_stack name with
            | Some(fully_qualified_name) ->
-               (self#push_module fully_qualified_name, `Import name)
+               (self#push_module fully_qualified_name, `Import fully_qualified_name)
            | None ->
                failwith ("Trying to import unknown module " ^ name))
-    | `Module (name, (`Block (bindings, dummy_phrase), pos)) ->
+    | `Module (name, p) ->
         let new_prefix = prefixWith name prefix in
         (* Add fully-qualified module to seen module list *)
         (* Add fully-qualified module to module stack *)
-        let o = (add_module_prefix new_prefix (StringSet.add new_prefix seen_modules)
-          seen_bindings (new_prefix :: module_scope_stack)) in
+        let o = self#add_seen_module new_prefix in
+        let o1 = o#push_module new_prefix in
+        let (o2, renamed_phrase) =
+          (add_module_prefix new_prefix o1#get_seen_modules o1#get_seen_bindings
+            ((`OpenStatement new_prefix)::binding_stack))#phrase p in
+        let o3 = {< seen_modules = o2#get_seen_modules; seen_bindings = o2#get_seen_bindings >} in
+        (o3, `Module (new_prefix, renamed_phrase))
+        (* printf "Renamed bindings for module %s: %s\n" name (print_list
+         * (List.map (Sugartypes.Show_binding.show)  (List.rev reversed_renamed_bindings))); *)
+    | x -> super#bindingnode x
+
+  method phrasenode = function
+    | `Block (bs, p) ->
+        (* Recursively process bindings / phrase *)
         let (o1, reversed_renamed_bindings) =
           List.fold_left (fun (o_acc, bs_acc) binding ->
             let (o_acc1, new_binding) = o_acc#binding binding in
             (o_acc1, new_binding :: bs_acc)
-          ) (o, []) bindings in
-        (* printf "Renamed bindings for module %s: %s\n" name (print_list
-         * (List.map (Sugartypes.Show_binding.show)  (List.rev reversed_renamed_bindings))); *)
-        let o2 = {< seen_modules = o1#get_seen_modules; seen_bindings = o1#get_seen_bindings >} in
-        (o2, `Module (new_prefix, (`Block (List.rev reversed_renamed_bindings, dummy_phrase), pos)))
-        (* let (o1, renamed_bindings) = o#list (fun o -> o#binding) bindings in *)
-        (* Restore old stack *)
-        (* printf "Renamed bindings for module %s: %s\n" name (print_list
-         * (List.map (Sugartypes.Show_binding.show)  (List.rev reversed_renamed_bindings))); *)
-        (* (o2, `Module (new_prefix, (`Block (renamed_bindings, dummy_phrase), pos))) *)
-    | x -> super#bindingnode x
-
+          ) (self, []) bs in
+        (* Restore the previous binding stack by making a copy of this object w/ new
+         * seen modules / bindings *)
+        let (o2, new_phrase) = o1#phrase p in
+        let o2 = {< seen_modules = o2#get_seen_modules; seen_bindings = o2#get_seen_bindings >} in
+        (o2, `Block (List.rev reversed_renamed_bindings, new_phrase))
+    | p -> super#phrasenode p
 
   method program = function
     | (bindings, body) ->
@@ -196,22 +232,40 @@ object(self)
 end
 
 let performRenaming prog =
-  snd ((add_module_prefix "" (StringSet.empty) (StringSet.empty) [""])#program prog)
+  snd ((add_module_prefix "" (StringSet.empty) (StringSet.empty) [`OpenStatement ""])#program prog)
+
+
+let has_no_modules =
+object
+  inherit SugarTraversals.predicate as super
+
+  val has_no_modules = true
+  method satisfied = has_no_modules
+
+  method bindingnode = function
+    | `Import _
+    | `Module _ -> {< has_no_modules = false >}
+    | b -> super#bindingnode b
+end
+
+let requires_desugar prog = (not ((has_no_modules#program prog)#satisfied))
 
 (* 1) Perform a renaming pass to expand names in modules to qualified names
  * 2) Peform a flattening pass to flatten modules to lists of bindings
  *)
 let desugar_modules program =
-  let renamedProgram = performRenaming program in
-  let (renamedBindings, renamedBody) = renamedProgram in
-  let flattenedProgram = performFlattening renamedProgram in
-  (*
-  printf "\n=============================================================\n";
-  printf "\n=============================================================\n";
-  printf "Before: %s\n" (Sugartypes.Show_program.show program);
-  printf "\n=============================================================\n";
-  printf "After: %s\n" (Sugartypes.Show_program.show flattenedProgram);
-  *)
-  flattenedProgram
+  if (requires_desugar program) then
+    let renamedProgram = performRenaming program in
+    let (renamedBindings, renamedBody) = renamedProgram in
+    let flattenedProgram = performFlattening renamedProgram in
+    (*
+    printf "\n=============================================================\n";
+    printf "\n=============================================================\n";
+    printf "Before: %s\n" (Sugartypes.Show_program.show program);
+    printf "\n=============================================================\n";
+    printf "After: %s\n" (Sugartypes.Show_program.show flattenedProgram);
+    *)
+    flattenedProgram
+  else program
 
 

--- a/frontend.ml
+++ b/frontend.ml
@@ -25,6 +25,7 @@ struct
 
   let program =
     fun tyenv pos_context program ->
+      let program = Chaser.add_dependencies "" program in
       let program = (ResolvePositions.resolve_positions pos_context)#program program in
         CheckXmlQuasiquotes.checker#program program;
         (   DesugarLAttributes.desugar_lattributes#program

--- a/moduleUtils.ml
+++ b/moduleUtils.ml
@@ -1,0 +1,35 @@
+open Utility
+
+let module_sep = ":::"
+
+type binding_stack_node = [
+  | `OpenStatement of string
+  | `LocalVarBinding of string
+]
+
+(* Given a name and a prefix, appends the prefix (with separator)
+ * as long as the prefix is not the empty string *)
+let prefixWith name prefix =
+  if prefix = "" then name else prefix ^ module_sep ^ name
+
+let print_stack_node = function
+ | `OpenStatement mn -> "module: " ^ mn
+ | `LocalVarBinding lvb -> "var: " ^ lvb
+
+let print_module_stack s = print_list (List.map print_stack_node s)
+
+let rec moduleInScopeInner seen_modules binding_stack module_name =
+  match binding_stack with
+    | [] ->
+        if StringSet.mem module_name seen_modules then Some(module_name) else None
+    | (`LocalVarBinding _)::xs -> moduleInScopeInner seen_modules xs module_name
+    | (`OpenStatement x)::xs ->
+        let fully_qual = prefixWith module_name x in
+        if StringSet.mem fully_qual seen_modules then
+          Some(fully_qual)
+        else
+          moduleInScopeInner seen_modules xs module_name
+
+let moduleInScope seen_modules binding_stack module_name =
+  moduleInScopeInner seen_modules binding_stack module_name
+

--- a/moduleUtils.mli
+++ b/moduleUtils.mli
@@ -1,0 +1,15 @@
+(* Renaming stack. We either have a variable binding or an "open" statement.
+ * If we have a variable binding after an "open" statement, then this should
+ * take priority over the variables contained within the opened module.
+ * Stack frames persist for a single scope (i.e. `Block) *)
+type binding_stack_node = [
+  | `OpenStatement of string
+  | `LocalVarBinding of string
+]
+
+val module_sep : string
+val print_stack_node : binding_stack_node -> string
+val print_module_stack : binding_stack_node list -> string
+val moduleInScope : Utility.StringSet.t -> binding_stack_node list -> string -> string option
+val prefixWith : string -> string -> string
+

--- a/sourceCode.ml
+++ b/sourceCode.ml
@@ -20,10 +20,9 @@ object (self)
 
   (* Return the portion of source code that falls between two positions *)
   method private extract_substring (start : Lexing.position) (finish : Lexing.position) =
-    if start == Lexing.dummy_pos || finish == Lexing.dummy_pos then
-      "*** DUMMY POSITION ****"
-    else
+    try
       Buffer.sub text start.Lexing.pos_cnum (finish.Lexing.pos_cnum - start.Lexing.pos_cnum)
+    with Invalid_argument _ -> "*** DUMMY POSITION ****"
 
   (* Return some lines of the source code *)
   method extract_line_range (startline : int) (finishline : int) =

--- a/test-harness
+++ b/test-harness
@@ -57,9 +57,11 @@ def check_expected(name, item, got, expected, errors):
     else:
         return True
 
-def evaluate(name, code, stdout='', stderr='', exit = '0', flags='-e', env = None, filemode=''):
+def evaluate(name, code, stdout='', stderr='', exit = '0', flags='-e', env = None, filemode='', extern_args=''):
     if filemode.startswith('true') :
         proc = Popen((links, code), stdout=PIPE, stderr=PIPE, env=env)
+    elif filemode.startswith('extern'):
+        proc = Popen((code, extern_args), stdout=PIPE, stderr=PIPE, env=env)
     else:
         proc = Popen((links, flags, code), stdout=PIPE, stderr=PIPE, env=env)
     passed = True

--- a/tests/modules.tests
+++ b/tests/modules.tests
@@ -1,0 +1,57 @@
+Modules hide inner definitions
+./tests/modules/basic-hide.links
+filemode : true
+stderr : @.*
+exit : 1
+
+Basic qualified binding resolution
+./tests/modules/basic-qual-resolution.links
+filemode : true
+stdout : "hello" : String
+
+Inner module qualified binding resolution
+./tests/modules/basic-inner-qual-resolution.links
+filemode : true
+stdout : "hi" : String
+
+Open allows basic unqualified binding access
+./tests/modules/basic-open.links
+filemode : true
+stdout : "hello!" : String
+
+Module nesting allows partially-qualified names to be used for resolution
+./tests/modules/basic-partial-qualification.links
+filemode : true
+stdout : "hello" : String
+
+Open allows partially-qualified names to be used for resolution
+./tests/modules/basic-partial-qualification-open.links
+filemode : true
+stdout : "hello" : String
+
+Open still allows fully-qualified names to be used
+./tests/modules/basic-open-fully-qual.links
+filemode : true
+stdout : "hello" : String
+
+Opened module does not shadow bindings after opening
+./tests/modules/basic-open-shadow.links
+filemode : true
+stdout : "hi" : String
+
+Opened module shadows previous bindings after opening
+./tests/modules/basic-open-no-shadow.links
+filemode : true
+stdout : "greetings" : String
+
+Cyclic dependencies outlawed
+./tests/modules/runmulti cyclicA.links
+filemode : true
+stderr : @.*
+exit : 1
+
+Module chasing
+./tests/modules/runmulti
+filemode : extern
+extern_args : moduleA.links
+stdout : "hello from c!" : String

--- a/tests/modules/basic-hide.links
+++ b/tests/modules/basic-hide.links
@@ -1,0 +1,7 @@
+module A {
+  fun foo() {
+    "hello!"
+  }
+}
+
+foo()

--- a/tests/modules/basic-inner-qual-resolution.links
+++ b/tests/modules/basic-inner-qual-resolution.links
@@ -1,0 +1,14 @@
+module A {
+
+  module B {
+    fun bar() {
+      "hi"
+    }
+  }
+
+  fun foo() {
+    "hello"
+  }
+}
+
+A:::B:::bar()

--- a/tests/modules/basic-open-fully-qual.links
+++ b/tests/modules/basic-open-fully-qual.links
@@ -1,0 +1,13 @@
+module A {
+  module B {
+    fun bar() {
+      "hello"
+    }
+  }
+
+  fun foo() {
+    B:::bar()
+  }
+}
+
+A:::B:::bar()

--- a/tests/modules/basic-open-no-shadow.links
+++ b/tests/modules/basic-open-no-shadow.links
@@ -1,0 +1,17 @@
+module A {
+  module B {
+    fun bar() {
+      "hello"
+    }
+  }
+
+  fun foo() {
+    "hi"
+  }
+}
+
+open A
+fun foo() {
+  "greetings"
+}
+foo()

--- a/tests/modules/basic-open-shadow.links
+++ b/tests/modules/basic-open-shadow.links
@@ -1,0 +1,17 @@
+module A {
+  module B {
+    fun bar() {
+      "hello"
+    }
+  }
+
+  fun foo() {
+    "hi"
+  }
+}
+
+fun foo() {
+  "greetings"
+}
+open A
+foo()

--- a/tests/modules/basic-open.links
+++ b/tests/modules/basic-open.links
@@ -1,0 +1,8 @@
+module A {
+  fun foo() {
+    "hello!"
+  }
+}
+
+open A
+foo()

--- a/tests/modules/basic-partial-qualification-open.links
+++ b/tests/modules/basic-partial-qualification-open.links
@@ -1,0 +1,14 @@
+module A {
+  module B {
+    fun bar() {
+      "hello"
+    }
+  }
+
+  fun foo() {
+    ()
+  }
+}
+
+open A
+B:::bar()

--- a/tests/modules/basic-partial-qualification.links
+++ b/tests/modules/basic-partial-qualification.links
@@ -1,0 +1,14 @@
+module A {
+  module B {
+    fun bar() {
+      "hello"
+    }
+  }
+
+  fun foo() {
+    B:::bar()
+  }
+}
+
+open A
+A:::foo()

--- a/tests/modules/basic-qual-resolution.links
+++ b/tests/modules/basic-qual-resolution.links
@@ -1,0 +1,7 @@
+module A {
+  fun foo() {
+    "hello"
+  }
+}
+
+A:::foo()

--- a/tests/modules/cyclicA.links
+++ b/tests/modules/cyclicA.links
@@ -1,0 +1,7 @@
+open CyclicB
+
+fun bar() {
+  ()
+}
+
+foo()

--- a/tests/modules/cyclicB.links
+++ b/tests/modules/cyclicB.links
@@ -1,0 +1,5 @@
+open CyclicC
+
+fun foo() {
+  baz()
+}

--- a/tests/modules/cyclicC.links
+++ b/tests/modules/cyclicC.links
@@ -1,0 +1,5 @@
+open CyclicB
+
+fun baz() {
+  ()
+}

--- a/tests/modules/moduleA.links
+++ b/tests/modules/moduleA.links
@@ -1,0 +1,3 @@
+open ModuleB
+
+foo()

--- a/tests/modules/moduleB.links
+++ b/tests/modules/moduleB.links
@@ -1,0 +1,4 @@
+open ModuleC
+fun foo() {
+  bar()
+}

--- a/tests/modules/moduleC.links
+++ b/tests/modules/moduleC.links
@@ -1,0 +1,3 @@
+fun bar() {
+  "hello from c!"
+}

--- a/tests/modules/runmulti
+++ b/tests/modules/runmulti
@@ -1,0 +1,4 @@
+#!/usr/bin/bash
+pushd tests/modules/ &> /dev/null
+links $@
+popd &> /dev/null

--- a/utility.ml
+++ b/utility.ml
@@ -415,6 +415,14 @@ struct
     | x::xs ->
         if pred x then (f x)::(filter_map pred f xs) else
           (filter_map pred f xs)
+
+  let print_list xs =
+    let rec print_list_inner = function
+        | [] -> ""
+        | e::[] -> e
+        | e::xs -> e ^ ", " ^ (print_list_inner xs) in
+    "[" ^ print_list_inner xs ^ "]"
+
 end
 include ListUtils
 


### PR DESCRIPTION
We can now have modules over multiple files.

moduleA.links:
```
open ModuleB

foo()
```

moduleB.links:
```
open ModuleC
fun foo() {
  bar()
}
```

moduleC.links:
```
fun bar() {
  "hello from c!"
}
```
output: "hello from c!" : String

The way the chaser works is to analyse the files (recursively) to check whether any dependencies cannot be satisfied in the current file. Dependencies (provided they form a DAG, which is enforced) will be topologically sorted when discovered, so there's no need for the user to specify a build order. Once all have been discovered and loaded, they are inlined as \`Module blocks within the root file, and the analysis works exactly the same as for namespace resolution.

Next steps:
* The chaser is still a little dumb, as it only looks in the current working directory (hence the runmulti hack in the tests...) so the next step is to make the chaser look in more places (i.e. the links lib directory, directory from where the script is running, any other library directories...)
* Positions are currently erased when the bindings are inlined as Module blocks. It would be better to retain the original position, but also report the file name.
* Caching is basically unsupported. Included modules aren't cached.