### PR TITLE
Issue 27

### DIFF
--- a/queryshredding.ml
+++ b/queryshredding.ml
@@ -1254,7 +1254,7 @@ struct
       | `Project (`Var x, l) -> `Project (`Var x, l)
       | `Project (`Project (`Project (`Var z, "1"), i), l) ->
         (* HACK: this keeps z annotated with its original unflattened type *)
-        `Project (`Var z, "1"^"_"^i^"_"^l)
+        `Project (`Var z, "1"^"@"^i^"@"^l)
       | `Record fields ->
         (* concatenate labels of nested records *)
         `Record
@@ -1264,7 +1264,7 @@ struct
                  | `Record inner_fields ->
                    StringMap.fold
                      (fun name' body fields ->
-                       StringMap.add (name ^ "_" ^ name') body fields)
+                       StringMap.add (name ^ "@" ^ name') body fields)
                      inner_fields
                      fields
                  | body ->
@@ -1288,7 +1288,7 @@ struct
           (* lift base expressions to records *)
           match flatten_inner e with
             | `Record fields -> `Record fields
-            | p -> `Record (StringMap.add "_" p StringMap.empty)
+            | p -> `Record (StringMap.add "@" p StringMap.empty)
         in
           `Singleton e'
       (* HACK: not sure if `Concat is supposed to appear here...
@@ -1323,7 +1323,7 @@ struct
                  | `Record inner_fields ->
                    StringMap.fold
                      (fun name' t fields ->
-                       StringMap.add (name ^ "_" ^ name') t fields)
+                       StringMap.add (name ^ "@" ^ name') t fields)
                      inner_fields
                      fields
                  | `Primitive p ->
@@ -1380,7 +1380,7 @@ struct
         `Record
           (StringMap.fold
              (fun name p fields ->
-               let names = split_string name '_' in
+               let names = split_string name '@' in
                  unflatten_field names p fields)
              fields
              StringMap.empty)
@@ -1410,7 +1410,7 @@ Fast unflattening.
       `Primitive _ -> `Primitive name
     | `Record rcd -> 
 	`Record (List.map (fun (nm,t') -> 
-	  (nm,make_tmpl_inner (name ^"_"^nm) t')) 
+	  (nm,make_tmpl_inner (name ^"@"^nm) t'))
 		   (StringMap.to_alist rcd))
     and make_tmpl_outer name t = 
       match t with 

--- a/tests/shredding/travel_portal.links
+++ b/tests/shredding/travel_portal.links
@@ -59,6 +59,14 @@ fun q_lineage() {
   }
 }
 
+fun issue27() {
+  query {
+    for (a <-- agencies)
+      [(name = a.name,
+        based_in = a.based_in)]
+  }
+}
+
 fun test() {
   assertEq(q(), [(name = "BayTours", phone = "415-1200"),
                  (name = "BayTours", phone = "415-1200"),
@@ -72,7 +80,10 @@ fun test() {
                                   (row = 6, "table" = "externaltours")]),
                          (data = (name = "HarborCruz", phone = "831-3000"),
                           prov = [(row = 2, "table" = "agencies"),
-                                  (row = 7, "table" = "externaltours")])])
+                                  (row = 7, "table" = "externaltours")])]);
+  # https://github.com/links-lang/links/issues/27
+  assertEq(issue27(), [(name = "BayTours", based_in = "San Francisco"),
+                       (name = "HarborCruz", based_in = "Santa Cruz")])
 }
 
 test()


### PR DESCRIPTION
This (somewhat arbitrarily) decides that '@' is not allowed in record fields and uses it as the separator for nested field names in queries. '@' seems to be allowed in SQL column names for at least PostgreSQL.