### PR TITLE
Add --path for specifying location to look for files

### DIFF
--- a/basicsettings.ml
+++ b/basicsettings.ml
@@ -98,3 +98,6 @@ let optimise = Settings.add_bool("optimise", false, `User)
 
 (* Compile & cache whole program, closures, and HTML *)
 let cache_whole_program = Settings.add_bool("cache_whole_program", false, `User)
+
+(* Paths to look for .links files in chasing pass *)
+let links_file_paths = Settings.add_string("links_file_paths", "", `User)

--- a/links.ml
+++ b/links.ml
@@ -429,6 +429,7 @@ let options : opt list =
 (*     (noshort, "broken-tests",        Some (run_tests Tests.broken_tests),                   None); *)
 (*     (noshort, "failing-tests",       Some (run_tests Tests.known_failures),                 None); *)
     (noshort, "pp",                  None,                             Some (Settings.set_value BS.pp));
+    (noshort, "path",                None,                             Some (fun str -> Settings.set_value BS.links_file_paths str));
     ]
 
 let file_list = ref []

--- a/loader.ml
+++ b/loader.ml
@@ -43,8 +43,7 @@ let read_program filename : (envs * program) =
     the IR *)
 let read_file_source (nenv, tyenv) (filename:string) =
   let sugar, pos_context =
-    Parse.parse_file Parse.program filename  in
-  (* printf "Parsed AST: \n%s \n\n" (Sugartypes.Show_program.show sugar); *)
+    ModuleUtils.try_parse_file filename in
   let program, t, tenv = Frontend.Pipeline.program tyenv pos_context sugar in
   let globals, main, nenv =
     Sugartoir.desugar_program

--- a/moduleUtils.ml
+++ b/moduleUtils.ml
@@ -33,3 +33,30 @@ let rec moduleInScopeInner seen_modules binding_stack module_name =
 let moduleInScope seen_modules binding_stack module_name =
   moduleInScopeInner seen_modules binding_stack module_name
 
+(* TODO: Unix-specific one for the moment, but no easy way to get this
+ * from OCaml Filename module... *)
+let path_sep = ":"
+
+let try_parse_file filename =
+  (* First, get the list of directories, with trailing slashes stripped *)
+  let poss_dirs =
+    let path_setting = Settings.get_value Basicsettings.links_file_paths in
+    let split_dirs = Str.split (Str.regexp path_sep) path_setting in
+    "" :: "." :: (List.map (fun path ->
+      let dir_sep = Filename.dir_sep in
+      if Filename.check_suffix path dir_sep then
+        Filename.chop_suffix path dir_sep
+      else
+        path) split_dirs) in
+
+  (* Loop through, trying to open the module with each path *)
+  let rec loop = (function
+    | [] -> failwith ("Could not find file " ^ filename)
+    | x :: xs ->
+        let candidate_filename =
+          if x = "" then filename else (x ^ Filename.dir_sep ^ filename) in
+        if Sys.file_exists candidate_filename then
+          Parse.parse_file Parse.program candidate_filename
+        else
+          loop xs) in
+  loop poss_dirs

--- a/moduleUtils.mli
+++ b/moduleUtils.mli
@@ -12,4 +12,4 @@ val print_stack_node : binding_stack_node -> string
 val print_module_stack : binding_stack_node list -> string
 val moduleInScope : Utility.StringSet.t -> binding_stack_node list -> string -> string option
 val prefixWith : string -> string -> string
-
+val try_parse_file : string -> (Sugartypes.program * Parse.position_context)

--- a/test-harness
+++ b/test-harness
@@ -59,11 +59,11 @@ def check_expected(name, item, got, expected, errors):
 
 def evaluate(name, code, stdout='', stderr='', exit = '0', flags='-e', env = None, filemode='', args=''):
     if filemode.startswith('true') :
-        proc = Popen((links, code), stdout=PIPE, stderr=PIPE, env=env)
+        proc = Popen([links, code], stdout=PIPE, stderr=PIPE, env=env)
     elif filemode.startswith('args'):
-        proc = Popen((links, args, code), stdout=PIPE, stderr=PIPE, env=env)
+        proc = Popen([links, args, code], stdout=PIPE, stderr=PIPE, env=env)
     else:
-        proc = Popen((links, flags, code), stdout=PIPE, stderr=PIPE, env=env)
+        proc = Popen([links, flags, code], stdout=PIPE, stderr=PIPE, env=env)
     passed = True
     errors = []
     for i in xrange(0, TIMEOUT*100):

--- a/test-harness
+++ b/test-harness
@@ -57,11 +57,11 @@ def check_expected(name, item, got, expected, errors):
     else:
         return True
 
-def evaluate(name, code, stdout='', stderr='', exit = '0', flags='-e', env = None, filemode='', extern_args=''):
+def evaluate(name, code, stdout='', stderr='', exit = '0', flags='-e', env = None, filemode='', args=''):
     if filemode.startswith('true') :
         proc = Popen((links, code), stdout=PIPE, stderr=PIPE, env=env)
-    elif filemode.startswith('extern'):
-        proc = Popen((code, extern_args), stdout=PIPE, stderr=PIPE, env=env)
+    elif filemode.startswith('args'):
+        proc = Popen((links, args, code), stdout=PIPE, stderr=PIPE, env=env)
     else:
         proc = Popen((links, flags, code), stdout=PIPE, stderr=PIPE, env=env)
     passed = True

--- a/tests/modules.tests
+++ b/tests/modules.tests
@@ -53,5 +53,5 @@ exit : 1
 Module chasing
 ./tests/modules/moduleA.links
 filemode : args
-args : --path="tests/modules"
+args : --path=tests/modules
 stdout : "hello from c!" : String

--- a/tests/modules.tests
+++ b/tests/modules.tests
@@ -51,7 +51,7 @@ stderr : @.*
 exit : 1
 
 Module chasing
-./tests/modules/runmulti
-filemode : extern
-extern_args : moduleA.links
+./tests/modules/moduleA.links
+filemode : args
+args : --path="tests/modules"
 stdout : "hello from c!" : String


### PR DESCRIPTION
It's now possible to invoke Links with the --path argument, with paths separated by colons, to specify directories to look for Links files when doing module chasing.

Example:

```
links --path="/some/path:~/some/other/path" test.links
```

will, when performing module chasing, look in:
* current working directory
* /some/path
* ~/some/other/path

This should also fix #58 (which seemed to be caused by inconsistencies in different versions of Python).