### PR TITLE
Newer version of modules system

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -89,6 +89,8 @@ SOURCES = $(OPC)                                \
           parse.mli parse.ml                    \
           sugarTraversals.mli  sugarTraversals.ml       \
 					moduleUtils.mli moduleUtils.ml \
+					uniquify.mli uniquify.ml \
+					scopeGraph.mli scopeGraph.ml \
 					chaser.mli chaser.ml \
 					desugarModules.mli desugarModules.ml \
           desugarDatatypes.mli desugarDatatypes.ml      \

--- a/basicsettings.ml
+++ b/basicsettings.ml
@@ -88,6 +88,9 @@ let allow_stale_cache = Settings.add_bool("allow_stale_cache", false, `System)
 (* Optimization pass? *)
 let optimise = Settings.add_bool("optimise", false, `User)
 
+(* Allow modules? *)
+let modules = Settings.add_bool("modules", false, `User)
+
 (* Compile & cache whole program, closures, and HTML *)
 let cache_whole_program = Settings.add_bool("cache_whole_program", false, `User)
 

--- a/chaser.ml
+++ b/chaser.ml
@@ -63,19 +63,6 @@ object(self)
           let to_add = Uniquify.lookup_var (List.hd ns) u_ast in
           self#add_import_candidate to_add
     | bn -> super#bindingnode bn
-
-  method phrasenode = function
-    | `QualifiedVar ns ->
-        if can_resolve_qual_name ns sg u_ast then self else
-          let to_add = Uniquify.lookup_var (List.hd ns) u_ast in
-          self#add_import_candidate to_add
-    | p -> super#phrasenode p
-  method datatype = function
-    | `QualifiedTypeApplication (ns, _) ->
-      if can_resolve_qual_name ns ty_sg u_ast then self else
-        let to_add = Uniquify.lookup_var (List.hd ns) u_ast in
-        self#add_import_candidate to_add
-    | dt -> super#datatype dt
 end
 
 

--- a/chaser.ml
+++ b/chaser.ml
@@ -7,12 +7,22 @@ type prog_map = program StringMap.t
 type filename = string
 (* Helper functions *)
 
+let split_fqn = Str.split (Str.regexp (Str.quote module_sep))
+
 (* Given fully-qualified module name, gets root module name *)
-(* module_sep isn't used here, unfortunately, since it's a regex special char *)
 let module_file_name module_name =
-  match (Str.split (Str.regexp (Str.quote module_sep)) module_name) with
+  match split_fqn module_name with
     | [] -> failwith "Internal error: empty list in module_file_name"
     | (x::_xs) -> x
+
+(* Given a fully-qualified name, gets the module prefix *)
+let module_prefix name =
+  let rec module_prefix_inner = function
+    | [] -> ""
+    | [x] -> ""
+    | x :: y :: [] -> x
+    | x :: xs -> x ^ module_sep ^ module_prefix_inner xs
+  in module_prefix_inner (split_fqn name)
 
 (* Helper function: given top-level module name, maps to expected filename *)
 let top_level_filename module_name =
@@ -20,6 +30,10 @@ let top_level_filename module_name =
 
 let print_sorted_deps xs =
   print_list (List.map print_list xs)
+
+let is_qualified str =
+  try Str.search_forward (Str.regexp (Str.quote ".")) str 0 > 0
+  with Notfound.NotFound _ -> false
 
 (* Given a module name, try and locate / parse the module file *)
 let parse_module module_name =
@@ -32,34 +46,49 @@ let assert_no_cycles = function
   | [x]::ys -> ()
   | (x::xs)::ys -> failwith ("Error -- cyclic dependencies: " ^ (String.concat ", " (x :: xs)))
 
-(*
-let print_external_deps prog =
-  let external_deps = find_external_refs prog in
-  printf "External dependencies:\n%s\n" (print_list external_deps)
-*)
-
 let unique_list xs =
   StringSet.elements (StringSet.of_list xs)
 
+let rec var_can_be_resolved seen_bindings binding_stack current_module_prefix name =
+  match binding_stack with
+    | [] -> false
+    | (`LocalVarBinding x)::xs ->
+        if x = name then true
+        else var_can_be_resolved seen_bindings xs current_module_prefix name
+    | (`OpenStatement x)::xs ->
+        let fully_qual = prefixWith name x in
+        if StringSet.mem fully_qual seen_bindings then true else
+          var_can_be_resolved seen_bindings xs current_module_prefix name
+
 (* Traversal to find module import references in the current file *)
-let rec find_module_refs prefix init_seen_modules init_import_candidates init_binding_stack =
+let rec find_module_refs prefix init_seen_modules init_import_candidates init_binding_stack init_seen_bindings =
 object(self)
   inherit SugarTraversals.fold as super
   (* Module definitions we've seen in the file *)
   val seen_modules = init_seen_modules
+  val seen_bindings = init_seen_bindings
   val binding_stack = init_binding_stack
   method add_seen_module x = {< seen_modules = StringSet.add x seen_modules >}
+  method add_seen_binding x = {< seen_bindings = StringSet.add x seen_bindings >}
   method get_seen_modules = seen_modules
+  method get_seen_bindings = seen_bindings
 
   method push_module name =
     {< binding_stack = (`OpenStatement name) :: binding_stack >}
 
+  method push_var_binding name =
+    {< binding_stack = (`LocalVarBinding name) :: binding_stack >}
 
   (* Imports that are not resolvable in the current file *)
   val import_candidates = init_import_candidates
   method add_import_candidate x =
     {< import_candidates = StringSet.add x import_candidates >}
   method get_import_candidates = import_candidates
+
+  method binder = function
+    | (name, _, _) ->
+        let o1 = self#push_var_binding name in
+        o1#add_seen_binding (prefixWith name prefix)
 
   method bindingnode = function
     | `Module (module_name, block) ->
@@ -69,7 +98,7 @@ object(self)
         let o = self#add_seen_module new_prefix in
         let o1 =
           (find_module_refs new_prefix o#get_seen_modules o#get_import_candidates
-            ((`OpenStatement new_prefix)::binding_stack))#phrase block in
+            ((`OpenStatement new_prefix)::binding_stack) o#get_seen_bindings)#phrase block in
         {< seen_modules = o1#get_seen_modules; import_candidates = o1#get_import_candidates >}
     | `Import name ->
         let scope_res = moduleInScope seen_modules binding_stack name in
@@ -83,6 +112,15 @@ object(self)
     | b -> super#bindingnode b
 
   method phrasenode = function
+    | `Var name when is_qualified name ->
+        let module_fn = module_file_name name in
+        printf "name: %s, stack: %s\n" name (print_module_stack binding_stack);
+        printf "module_fn: %s, seen_modules: %s\n" module_fn (Utility.print_list (StringSet.elements self#get_seen_modules));
+        if var_can_be_resolved seen_bindings binding_stack prefix name
+           || StringSet.mem (module_prefix name) self#get_seen_modules then
+          self
+        else
+          self#add_import_candidate (module_file_name name)
     | `Block (bs, p) ->
         (* Recursively process bindings / phrase *)
         let o1 =
@@ -97,7 +135,7 @@ end
 
 
 let find_external_refs prog =
-  StringSet.elements ((find_module_refs "" StringSet.empty StringSet.empty [])#program prog)#get_import_candidates
+  StringSet.elements ((find_module_refs "" StringSet.empty StringSet.empty [] StringSet.empty)#program prog)#get_import_candidates
 
 let rec add_module_bindings deps dep_map =
   match deps with
@@ -143,8 +181,6 @@ let add_dependencies module_name module_prog =
   let sorted_deps = Graph.topo_sort_sccs deps in
   (* Each entry should be *precisely* one element (otherwise we have cycles) *)
   assert_no_cycles sorted_deps;
-  (* printf "Sorted deps: %s\n" (print_sorted_deps sorted_deps); *)
-
   (* Now, build up binding list where each opened dependency is mapped to a `Module containing
    * its list of inner bindings. *)
   (* FIXME: This isn't reassigning positions! What we'll want is to retain the positions, but modify

--- a/chaser.ml
+++ b/chaser.ml
@@ -2,6 +2,8 @@ open Utility
 open Sugartypes
 open Printf
 open ModuleUtils
+open Uniquify
+open ScopeGraph
 
 type prog_map = program StringMap.t
 type filename = string

--- a/chaser.ml
+++ b/chaser.ml
@@ -1,3 +1,8 @@
+type filename = string
+
+let add_dependencies _ _ = failwith "out of order for now"
+let add_module_bindings _ _ = failwith "out of order for now"
+(*
 open Utility
 open Sugartypes
 open Printf
@@ -193,4 +198,4 @@ let add_dependencies module_name module_prog =
   (* Finally, add this to the start of the original list of bindings *)
   transformed_prog
 
-
+*)

--- a/chaser.ml
+++ b/chaser.ml
@@ -8,8 +8,9 @@ type filename = string
 (* Helper functions *)
 
 (* Given fully-qualified module name, gets root module name *)
+(* module_sep isn't used here, unfortunately, since it's a regex special char *)
 let module_file_name module_name =
-  match (Str.split (Str.regexp module_sep) module_name) with
+  match (Str.split (Str.regexp (Str.quote module_sep)) module_name) with
     | [] -> failwith "Internal error: empty list in module_file_name"
     | (x::_xs) -> x
 

--- a/chaser.ml
+++ b/chaser.ml
@@ -58,10 +58,6 @@ object(self)
   method get_import_candidates = import_candidates
 
   method bindingnode = function
-    | `Import n ->
-        if can_resolve_name n sg u_ast then self else
-          let to_add = Uniquify.lookup_var n u_ast in
-           self#add_import_candidate to_add
     | `QualifiedImport ns ->
         if can_resolve_qual_name ns sg u_ast then self else
           let to_add = Uniquify.lookup_var (List.hd ns) u_ast in
@@ -90,10 +86,7 @@ let rec add_module_bindings deps dep_map =
       try
         let (bindings, _) = StringMap.find module_name dep_map in
         (* TODO: Fix dummy position to be more meaningful, if necessary *)
-        (`Module (module_name,
-          (`Block (bindings, (`RecordLit ([], None), Sugartypes.dummy_position)),
-          Sugartypes.dummy_position)
-          ), Sugartypes.dummy_position) :: (add_module_bindings ys dep_map)
+        (`Module (module_name, bindings), Sugartypes.dummy_position) :: (add_module_bindings ys dep_map)
       with Notfound.NotFound _ ->
         failwith "Trying to find %s in dep map containing keys: %s\n" module_name (print_list (List.map fst (StringMap.bindings dep_map)));
     | _ -> failwith "Internal error: impossible pattern in add_module_bindings"

--- a/chaser.mli
+++ b/chaser.mli
@@ -1,4 +1,4 @@
 (* val print_external_deps : Sugartypes.program -> unit *)
 type filename = string
-val add_dependencies : filename -> Sugartypes.program -> (ScopeGraph.scope_graph * Uniquify.unique_ast)
+val add_dependencies : filename -> Sugartypes.program -> (ScopeGraph.scope_graph * ScopeGraph.scope_graph * Uniquify.unique_ast)
 val add_module_bindings : string list list -> Sugartypes.program Utility.StringMap.t -> Sugartypes.binding list

--- a/chaser.mli
+++ b/chaser.mli
@@ -1,4 +1,4 @@
 (* val print_external_deps : Sugartypes.program -> unit *)
 type filename = string
-val add_dependencies : filename -> Sugartypes.program -> Sugartypes.program
+val add_dependencies : filename -> Sugartypes.program -> (ScopeGraph.scope_graph * Uniquify.unique_ast)
 val add_module_bindings : string list list -> Sugartypes.program Utility.StringMap.t -> Sugartypes.binding list

--- a/desugarDatatypes.ml
+++ b/desugarDatatypes.ml
@@ -116,7 +116,7 @@ struct
       match t with
         | `TypeVar (s, _, _) -> (try `MetaTypeVar (lookup_type s)
                                 with NotFound _ -> raise (UnexpectedFreeVar s))
-        | `QualifiedTypeVar _ -> assert false (* will have been erase *)
+        | `QualifiedTypeApplication _ -> assert false (* will have been erased *)
         | `Function (f, e, t) ->
             `Function (Types.make_tuple_type (List.map (datatype var_env) f),
                        row var_env alias_env e,

--- a/desugarDatatypes.ml
+++ b/desugarDatatypes.ml
@@ -116,6 +116,7 @@ struct
       match t with
         | `TypeVar (s, _, _) -> (try `MetaTypeVar (lookup_type s)
                                 with NotFound _ -> raise (UnexpectedFreeVar s))
+        | `QualifiedTypeVar _ -> assert false (* will have been erase *)
         | `Function (f, e, t) ->
             `Function (Types.make_tuple_type (List.map (datatype var_env) f),
                        row var_env alias_env e,

--- a/desugarModules.ml
+++ b/desugarModules.ml
@@ -90,9 +90,8 @@ object(self)
   method get_bindings = List.rev bindings
 
   method binding = function
-    | (`Module (_, (`Block (bindings, _), _)), _) ->
-        List.fold_left (fun acc binding -> acc#binding binding) self bindings
-    | (`Import _, _) -> self
+    | (`Module (_, bindings), _) ->
+        self#list (fun o -> o#binding) bindings
     | (`QualifiedImport _, _) -> self
     | b -> self#add_binding ((flatten_simple ())#binding b)
 
@@ -132,8 +131,7 @@ let desugarModules scope_graph unique_ast =
   (*
   printf "Scope graph: %s\n" (ScopeGraph.show_scope_graph scope_graph);
   printf "Before module desugar: %s\n" (Sugartypes.Show_program.show unique_prog);
-  printf "\n=============================================================\n";
-  *)
+  printf "\n=============================================================\n"; *)
   let plain_prog =
     (perform_renaming scope_graph unique_ast)#program unique_prog in
   let o = (flatten_bindings ())#program plain_prog in

--- a/desugarModules.ml
+++ b/desugarModules.ml
@@ -43,7 +43,7 @@ let get_fq_resolved_decl decl_name sg u_ast =
 let resolve name sg u_ast =
   match ScopeGraph.resolve_reference name sg u_ast with
     | `UnsuccessfulResolution ->
-        (* failwith ("Lookup of " ^ name ^ " was unsuccessful") *)
+        (* failwith ("Resolution of " ^ name ^ " was unsuccessful") *)
         Uniquify.lookup_var name u_ast
     | `SuccessfulResolution decl_name ->
         (* printf "Successful resolution of name %s: %s\n" name decl_name; *)
@@ -130,14 +130,15 @@ end
 let desugarModules scope_graph unique_ast =
   let unique_prog = Uniquify.get_ast unique_ast in
   (*
+  printf "Scope graph: %s\n" (ScopeGraph.show_scope_graph scope_graph);
   printf "Before module desugar: %s\n" (Sugartypes.Show_program.show unique_prog);
-  printf "\n=============================================================\n"; *)
+  printf "\n=============================================================\n";
+  *)
   let plain_prog =
     (perform_renaming scope_graph unique_ast)#program unique_prog in
   let o = (flatten_bindings ())#program plain_prog in
   let flattened_bindings = o#get_bindings in
   let flattened_prog = (flattened_bindings, snd plain_prog) in
   (* Debug *)
-  (*
-  printf "After module desugar: %s\n" (Sugartypes.Show_program.show flattened_prog); *)
+  (* printf "After module desugar: %s\n" (Sugartypes.Show_program.show flattened_prog); *)
   flattened_prog

--- a/desugarModules.ml
+++ b/desugarModules.ml
@@ -1,5 +1,4 @@
-(*pp deriving *)
-
+(* New implementation of desugarModules making use of the scope graph. *)
 (*
  * Desugars modules into plain binders.
  * Bindingnode -> [Bindingnode]
@@ -18,9 +17,9 @@
  *
  *  --->
  *
- * val Foo:::bobsleigh = ...;
- * fun Foo:::x() { ...}
- * fun Foo:::Bar:::y() { ... }
+ * val Foo.bobsleigh = ...;
+ * fun Foo.x() { ...}
+ * fun Foo.Bar.y() { ... }
  * val x = ...;
  *
 *)
@@ -28,9 +27,39 @@ open Utility
 open Sugartypes
 open Printf
 open ModuleUtils
+open ScopeGraph
 
-(* Only `Module and `Import don't preserve structure. We can just do a map on everything
- * else... *)
+let get_fq_resolved_decl decl_name sg u_ast =
+  ScopeGraph.make_resolved_plain_name decl_name sg u_ast
+
+(* Wrapper function taking a unique reference, scope graph, and
+ * unique AST, and providing a single output reference name.
+ *
+ * If the resolution is unsuccessful, will simply return the plain name,
+ * which will be picked up as an error later.
+ *
+ * If the resolution is ambiguous, then the function will raise an error.
+ * *)
+let resolve name sg u_ast =
+  match ScopeGraph.resolve_reference name sg u_ast with
+    | `UnsuccessfulResolution ->
+        Uniquify.lookup_var name u_ast
+    | `SuccessfulResolution decl_name ->
+        (* printf "Successful resolution of name %s: %s\n" name decl_name; *)
+        get_fq_resolved_decl decl_name sg u_ast
+    | `AmbiguousResolution decl_names ->
+        let plain_names = List.map (fun n -> get_fq_resolved_decl n sg u_ast) decl_names in
+        failwith ("Error: ambiguous resolution for " ^ name ^ ":" ^ (print_list decl_names))
+
+
+let rec get_last_list_value = function
+  | [] -> failwith "INTERNAL ERROR: Empty list in get_last_list_value. This can only be caused by an" ^
+            "empty qualified name and so should be outlawed by the grammar"
+  | [x] -> x
+  | x::xs -> get_last_list_value xs
+
+
+(* After renaming, we can simply discard modules and imports. *)
 let rec flatten_simple = fun () ->
 object(self)
   inherit SugarTraversals.map as super
@@ -63,152 +92,51 @@ object(self)
     | (`Module (_, (`Block (bindings, _), _)), _) ->
         List.fold_left (fun acc binding -> acc#binding binding) self bindings
     | (`Import _, _) -> self
+    | (`QualifiedImport _, _) -> self
     | b -> self#add_binding ((flatten_simple ())#binding b)
 
   method program = function
     | (bindings, _body) -> self#list (fun o -> o#binding) bindings
-
 end
 
-let performFlattening : program -> program =
-  fun programToFlatten ->
-    let (bindings, phrase) = programToFlatten in
-    let flattened_bindings =
-      ((flatten_bindings ())#program programToFlatten)#get_bindings in
-    (flattened_bindings, phrase)
-
-(* Given a plain module name, checks whether it is in scope according to the
- * current stack of open modules *)
-
-(* Given a module stack, a reference tree, and a plain variable name, resolves
- * the fully-qualified name according to the priority of the stack.
- * If there are no matches, leave it as it is (either FQ already or erroneous) *)
-let rec substituteVar seen_bindings binding_stack current_module_prefix var_name =
-    match binding_stack with
-    | [] -> var_name
-    | (`LocalVarBinding x)::xs ->
-        if x = var_name then
-          prefixWith x current_module_prefix
-        else
-          substituteVar seen_bindings xs current_module_prefix var_name
-    | (`OpenStatement x)::xs ->
-        let fully_qual = prefixWith var_name x in
-        if StringSet.mem fully_qual seen_bindings then
-          fully_qual
-        else
-          substituteVar seen_bindings xs current_module_prefix var_name
-
-(* Add module prefix to all internal binder names and variables *)
-let rec add_module_prefix prefix init_seen_modules init_seen_bindings init_binding_stack =
+let perform_renaming scope_graph unique_ast =
 object(self)
-  inherit SugarTraversals.fold_map as super
-
-  val seen_modules = init_seen_modules
-  val seen_bindings = init_seen_bindings
-  val binding_stack = init_binding_stack
-
-  method add_seen_module name =
-    {< seen_modules = StringSet.add name seen_modules >}
-
-  method push_module name =
-    {< binding_stack = (`OpenStatement name) :: binding_stack >}
-
-  method push_var_binding name =
-    {< binding_stack = (`LocalVarBinding name) :: binding_stack >}
-
-  method add_seen_binding name =
-    {< seen_bindings = StringSet.add name seen_bindings >}
-
-  method get_binding_stack = binding_stack
-  method get_seen_modules = seen_modules
-  method get_seen_bindings = seen_bindings
-
-  method set_stack s = {< binding_stack = s >}
+  inherit SugarTraversals.map as super
 
   method binder = function
-    | (old_name, dt, pos) ->
-        let new_name = prefixWith old_name prefix in
-        let o = (self#push_var_binding old_name) in
-        (o#add_seen_binding new_name, (new_name, dt, pos))
-
-  method bindingnode = function
-    | `Import name ->
-        (* Check to see whether module is in our seen list. If so, we're golden,
-         * push onto open module stack (fully-qualified).
-         * If not, throw an error. *)
-        (match moduleInScope seen_modules binding_stack name with
-           | Some(fully_qualified_name) ->
-               (self#push_module fully_qualified_name, `Import fully_qualified_name)
-           | None ->
-               failwith ("Trying to import unknown module " ^ name))
-    | `Module (name, p) ->
-        let new_prefix = prefixWith name prefix in
-        (* Add fully-qualified module to seen module list *)
-        (* Add fully-qualified module to module stack *)
-        let o = self#add_seen_module new_prefix in
-        let o1 = o#push_module new_prefix in
-        let (o2, renamed_phrase) =
-          (add_module_prefix new_prefix o1#get_seen_modules o1#get_seen_bindings
-            ((`OpenStatement new_prefix)::binding_stack))#phrase p in
-        let o3 = {< seen_modules = o2#get_seen_modules; seen_bindings = o2#get_seen_bindings >} in
-        (o3, `Module (new_prefix, renamed_phrase))
-    | x -> super#bindingnode x
+    | (unique_name, dt, pos) ->
+        (* Binders should just be resolved to their unique FQ name *)
+        let plain_name =
+          ScopeGraph.make_resolved_plain_name unique_name scope_graph unique_ast in
+        (plain_name, dt, pos)
 
   method phrasenode = function
-    | `Var old_name ->
-        (* Add prefix onto var name*)
-        let new_name = substituteVar seen_bindings binding_stack prefix old_name in
-        (self, `Var new_name)
-    | `Block (bs, p) ->
-        (* Recursively process bindings / phrase *)
-        let (o1, reversed_renamed_bindings) =
-          List.fold_left (fun (o_acc, bs_acc) binding ->
-            let (o_acc1, new_binding) = o_acc#binding binding in
-            (o_acc1, new_binding :: bs_acc)
-          ) (self, []) bs in
-        (* Restore the previous binding stack by making a copy of this object w/ new
-         * seen modules / bindings *)
-        let (o2, new_phrase) = o1#phrase p in
-        let o2 = {< seen_modules = o2#get_seen_modules; seen_bindings = o2#get_seen_bindings >} in
-        (o2, `Block (List.rev reversed_renamed_bindings, new_phrase))
-    | p -> super#phrasenode p
+    | `Var name ->
+        (* Resolve name. If it's ambiguous, throw an error.
+         * If it's not found, just put the plain one back in and the error will
+         * be picked up later.*)
+        printf "Attempting to resolve Var %s\n" name;
+        `Var (resolve name scope_graph unique_ast)
+    | `QualifiedVar names ->
+        (* Only need to look at the final name here *)
+        let name = get_last_list_value names in
+        (* printf "Attempting to resolve (qualified) Var %s\n" name; *)
+        `Var (resolve name scope_graph unique_ast)
+    | pn -> super#phrasenode pn
 end
 
-let performRenaming prog =
-  snd ((add_module_prefix "" (StringSet.empty) (StringSet.empty) [`OpenStatement ""])#program prog)
 
-let has_no_modules =
-object
-  inherit SugarTraversals.predicate as super
-
-  val has_no_modules = true
-  method satisfied = has_no_modules
-
-  method bindingnode = function
-    | `Import _
-    | `Module _ -> {< has_no_modules = false >}
-    | b -> super#bindingnode b
-end
-
-let requires_desugar prog = (not ((has_no_modules#program prog)#satisfied))
-
-(* 1) Perform a renaming pass to expand names in modules to qualified names
- * 2) Peform a flattening pass to flatten modules to lists of bindings
- *)
-let desugar_modules program =
-  (* Chaser.print_external_deps program; *)
-  if (requires_desugar program) then
-    let renamedProgram = performRenaming program in
-    let (renamedBindings, renamedBody) = renamedProgram in
-    let flattenedProgram = performFlattening renamedProgram in
-    (*
-    printf "\n=============================================================\n";
-    printf "\n=============================================================\n";
-    printf "Before module desugar: %s\n" (Sugartypes.Show_program.show program);
-    printf "\n=============================================================\n";
-    printf "After module desugar: %s\n" (Sugartypes.Show_program.show flattenedProgram);
-    *)
-    flattenedProgram
-  else program
-
-
+let desugarModules scope_graph unique_ast =
+  let unique_prog = Uniquify.get_ast unique_ast in
+  (*
+  printf "Before module desugar: %s\n" (Sugartypes.Show_program.show unique_prog);
+  printf "\n=============================================================\n";
+  *)
+  let plain_prog =
+    (perform_renaming scope_graph unique_ast)#program unique_prog in
+  let o = (flatten_bindings ())#program plain_prog in
+  let flattened_bindings = o#get_bindings in
+  let flattened_prog = (flattened_bindings, snd plain_prog) in
+  (* Debug *)
+  (* printf "After module desugar: %s\n" (Sugartypes.Show_program.show flattened_prog); *)
+  flattened_prog

--- a/desugarModules.ml
+++ b/desugarModules.ml
@@ -43,6 +43,7 @@ let get_fq_resolved_decl decl_name sg u_ast =
 let resolve name sg u_ast =
   match ScopeGraph.resolve_reference name sg u_ast with
     | `UnsuccessfulResolution ->
+        (* failwith ("Lookup of " ^ name ^ " was unsuccessful") *)
         Uniquify.lookup_var name u_ast
     | `SuccessfulResolution decl_name ->
         (* printf "Successful resolution of name %s: %s\n" name decl_name; *)
@@ -115,7 +116,7 @@ object(self)
         (* Resolve name. If it's ambiguous, throw an error.
          * If it's not found, just put the plain one back in and the error will
          * be picked up later.*)
-        printf "Attempting to resolve Var %s\n" name;
+        (* printf "Attempting to resolve Var %s\n" name; *)
         `Var (resolve name scope_graph unique_ast)
     | `QualifiedVar names ->
         (* Only need to look at the final name here *)
@@ -130,13 +131,13 @@ let desugarModules scope_graph unique_ast =
   let unique_prog = Uniquify.get_ast unique_ast in
   (*
   printf "Before module desugar: %s\n" (Sugartypes.Show_program.show unique_prog);
-  printf "\n=============================================================\n";
-  *)
+  printf "\n=============================================================\n"; *)
   let plain_prog =
     (perform_renaming scope_graph unique_ast)#program unique_prog in
   let o = (flatten_bindings ())#program plain_prog in
   let flattened_bindings = o#get_bindings in
   let flattened_prog = (flattened_bindings, snd plain_prog) in
   (* Debug *)
-  (* printf "After module desugar: %s\n" (Sugartypes.Show_program.show flattened_prog); *)
+  (*
+  printf "After module desugar: %s\n" (Sugartypes.Show_program.show flattened_prog); *)
   flattened_prog

--- a/desugarModules.mli
+++ b/desugarModules.mli
@@ -1,1 +1,1 @@
-val desugar_modules : Sugartypes.program -> Sugartypes.program
+val desugarModules : ScopeGraph.scope_graph -> Uniquify.unique_ast -> Sugartypes.program

--- a/desugarModules.mli
+++ b/desugarModules.mli
@@ -1,1 +1,1 @@
-val desugarModules : ScopeGraph.scope_graph -> Uniquify.unique_ast -> Sugartypes.program
+val desugarModules : ScopeGraph.scope_graph -> ScopeGraph.scope_graph -> Uniquify.unique_ast -> Sugartypes.program

--- a/frontend.ml
+++ b/frontend.ml
@@ -30,8 +30,7 @@ struct
       (* let program = Chaser.add_dependencies "" program in *)
       let program =
         if ModuleUtils.contains_modules program then
-        let unique_ast = Uniquify.uniquify_ast program in
-        let scope_graph = ScopeGraph.create_scope_graph (Uniquify.get_ast unique_ast) in
+        let (scope_graph, unique_ast) = Chaser.add_dependencies "" program in
         (* Printf.printf "%s\n" (ScopeGraph.show_scope_graph scope_graph); *)
         DesugarModules.desugarModules scope_graph unique_ast
       else program in

--- a/frontend.ml
+++ b/frontend.ml
@@ -30,9 +30,9 @@ struct
       (* let program = Chaser.add_dependencies "" program in *)
       let program =
         if ModuleUtils.contains_modules program then
-        let (scope_graph, unique_ast) = Chaser.add_dependencies "" program in
+        let (scope_graph, ty_scope_graph, unique_ast) = Chaser.add_dependencies "" program in
         (* Printf.printf "%s\n" (ScopeGraph.show_scope_graph scope_graph); *)
-        DesugarModules.desugarModules scope_graph unique_ast
+        DesugarModules.desugarModules scope_graph ty_scope_graph unique_ast
       else program in
         CheckXmlQuasiquotes.checker#program program;
         (   DesugarLAttributes.desugar_lattributes#program

--- a/frontend.ml
+++ b/frontend.ml
@@ -28,10 +28,13 @@ struct
       let program = (ResolvePositions.resolve_positions pos_context)#program program in
       (* Module-y things *)
       (* let program = Chaser.add_dependencies "" program in *)
-      let unique_ast = Uniquify.uniquify_ast program in
-      let scope_graph = ScopeGraph.create_scope_graph (Uniquify.get_ast unique_ast) in
-      (* Printf.printf "%s\n" (ScopeGraph.show_scope_graph scope_graph); *)
-      let program = DesugarModules.desugarModules scope_graph unique_ast in
+      let program =
+        if ModuleUtils.contains_modules program then
+        let unique_ast = Uniquify.uniquify_ast program in
+        let scope_graph = ScopeGraph.create_scope_graph (Uniquify.get_ast unique_ast) in
+        (* Printf.printf "%s\n" (ScopeGraph.show_scope_graph scope_graph); *)
+        DesugarModules.desugarModules scope_graph unique_ast
+      else program in
         CheckXmlQuasiquotes.checker#program program;
         (   DesugarLAttributes.desugar_lattributes#program
         ->- RefineBindings.refine_bindings#program

--- a/frontend.ml
+++ b/frontend.ml
@@ -27,12 +27,15 @@ struct
     fun tyenv pos_context program ->
       let program = (ResolvePositions.resolve_positions pos_context)#program program in
       (* Module-y things *)
-      (* let program = Chaser.add_dependencies "" program in *)
       let program =
         if ModuleUtils.contains_modules program then
-        let (scope_graph, ty_scope_graph, unique_ast) = Chaser.add_dependencies "" program in
-        (* Printf.printf "%s\n" (ScopeGraph.show_scope_graph scope_graph); *)
-        DesugarModules.desugarModules scope_graph ty_scope_graph unique_ast
+          if Settings.get_value Basicsettings.modules then
+            let (scope_graph, ty_scope_graph, unique_ast) = Chaser.add_dependencies "" program in
+            (* Printf.printf "%s\n" (ScopeGraph.show_scope_graph scope_graph); *)
+            DesugarModules.desugarModules scope_graph ty_scope_graph unique_ast
+          else
+            failwith ("File contains modules, but modules not enabled. Please set " ^
+              "modules flag to true, or run with -m.")
       else program in
         CheckXmlQuasiquotes.checker#program program;
         (   DesugarLAttributes.desugar_lattributes#program

--- a/lexer.mll
+++ b/lexer.mll
@@ -224,8 +224,6 @@ exception LexicalError of (string * Lexing.position)
 
 let def_id = (['a'-'z' 'A'-'Z'] ['a'-'z' 'A'-'Z' '_' '0'-'9']*)
 let module_name = (['A'-'Z'] (['A'-'Z' 'a'-'z'])*)
-let qualified_module = (module_name ((":::" module_name)*))
-let qualified_var = (qualified_module (":::" def_id))
 let octal_code = (['0'-'3']['0'-'7']['0'-'7'])
 let hex_code   = (['0'-'9''a'-'f''A'-'F']['0'-'9''a'-'f''A'-'F'])
 let def_qname = ('#' | def_id (':' def_id)*)
@@ -299,7 +297,6 @@ rule lex ctxt nl = parse
   | '.'                                 { DOT }
   | ".."                                { DOTDOT }
   | "::"                                { COLONCOLON }
-  | ":::"                               { COLONCOLONCOLON }
   | ':'                                 { COLON }
   | '!'                                 { BANG }
   | '?'                                 { QUESTION }
@@ -320,12 +317,10 @@ rule lex ctxt nl = parse
   | "infixr"                            { INFIXR ctxt#setprec }
   | "prefix"                            { PREFIX ctxt#setprec }
   | "postfix"                           { POSTFIX ctxt#setprec }
-  (* | qualified_module as modd            { QUALIFIEDMODULE modd } *)
   | def_id as var                       { try List.assoc var keywords
                                           with Not_found | NotFound _ ->
                                             if Char.isUpper var.[0] then CONSTRUCTOR var
                                             else VARIABLE var }
-  | qualified_var as var                { QUALIFIEDVARIABLE var }
   | def_blank                           { lex ctxt nl lexbuf }
   | _                                   { raise (LexicalError (lexeme lexbuf, lexeme_end_p lexbuf)) }
 and starttag ctxt nl = parse

--- a/links.ml
+++ b/links.ml
@@ -422,6 +422,7 @@ let options : opt list =
     (noshort, "measure-performance", set measuring true,               None);
     ('n',     "no-types",            set BS.printing_types false,         None);
     ('e',     "evaluate",            None,                             Some (fun str -> push_back str to_evaluate));
+    ('m',     "modules",             set BS.modules true,              None);
     (noshort, "config",              None,                             Some (fun name -> config_file := Some name));
     (noshort, "dump",                None,
      Some(fun filename -> Loader.print_cache filename;

--- a/links.ml
+++ b/links.ml
@@ -441,8 +441,8 @@ let main () =
   for_each !file_list (fun filename ->
     let sugar, pos_context =
       ModuleUtils.try_parse_file filename in
-    let uniquified_sugar = Uniquify.get_ast (Uniquify.uniquify_ast sugar) in
-    ScopeGraph.make_and_print_scope_graph uniquified_sugar)
+    let uniquified_ast = Uniquify.uniquify_ast sugar in
+    ScopeGraph.make_and_print_scope_graph uniquified_ast)
 
 (*
   let prelude, ((_valenv, nenv, tyenv) as envs) = measure "prelude" load_prelude () in

--- a/links.ml
+++ b/links.ml
@@ -439,12 +439,6 @@ let file_list = ref []
 
 let main () =
   for_each !file_list (fun filename ->
-    let sugar, pos_context =
-      ModuleUtils.try_parse_file filename in
-    let uniquified_ast = Uniquify.uniquify_ast sugar in
-    ScopeGraph.make_and_print_scope_graph uniquified_ast)
-
-(*
   let prelude, ((_valenv, nenv, tyenv) as envs) = measure "prelude" load_prelude () in
 
   for_each !to_evaluate (evaluate_string_in envs);
@@ -459,8 +453,7 @@ let main () =
     begin
       print_endline (Settings.get_value BS.welcome_note);
       interact envs
-    end
-*)
+    end)
 
 (* jcheney:
    Implementation of "cache_whole_program" setting.

--- a/links.ml
+++ b/links.ml
@@ -438,7 +438,6 @@ let options : opt list =
 let file_list = ref []
 
 let main () =
-  for_each !file_list (fun filename ->
   let prelude, ((_valenv, nenv, tyenv) as envs) = measure "prelude" load_prelude () in
 
   for_each !to_evaluate (evaluate_string_in envs);
@@ -453,7 +452,7 @@ let main () =
     begin
       print_endline (Settings.get_value BS.welcome_note);
       interact envs
-    end)
+    end
 
 (* jcheney:
    Implementation of "cache_whole_program" setting.

--- a/links.ml
+++ b/links.ml
@@ -438,6 +438,13 @@ let options : opt list =
 let file_list = ref []
 
 let main () =
+  for_each !file_list (fun filename ->
+    let sugar, pos_context =
+      ModuleUtils.try_parse_file filename in
+    let uniquified_sugar = Uniquify.get_ast (Uniquify.uniquify_ast sugar) in
+    ScopeGraph.make_and_print_scope_graph uniquified_sugar)
+
+(*
   let prelude, ((_valenv, nenv, tyenv) as envs) = measure "prelude" load_prelude () in
 
   for_each !to_evaluate (evaluate_string_in envs);
@@ -453,7 +460,7 @@ let main () =
       print_endline (Settings.get_value BS.welcome_note);
       interact envs
     end
-
+*)
 
 (* jcheney:
    Implementation of "cache_whole_program" setting.

--- a/moduleUtils.ml
+++ b/moduleUtils.ml
@@ -1,6 +1,6 @@
 open Utility
 
-let module_sep = ":::"
+let module_sep = "."
 
 type binding_stack_node = [
   | `OpenStatement of string

--- a/moduleUtils.ml
+++ b/moduleUtils.ml
@@ -44,4 +44,4 @@ object
     | b -> super#bindingnode b
 end
 
-let contains_modules prog = (not ((has_no_modules#program prog)#satisfied))
+let contains_modules prog = true (* (not ((has_no_modules#program prog)#satisfied)) *)

--- a/moduleUtils.ml
+++ b/moduleUtils.ml
@@ -44,4 +44,4 @@ object
     | b -> super#bindingnode b
 end
 
-let contains_modules prog = true (* (not ((has_no_modules#program prog)#satisfied)) *)
+let contains_modules prog = not ((has_no_modules#program prog)#satisfied)

--- a/moduleUtils.ml
+++ b/moduleUtils.ml
@@ -42,6 +42,14 @@ object
     | `QualifiedImport _
     | `Module _ -> {< has_no_modules = false >}
     | b -> super#bindingnode b
+
+  method datatype = function
+    | `QualifiedTypeApplication _ -> {< has_no_modules = false >}
+    | dt -> super#datatype dt
+
+  method phrasenode = function
+    | `QualifiedVar _ -> {< has_no_modules = false >}
+    | pn -> super#phrasenode pn
 end
 
 let contains_modules prog = not ((has_no_modules#program prog)#satisfied)

--- a/moduleUtils.ml
+++ b/moduleUtils.ml
@@ -2,37 +2,6 @@ open Utility
 
 let module_sep = "."
 
-type binding_stack_node = [
-  | `OpenStatement of string
-  | `LocalVarBinding of string
-]
-
-(* Given a name and a prefix, appends the prefix (with separator)
- * as long as the prefix is not the empty string *)
-let prefixWith name prefix =
-  if prefix = "" then name else prefix ^ module_sep ^ name
-
-let print_stack_node = function
- | `OpenStatement mn -> "module: " ^ mn
- | `LocalVarBinding lvb -> "var: " ^ lvb
-
-let print_module_stack s = print_list (List.map print_stack_node s)
-
-let rec moduleInScopeInner seen_modules binding_stack module_name =
-  match binding_stack with
-    | [] ->
-        if StringSet.mem module_name seen_modules then Some(module_name) else None
-    | (`LocalVarBinding _)::xs -> moduleInScopeInner seen_modules xs module_name
-    | (`OpenStatement x)::xs ->
-        let fully_qual = prefixWith module_name x in
-        if StringSet.mem fully_qual seen_modules then
-          Some(fully_qual)
-        else
-          moduleInScopeInner seen_modules xs module_name
-
-let moduleInScope seen_modules binding_stack module_name =
-  moduleInScopeInner seen_modules binding_stack module_name
-
 (* TODO: Unix-specific one for the moment, but no easy way to get this
  * from OCaml Filename module... *)
 let path_sep = ":"
@@ -60,3 +29,19 @@ let try_parse_file filename =
         else
           loop xs) in
   loop poss_dirs
+
+
+let has_no_modules =
+object
+  inherit SugarTraversals.predicate as super
+
+  val has_no_modules = true
+  method satisfied = has_no_modules
+
+  method bindingnode = function
+    | `Import _
+    | `Module _ -> {< has_no_modules = false >}
+    | b -> super#bindingnode b
+end
+
+let contains_modules prog = (not ((has_no_modules#program prog)#satisfied))

--- a/moduleUtils.ml
+++ b/moduleUtils.ml
@@ -39,7 +39,7 @@ object
   method satisfied = has_no_modules
 
   method bindingnode = function
-    | `Import _
+    | `QualifiedImport _
     | `Module _ -> {< has_no_modules = false >}
     | b -> super#bindingnode b
 end

--- a/moduleUtils.mli
+++ b/moduleUtils.mli
@@ -1,15 +1,3 @@
-(* Renaming stack. We either have a variable binding or an "open" statement.
- * If we have a variable binding after an "open" statement, then this should
- * take priority over the variables contained within the opened module.
- * Stack frames persist for a single scope (i.e. `Block) *)
-type binding_stack_node = [
-  | `OpenStatement of string
-  | `LocalVarBinding of string
-]
-
 val module_sep : string
-val print_stack_node : binding_stack_node -> string
-val print_module_stack : binding_stack_node list -> string
-val moduleInScope : Utility.StringSet.t -> binding_stack_node list -> string -> string option
-val prefixWith : string -> string -> string
 val try_parse_file : string -> (Sugartypes.program * Parse.position_context)
+val contains_modules : Sugartypes.program -> bool

--- a/parser.mly
+++ b/parser.mly
@@ -306,7 +306,7 @@ nofun_declaration:
 
 links_module:
 | MODULE module_name moduleblock                               { let (mod_name, name_pos) = $2 in
-                                                                 `Module (mod_name, (`Block $3, name_pos)), name_pos }
+                                                                 `Module (mod_name, $3), name_pos }
 module_name:
 | CONSTRUCTOR                                                  { $1 , pos () }
 
@@ -839,7 +839,7 @@ record_labels:
 
 links_open:
 | OPEN qualified_name                                          { `QualifiedImport $2, pos () }
-| OPEN CONSTRUCTOR                                             { `Import $2, pos () }
+| OPEN CONSTRUCTOR                                             { `QualifiedImport [$2], pos () }
 
 binding:
 | VAR pattern EQ exp SEMICOLON                                 { `Val ([], $2, $4, `Unknown, None), pos () }
@@ -855,7 +855,7 @@ bindings:
 | bindings binding                                             { $1 @ [$2] }
 
 moduleblock:
-| LBRACE bindings RBRACE                                       { ($2, (`RecordLit ([], None), pos())) }
+| LBRACE bindings RBRACE                                       { $2 }
 
 block:
 | LBRACE block_contents RBRACE                                 { $2 }

--- a/parser.mly
+++ b/parser.mly
@@ -167,6 +167,20 @@ let parseRegexFlags f =
 
 let datatype d = d, None
 
+let module_sep = "."
+
+let join_qual_list = String.concat module_sep
+
+(* hack, brb *)
+(*
+let rec disambiguate_session xs =
+  match xs with
+    | [] -> failwith "empty qualified var when parsing session"
+    | [x] -> ([], `TypeVar (x, None, `Rigid))
+    | x :: xs ->
+        let (xs', end_ty_var) = loop xs in
+        (x :: xs', end_ty_var) in
+*)
 %}
 
 %token END
@@ -185,8 +199,8 @@ let datatype d = d, None
 %token LEFTTRIANGLE RIGHTTRIANGLE NU
 %token FOR LARROW LLARROW WHERE FORMLET PAGE
 %token LRARROW
-%token COMMA VBAR DOT DOTDOT COLON COLONCOLON COLONCOLONCOLON
-%token TABLE TABLEHANDLE TABLEKEYS FROM DATABASE QUERY WITH YIELDS ORDERBY 
+%token COMMA VBAR DOT DOTDOT COLON COLONCOLON
+%token TABLE TABLEHANDLE TABLEKEYS FROM DATABASE QUERY WITH YIELDS ORDERBY
 %token UPDATE DELETE INSERT VALUES SET RETURNING
 %token READONLY DEFAULT
 %token ESCAPE
@@ -198,8 +212,8 @@ let datatype d = d, None
 %token <float> UFLOAT
 %token <string> STRING CDATA REGEXREPL
 %token <char> CHAR
-%token <string> QUALIFIEDVARIABLE VARIABLE CONSTRUCTOR KEYWORD PERCENTVAR
-%token <string> QUALIFIEDMODULE LXML ENDTAG
+%token <string> VARIABLE CONSTRUCTOR KEYWORD PERCENTVAR
+%token <string> LXML ENDTAG
 %token RXML SLASHRXML
 %token MU FORALL ALIEN SIG OPEN
 %token MODULE
@@ -389,9 +403,16 @@ constant:
 | FALSE                                                        { `Bool false, pos() }
 | CHAR                                                         { `Char $1   , pos() }
 
+qualified_name:
+| CONSTRUCTOR DOT qualified_name_inner                         { $1 :: $3 }
+
+qualified_name_inner:
+| CONSTRUCTOR DOT qualified_name_inner                         { $1 :: $3 }
+| VARIABLE                                                     { [$1] }
+
 atomic_expression:
+| qualified_name                                               { `Var (join_qual_list $1), pos() }
 | VARIABLE                                                     { `Var $1, pos() }
-| QUALIFIEDVARIABLE                                            { `Var $1, pos() }
 | constant                                                     { let c, p = $1 in `Constant c, p }
 | parenthesized_thing                                          { $1 }
 /* HACK: allows us to support both mailbox receive syntax
@@ -832,8 +853,7 @@ record_labels:
 | record_label                                                 { [$1] }
 
 links_open:
-| OPEN QUALIFIEDVARIABLE                                       { `Import $2, pos () }
-| OPEN QUALIFIEDMODULE                                         { `Import $2, pos () }
+| OPEN qualified_name                                          { `Import (join_qual_list $2), pos () }
 | OPEN CONSTRUCTOR                                             { `Import $2, pos () }
 
 binding:
@@ -958,6 +978,15 @@ forall_datatype:
 | FORALL varlist DOT datatype                                  { `Forall (List.map fst $2, $4) }
 | session_datatype                                             { $1 }
 
+/* Parenthesised dts disambiguate between sending qualified types and recursion variables.
+   e.g:
+
+     S = !ModuleA.ModuleB.Type.S
+     should be written
+     S = !(ModuleA.ModuleB.Type).S
+
+     Parenthesised versions take priority over non-parenthesised versions.
+*/
 session_datatype:
 | BANG datatype DOT datatype                                   { `Output ($2, $4) }
 | QUESTION datatype DOT datatype                               { `Input ($2, $4) }
@@ -969,6 +998,7 @@ session_datatype:
 
 parenthesized_datatypes:
 | LPAREN RPAREN                                                { [] }
+| LPAREN qualified_name RPAREN                                 { [`TypeVar (join_qual_list $2, None, `Rigid)] }
 | LPAREN datatypes RPAREN                                      { $2 }
 
 primary_datatype:

--- a/parser.mly
+++ b/parser.mly
@@ -395,6 +395,15 @@ qualified_name_inner:
 | CONSTRUCTOR DOT qualified_name_inner                         { $1 :: $3 }
 | VARIABLE                                                     { [$1] }
 
+qualified_type_name:
+| CONSTRUCTOR DOT qualified_type_name_inner                    { $1 :: $3 }
+
+qualified_type_name_inner:
+| CONSTRUCTOR DOT qualified_type_name_inner                    { $1 :: $3 }
+| CONSTRUCTOR                                                  { [$1] }
+
+
+
 atomic_expression:
 | qualified_name                                               { `QualifiedVar $1, pos() }
 | VARIABLE                                                     { `Var $1, pos() }
@@ -983,7 +992,7 @@ session_datatype:
 
 parenthesized_datatypes:
 | LPAREN RPAREN                                                { [] }
-| LPAREN qualified_name RPAREN                                 { [`QualifiedTypeVar ($2, None, `Rigid)] }
+| LPAREN qualified_type_name RPAREN                            { [`QualifiedTypeApplication ($2, [])] }
 | LPAREN datatypes RPAREN                                      { $2 }
 
 primary_datatype:

--- a/parser.mly
+++ b/parser.mly
@@ -166,21 +166,6 @@ let parseRegexFlags f =
     List.map (function 'l' -> `RegexList | 'n' -> `RegexNative | 'g' -> `RegexGlobal) (asList f 0 [])
 
 let datatype d = d, None
-
-let module_sep = "."
-
-let join_qual_list = String.concat module_sep
-
-(* hack, brb *)
-(*
-let rec disambiguate_session xs =
-  match xs with
-    | [] -> failwith "empty qualified var when parsing session"
-    | [x] -> ([], `TypeVar (x, None, `Rigid))
-    | x :: xs ->
-        let (xs', end_ty_var) = loop xs in
-        (x :: xs', end_ty_var) in
-*)
 %}
 
 %token END
@@ -411,7 +396,7 @@ qualified_name_inner:
 | VARIABLE                                                     { [$1] }
 
 atomic_expression:
-| qualified_name                                               { `Var (join_qual_list $1), pos() }
+| qualified_name                                               { `QualifiedVar $1, pos() }
 | VARIABLE                                                     { `Var $1, pos() }
 | constant                                                     { let c, p = $1 in `Constant c, p }
 | parenthesized_thing                                          { $1 }
@@ -853,7 +838,7 @@ record_labels:
 | record_label                                                 { [$1] }
 
 links_open:
-| OPEN qualified_name                                          { `Import (join_qual_list $2), pos () }
+| OPEN qualified_name                                          { `QualifiedImport $2, pos () }
 | OPEN CONSTRUCTOR                                             { `Import $2, pos () }
 
 binding:
@@ -998,7 +983,7 @@ session_datatype:
 
 parenthesized_datatypes:
 | LPAREN RPAREN                                                { [] }
-| LPAREN qualified_name RPAREN                                 { [`TypeVar (join_qual_list $2, None, `Rigid)] }
+| LPAREN qualified_name RPAREN                                 { [`QualifiedTypeVar ($2, None, `Rigid)] }
 | LPAREN datatypes RPAREN                                      { $2 }
 
 primary_datatype:

--- a/parser.mly
+++ b/parser.mly
@@ -847,7 +847,7 @@ record_labels:
 | record_label                                                 { [$1] }
 
 links_open:
-| OPEN qualified_name                                          { `QualifiedImport $2, pos () }
+| OPEN qualified_type_name                                     { `QualifiedImport $2, pos () }
 | OPEN CONSTRUCTOR                                             { `QualifiedImport [$2], pos () }
 
 binding:

--- a/refineBindings.ml
+++ b/refineBindings.ml
@@ -35,7 +35,6 @@ let refine_bindings : binding list -> binding list =
               | `Funs _ -> assert false
               | `Exp _
               | `Foreign _
-              | `Import _
               | `Type _
               | `Val _ ->
                   (* collapse the group we're collecting, then start a
@@ -265,7 +264,6 @@ module RefineTypeBindings = struct
           | `Funs _
           | `Fun _
           | `Foreign _
-          | `Import _
           | `Val _
           | `Exp _
           | `Infix ->

--- a/refineBindings.ml
+++ b/refineBindings.ml
@@ -28,8 +28,11 @@ let refine_bindings : binding list -> binding list =
         List.fold_right
           (fun (binding,_ as bind) (thisgroup, othergroups) ->
             match binding with
-              (* Modules and funs will have been eliminated by now *)
+              (* Modules & qualified imports will have been eliminated by now. Funs
+               * aren't introduced yet. *)
+              | `Def _ -> assert false
               | `Module _ -> assert false
+              | `QualifiedImport _ -> assert false
               | `Funs _ -> assert false
               | `Exp _
               | `Foreign _
@@ -258,7 +261,9 @@ module RefineTypeBindings = struct
       let group, groups =
         List.fold_right (fun (binding, _ as bind) (currentGroup, otherGroups) ->
           match binding with
+          | `Def _ -> assert false
           | `Module _ -> assert false
+          | `QualifiedImport _ -> assert false
           | `Funs _
           | `Fun _
           | `Foreign _

--- a/refineBindings.ml
+++ b/refineBindings.ml
@@ -30,7 +30,6 @@ let refine_bindings : binding list -> binding list =
             match binding with
               (* Modules & qualified imports will have been eliminated by now. Funs
                * aren't introduced yet. *)
-              | `Def _ -> assert false
               | `Module _ -> assert false
               | `QualifiedImport _ -> assert false
               | `Funs _ -> assert false
@@ -261,7 +260,6 @@ module RefineTypeBindings = struct
       let group, groups =
         List.fold_right (fun (binding, _ as bind) (currentGroup, otherGroups) ->
           match binding with
-          | `Def _ -> assert false
           | `Module _ -> assert false
           | `QualifiedImport _ -> assert false
           | `Funs _

--- a/scopeGraph.ml
+++ b/scopeGraph.ml
@@ -56,6 +56,12 @@ let get_scope_num =
   *  expression -> scope
 *)
 
+(* Declaration with no associated scope *)
+let plain_decl d = (d, None)
+
+(* Declaration with associated named scope. S is SCOPE ID. *)
+let annotated_decl d s = (d, Some s)
+
 let add_declaration scope decl =
   { scope with declarations = decl :: scope.declarations }
 
@@ -73,7 +79,7 @@ let new_scope parent =
 
 let add_scope scope_id scope scope_graph = IntMap.add scope_id scope scope_graph
 
-let rec sg_bindings init_scope init_scope_graph scope_id =
+let rec construct_sg init_scope init_scope_graph scope_id =
 object(self)
   inherit SugarTraversals.fold as super
   (* Current scope *)
@@ -85,19 +91,56 @@ object(self)
   val scope_graph = init_scope_graph
   method get_scope_graph = scope_graph
 
+  method qn_add_references = function
+    | [] -> failwith "Internal error: empty qualified name list"
+    | [x] -> set_scope (add_reference scope x)
+    | x :: xs ->
+        (* Add reference to current scope *)
+        let scope1 = add_reference scope x in
+        (* Create new, top-level scope and add *import* *)
+        let qn_scope = new_scope None in
+        let qn_scope_id = get_scope_num () in
+        let qn_scope1 = add_import qn_scope x in
+        (* Recurse using new scope on remainder of list *)
+        let o_rec = (construct_sg qn_scope1 scope_graph qn_scope_id)#qn_add_references xs in
+        let rec_scope = o_rec#get_scope in
+        let rec_sg = o_rec#get_scope_graph in
+        let new_sg = add_scope qn_scope_id rec_scope rec_sg in
+        {< scope = scope1, scope_graph = new_sg >}
+
+  method phrasenode = function
+    | `Var n ->
+        (* Add to references for current scope *)
+        {< scope = add_reference scope n >}
+    | `QualifiedVar ns ->
+        self#qn_add_references ns
+    | pn -> super#phrasenode pn
+
+  (* *should* be the same for types, but if not, we can distinguish
+   * type declarations from term declarations *)
+  method datatype = function
+    | `TypeVar n ->
+        (* Add to references for current scope *)
+        {< scope = add_reference scope n >}
+    | `QualifiedVar ns ->
+        self#qn_add_references ns
+    | dt -> super#datatype dt
+
   method bindingnode = function
     | `Def (name, b) ->
-        (* Populate inner scope, then add to scope graph *)
-        let inner_scope_num = get_scope_num () in
+        (* Add binding to declaration list. *)
+        let new_decls = add_declaration scope (plain_decl name) in
         let o_bindingnode = self#bindingnode b in
-        o_bindingnode#add_scope inner_scope_num o_bindingnode#get_scope
+        (* Now, we want to update the SG, as well as adding a new declaration to this scope *)
+        let new_sg = o_bindingnode#get_scope_graph in
+        {< scope_graph = new_sg, scope = new_decls >}
     | `Fun ((fn_name, _, _), _lin, (_tyvars, fn_phrase), _loc, _dtopt) ->
         (* Generate a new scope *)
         let fn_scope_num = get_scope_num () in
         (* Functions are assumed to be recursive, so are added to the scope *)
-        let fn_scope = add_declaration (new_scope (Some scope_id)) fn_name in
+        let fn_scope = add_declaration (new_scope (Some scope_id)) (plain_decl fn_name) in
         (* Now, perform an analysis on the function expression *)
-        let o_scope = sg_inner_bindings fn_scope scope_graph fn_scope_num in
+        let o_scope = construct_sg fn_scope scope_graph fn_scope_num in
         (* Finally, get the updated scope graph, and add the new scope. *)
         let (fn_sg, fn_scope1) = (o_scope#get_scope_graph, o_scope#get_scope) in
         let new_sg = add_scope fn_scope_num fn_scope fn_sg in
@@ -110,25 +153,52 @@ object(self)
          * For now, let it be -- the old one had a similar issue, I think. *)
         assert false
     | `Import n ->
-        (* Add to imports list *)
-        (* to be continued... *)
-
-
-
+        (* Unqualified import. Add to imports list and references list. *)
+        let scope1 = add_reference scope n in
+        set_scope add_import scope1 n
+    | `QualifiedImport ns ->
+        (* Next, we need to properly set up anonymous scopes *)
+        (* Firstly, add all segments of the qualified name into the imports list. *)
+        let o1 = self#qn_add_references ns in
+        o1#list (fun o n ->
+            let modified_scope = add_import o#get_scope n in
+            o#set_scope new_import) ns
+    | `Val (_tvs, pat, phr, _loc, _dtopt) ->
+        (* (Deviating slightly from the algorithm in the paper here since our pattern
+         * language is more complex).
+         * Process the phrase using the current scope. Then, create a new scope
+         * for the remainder of the binding list (and associated phrase), with
+         * declarations of the pattern variables, and return this. *)
+        let o = (construct_sg scope scope_graph scope_id)#phrase phr in
+        (* Get the scope and new scope graph froim the processed phrase *)
+        let (phr_scope, phr_sg) = (o#get_scope, o#get_scope_graph) in
+        (* Create a new scope which contains the variable bindings introduced by the patterns *)
+        let following_scope_id = get_scope_num () in
+        let following_scope = new_scope (Some scope_id) in
+        let o_pattern = (construct_sg following_scope phr_sg following_scope_id)#pattern pat in
+        let (pat_scope, pat_sg) = (o_pattern#get_scope, o_pattern#get_scope_graph) in
+        (* Save this scope to SG, since it's done now. *)
+        let new_sg = add_scope scope_id phr_scope pat_sg in
+        (* Return new scope with old scope added to SG. *)
+        {< scope = pat_scope, scope_graph = new_sg >}
+    | `Infix -> self
+    | `Exp p -> self#phrase p
+    | `Foreign ((bnd_name, _, _), _name, _dt) ->
+        (* Not entirely sure how FFI works (if at all?) -- just add binder as a
+         * decl *)
+        {< scope = add_decl scope (plain_decl bnd_name) >}
+    | `Module (n, bl) ->
+        (* Create new scope, with current scope as parent *)
+        let module_scope_id = get_scope_num () in
+        let module_scope = new_scope (Some scope_id) in
+        (* Add declaration, with annotation of new scope name *)
+        let module_decl = annotated_decl n module_scope_id in
+        let our_scope = add_decl scope module_decl in
+        (* Proceed to process declarations using new scope *)
+        let o_module = module_scope scope_graph module_scope_id in
+        (* Using returned scope graph, process remainder of declarations *)
+        {< scope = our_scope, scope_graph = o_module#get_scope_graph >}
 end
-and sg_inner_bindings init_scope init_scope_graph =
-object(self)
-  inherit SugarTraversals.fold as super
-  val scope = init_scope
-  method get_scope = scope
-end
-and sg_phrase =
-object(self)
-  inherit SugarTraversals.fold as super
-  val scope = init_scope
-  method get_scope = scope
-end
-
 
 let create_scope_graph prog =
   let o = (sg_global_bindings (new_scope None) (IntMap.singleton 0) 0)#program prog in

--- a/scopeGraph.ml
+++ b/scopeGraph.ml
@@ -173,18 +173,20 @@ object(self)
          * for the remainder of the binding list (and associated phrase), with
          * declarations of the pattern variables, and return this. *)
         let o = (construct_sg scope scope_graph scope_id)#phrase phr in
-        (* Get the scope and new scope graph froim the processed phrase *)
+        (* Get the scope and new scope graph from the processed phrase *)
         let (phr_scope, phr_sg) = (o#get_scope, o#get_scope_graph) in
-        (* Create a new scope which contains the variable bindings introduced by the patterns *)
+        let phr_sg1 = add_scope scope_id phr_scope phr_sg in
+        (* This scope declares the new patterns *)
+        let o_pattern = (construct_sg phr_scope phr_sg1 scope_id)#pattern pat in
+        let (pat_scope, pat_sg) =
+          (o_pattern#get_scope, o_pattern#get_scope_graph) in
+        (* Save this scope to SG, since it's done now. *)
+        let new_sg = add_scope scope_id pat_scope pat_sg in
+        (* Add a fresh scope *)
         let following_scope_id = get_scope_num () in
         let following_scope = new_scope (Some scope_id) in
-        let o_pattern = (construct_sg following_scope phr_sg following_scope_id)#pattern pat in
-        let (pat_scope, pat_scope_id, pat_sg) =
-          (o_pattern#get_scope, o_pattern#get_scope_id, o_pattern#get_scope_graph) in
-        (* Save this scope to SG, since it's done now. *)
-        let new_sg = add_scope scope_id phr_scope pat_sg in
         (* Return new scope with old scope added to SG. *)
-        {< scope = pat_scope; scope_id = pat_scope_id; scope_graph = new_sg >}
+        {< scope = following_scope; scope_id = following_scope_id; scope_graph = new_sg >}
     | `Infix -> self
     | `Exp p -> self#phrase p
     | `Foreign ((bnd_name, _, _), _name, _dt) ->

--- a/scopeGraph.ml
+++ b/scopeGraph.ml
@@ -278,16 +278,14 @@ let construct_sg_imp prog =
             (* Back to our parameters *)
             self
         | `Import n ->
-            let after_import_scope_id = create_scope (Some scope_id) in
-            add_ref_to_scope n after_import_scope_id;
-            add_import_to_scope n after_import_scope_id;
-            {< scope_id = after_import_scope_id >}
+            let next_scope_id = create_scope (Some scope_id) in
+            add_ref_to_scope n next_scope_id;
+            add_import_to_scope n next_scope_id;
+            {< scope_id = next_scope_id >}
         | `QualifiedImport ns ->
-            let after_import_scope_id = create_scope (Some scope_id) in
-            let o = {< scope_id = after_import_scope_id >} in
             let _ = self#qualified_name ns in
-            add_import_to_scope (get_last_list_element ns) after_import_scope_id;
-            o
+            add_import_to_scope (get_last_list_element ns) scope_id;
+            self
         | bn -> super#bindingnode bn
 
     method binder (n, _, _) =

--- a/scopeGraph.ml
+++ b/scopeGraph.ml
@@ -1,0 +1,136 @@
+(* Name of a scope *)
+type scope_name = string option
+
+(* Top-level scope *)
+type scope_graph = scope intmap
+
+(* Position *)
+type position = int
+
+(* Declaration -- generally a binder. Contains name, position, and optional
+ * named scope reference *)
+type declaration = (string * position * scope option)
+
+(* Name of a reference (function application, argument, etc.) *)
+type reference = (string * position)
+
+(* Name of an import (either in-module or out-of-module *)
+type import  = (string * position)
+
+(* Lists of declarations, references, imports, and an optional parent scope *)
+type scope =
+  { declarations : declaration list;
+    references : reference list;
+    imports : import list;
+    parent_scope : scope option
+  }
+
+(* Gets a list of scopes from the scope graph *)
+let get_scopes sg = sg
+
+(* Gets a list of declarations from a scope *)
+let get_declarations scope = scope.declarations
+
+(* Gets a list of references from a scope *)
+let get_references scope = scope.references
+
+let get_imports scope = scope.imports
+
+let get_parent scope = scope.parent_scope
+
+(* Scope graph construction *)
+
+(* Scope counter *)
+let scope_counter = ref 0
+let get_scope_num =
+  let counter = scope_counter in
+  fun () ->
+    begin
+      incr counter;
+      !counter
+    end
+
+(* We need:
+  *  top level bindings -> scope
+  *  block bindings -> scope
+  *  expression -> scope
+*)
+
+let add_declaration scope decl =
+  { scope with declarations = decl :: scope.declarations }
+
+let add_reference scope reference =
+  { scope with references = reference :: scope.references }
+
+let add_import scope import =
+  { scope with imports = import :: scope.imports }
+
+let new_scope parent =
+  { declarations = [];
+    references = [];
+    imports = [];
+    parent_scope = parent }
+
+let add_scope scope_id scope scope_graph = IntMap.add scope_id scope scope_graph
+
+let rec sg_bindings init_scope init_scope_graph scope_id =
+object(self)
+  inherit SugarTraversals.fold as super
+  (* Current scope *)
+  val scope = init_scope
+  method get_scope = scope
+  method set_scope s = {< scope = s >}
+
+  (* Overall scope graph *)
+  val scope_graph = init_scope_graph
+  method get_scope_graph = scope_graph
+
+  method bindingnode = function
+    | `Def (name, b) ->
+        (* Populate inner scope, then add to scope graph *)
+        let inner_scope_num = get_scope_num () in
+        let o_bindingnode = self#bindingnode b in
+        o_bindingnode#add_scope inner_scope_num o_bindingnode#get_scope
+    | `Fun ((fn_name, _, _), _lin, (_tyvars, fn_phrase), _loc, _dtopt) ->
+        (* Generate a new scope *)
+        let fn_scope_num = get_scope_num () in
+        (* Functions are assumed to be recursive, so are added to the scope *)
+        let fn_scope = add_declaration (new_scope (Some scope_id)) fn_name in
+        (* Now, perform an analysis on the function expression *)
+        let o_scope = sg_inner_bindings fn_scope scope_graph fn_scope_num in
+        (* Finally, get the updated scope graph, and add the new scope. *)
+        let (fn_sg, fn_scope1) = (o_scope#get_scope_graph, o_scope#get_scope) in
+        let new_sg = add_scope fn_scope_num fn_scope fn_sg in
+        {< scope_graph = new_sg >}
+    | `Funs _ ->
+        (* This is kind of problematic: `Funs is introduced in refineBindings, but
+         * this will mean that mutually-recursive functions can't share names at
+         * the top-level. Perhaps it could make sense to do two passes: one before (in order
+         * to introduce `Funs) and one after (after module desugaring)
+         * For now, let it be -- the old one had a similar issue, I think. *)
+        assert false
+    | `Import n ->
+        (* Add to imports list *)
+        (* to be continued... *)
+
+
+
+end
+and sg_inner_bindings init_scope init_scope_graph =
+object(self)
+  inherit SugarTraversals.fold as super
+  val scope = init_scope
+  method get_scope = scope
+end
+and sg_phrase =
+object(self)
+  inherit SugarTraversals.fold as super
+  val scope = init_scope
+  method get_scope = scope
+end
+
+
+let create_scope_graph prog =
+  let o = (sg_global_bindings (new_scope None) (IntMap.singleton 0) 0)#program prog in
+  o#get_scope_graph
+

--- a/scopeGraph.mli
+++ b/scopeGraph.mli
@@ -1,0 +1,19 @@
+(* Scope graph, as per "A Theory of Name Resolution" by Neron, Tolmach, Visser,
+ * and Wachmuth *)
+
+type scope_name
+type scope_graph
+type scope
+type declaration
+type reference
+type import
+
+(* Functions on scopes and scope graphs *)
+val get_scopes : scope_graph -> scope list
+val get_declarations : scope -> declaration list
+val get_references : scope -> reference list
+val get_imports : scope -> import_list
+val get_parent : scope -> scope option
+
+(* Scope graph construction *)
+val create_scope_graph : Sugartypes.program -> scope_graph

--- a/scopeGraph.mli
+++ b/scopeGraph.mli
@@ -8,15 +8,19 @@ type declaration
 type reference
 type import
 
-(* Functions on scopes and scope graphs *)
-(* might change these
-val get_scopes : scope_graph -> scope list
-val get_declarations : scope -> declaration list
-val get_references : scope -> reference list
-val get_imports : scope -> import list
-val get_parent : scope -> scope option
-*)
-
 (* Scope graph construction *)
 val create_scope_graph : Sugartypes.program -> scope_graph
 val make_and_print_scope_graph : Sugartypes.program -> unit
+
+(* Name resolution *)
+type name = Sugartypes.name
+type fq_name = Sugartypes.name
+type unique_name = Sugartypes.name
+
+(* Given a unique declaration name and a scope graph, returns the
+ * fully-qualified name of the declaration (or None if it doesn't exist) *)
+(* val get_fq_decl_name : unique_name -> scope_graph -> fq_name option *)
+
+(* Given a unique reference name and a scope graph, returns a list of possible
+ * fully-qualified (plain) names *)
+(* val resolve_fq_name : unique_name -> scope_graph -> fq_name list *)

--- a/scopeGraph.mli
+++ b/scopeGraph.mli
@@ -17,10 +17,20 @@ type name = Sugartypes.name
 type fq_name = Sugartypes.name
 type unique_name = Sugartypes.name
 
-(* Given a unique declaration name and a scope graph, returns the
- * fully-qualified name of the declaration (or None if it doesn't exist) *)
-(* val get_fq_decl_name : unique_name -> scope_graph -> fq_name option *)
 
-(* Given a unique reference name and a scope graph, returns a list of possible
- * fully-qualified (plain) names *)
-(* val resolve_fq_name : unique_name -> scope_graph -> fq_name list *)
+type resolution_result = [
+  | `AmbiguousResolution of name list
+  | `SuccessfulResolution of name
+  | `UnsuccessfulResolution
+]
+
+(* Resolves a unique *declaration* name to a fully-qualified plain name *)
+val make_resolved_plain_name: unique_name -> scope_graph -> Uniquify.unique_ast -> name
+
+(* Resolves a unique *reference* name to a resolution_result, which will either
+ * be a successful resolution containing a single unique *declaration* name,
+ * a list of possible ambiguous resolutions (containing declaration names), or
+ * an unsuccessful resolution *)
+val resolve_reference: unique_name -> scope_graph -> Uniquify.unique_ast -> resolution_result
+
+val show_scope_graph : scope_graph -> string

--- a/scopeGraph.mli
+++ b/scopeGraph.mli
@@ -19,3 +19,4 @@ val get_parent : scope -> scope option
 
 (* Scope graph construction *)
 val create_scope_graph : Sugartypes.program -> scope_graph
+val make_and_print_scope_graph : Sugartypes.program -> unit

--- a/scopeGraph.mli
+++ b/scopeGraph.mli
@@ -10,7 +10,7 @@ type import
 
 (* Scope graph construction *)
 val create_scope_graph : Sugartypes.program -> scope_graph
-val make_and_print_scope_graph : Sugartypes.program -> unit
+val make_and_print_scope_graph : Uniquify.unique_ast -> unit
 
 (* Name resolution *)
 type name = Sugartypes.name

--- a/scopeGraph.mli
+++ b/scopeGraph.mli
@@ -9,11 +9,13 @@ type reference
 type import
 
 (* Functions on scopes and scope graphs *)
+(* might change these
 val get_scopes : scope_graph -> scope list
 val get_declarations : scope -> declaration list
 val get_references : scope -> reference list
-val get_imports : scope -> import_list
+val get_imports : scope -> import list
 val get_parent : scope -> scope option
+*)
 
 (* Scope graph construction *)
 val create_scope_graph : Sugartypes.program -> scope_graph

--- a/scopeGraph.mli
+++ b/scopeGraph.mli
@@ -10,6 +10,7 @@ type import
 
 (* Scope graph construction *)
 val create_scope_graph : Sugartypes.program -> scope_graph
+val create_type_scope_graph : Sugartypes.program -> scope_graph
 val make_and_print_scope_graph : Uniquify.unique_ast -> unit
 
 (* Name resolution *)

--- a/sugarTraversals.ml
+++ b/sugarTraversals.ml
@@ -449,11 +449,10 @@ class map =
       function
       | `TypeVar _x ->
           let _x = o#known_type_variable _x in `TypeVar _x
-      | `QualifiedTypeVar (ns, sk_opt, frdm) ->
+      | `QualifiedTypeApplication (ns, args) ->
           let ns = o#list (fun o -> o#name) ns in
-          let sk_opt = o#option (fun o -> o#subkind) sk_opt in
-          let frdm = o#freedom frdm in
-          `QualifiedTypeVar (ns, sk_opt, frdm)
+          let args = o#list (fun o -> o#type_arg) args in
+          `QualifiedTypeApplication (ns, args)
       | `Function (_x, _x_i1, _x_i2) ->
           let _x = o#list (fun o -> o#datatype) _x in
           let _x_i1 = o#row _x_i1 in
@@ -986,10 +985,10 @@ class fold =
       function
       | `TypeVar _x ->
           let o = o#known_type_variable _x in o
-      | `QualifiedTypeVar (ns, sk_opt, frdm) ->
+      | `QualifiedTypeApplication (ns, args) ->
           let o = o#list (fun o -> o#name) ns in
-          let o = o#option (fun o -> o#subkind) sk_opt in
-          let o = o#freedom frdm in o
+          let o = o#list (fun o -> o#type_arg) args in
+          o
       | `Function (_x, _x_i1, _x_i2) ->
           let o = o#list (fun o -> o#datatype) _x in
           let o = o#row _x_i1 in let o = o#datatype _x_i2 in o
@@ -1623,11 +1622,10 @@ class fold_map =
       function
       | `TypeVar _x ->
           let (o, _x) = o#known_type_variable _x in (o, (`TypeVar _x))
-      | `QualifiedTypeVar (ns, sk_opt, frdm) ->
+      | `QualifiedTypeApplication (ns, args) ->
           let (o, ns) = o#list (fun o -> o#name) ns in
-          let (o, sk_opt) = o#option (fun o -> o#subkind) sk_opt in
-          let (o, frdm) = o#freedom frdm in
-          (o, `QualifiedTypeVar (ns, sk_opt, frdm))
+          let (o, args) = o#list (fun o -> o#type_arg) args in
+          (o, `QualifiedTypeApplication (ns, args))
       | `Function (_x, _x_i1, _x_i2) ->
           let (o, _x) = o#list (fun o -> o#datatype) _x in
           let (o, _x_i1) = o#row _x_i1 in

--- a/sugarTraversals.ml
+++ b/sugarTraversals.ml
@@ -152,6 +152,8 @@ class map =
       function
       | `Constant _x -> let _x = o#constant _x in `Constant _x
       | `Var _x -> let _x = o#name _x in `Var _x
+      | `QualifiedVar _xs ->
+          let _xs = o#list (fun o -> o#name) _xs in `QualifiedVar _xs
       | `FunLit (_x, _x1, _x_i1, _x_i2) -> let _x_i1 = o#funlit _x_i1 in
                                            let _x_i2 = o#location _x_i2 in `FunLit (_x, _x1, _x_i1, _x_i2)
       | `Spawn (_x, _x_i1, _x_i2, _x_i3) -> let _x_i1 = o#location _x_i1 in
@@ -447,6 +449,11 @@ class map =
       function
       | `TypeVar _x ->
           let _x = o#known_type_variable _x in `TypeVar _x
+      | `QualifiedTypeVar (ns, sk_opt, frdm) ->
+          let ns = o#list (fun o -> o#name) ns in
+          let sk_opt = o#option (fun o -> o#subkind) sk_opt in
+          let frdm = o#freedom frdm in
+          `QualifiedTypeVar (ns, sk_opt, frdm)
       | `Function (_x, _x_i1, _x_i2) ->
           let _x = o#list (fun o -> o#datatype) _x in
           let _x_i1 = o#row _x_i1 in
@@ -523,6 +530,10 @@ class map =
 
     method bindingnode : bindingnode -> bindingnode =
       function
+      | `Def (n, b) ->
+          let n = o#name n in
+          let b = o#bindingnode b in
+          `Def (n, b)
       | `Val ((_x, _x_i1, _x_i2, _x_i3, _x_i4)) ->
           let _x_i1 = o#pattern _x_i1 in
           let _x_i2 = o#phrase _x_i2 in
@@ -552,6 +563,9 @@ class map =
           let _x_i1 = o#name _x_i1 in
           let _x_i2 = o#datatype' _x_i2 in `Foreign ((_x, _x_i1, _x_i2))
       | `Import _x -> let _x = o#string _x in `Import _x
+      | `QualifiedImport _xs ->
+          let _xs = o#list (fun o -> o#name) _xs in
+          `QualifiedImport _xs
       | `Type ((_x, _x_i1, _x_i2)) ->
           let _x = o#name _x in
           let _x_i1 =
@@ -717,6 +731,8 @@ class fold =
       function
       | `Constant _x -> let o = o#constant _x in o
       | `Var _x -> let o = o#name _x in o
+      | `QualifiedVar _xs ->
+          let o = o#list (fun o -> o#name) _xs in o
       | `FunLit (_x, _x1, _x_i1, _x_i2) -> let o = o#funlit _x_i1 in let _x_i2 = o#location _x_i2 in o
       | `Spawn (_x, _x_i1, _x_i2, _x_i3) -> let o = o#location _x_i1 in let o = o#phrase _x_i2 in o
       | `Query (_x, _x_i1, _x_i2) ->
@@ -975,6 +991,10 @@ class fold =
       function
       | `TypeVar _x ->
           let o = o#known_type_variable _x in o
+      | `QualifiedTypeVar (ns, sk_opt, frdm) ->
+          let o = o#list (fun o -> o#name) ns in
+          let o = o#option (fun o -> o#subkind) sk_opt in
+          let o = o#freedom frdm in o
       | `Function (_x, _x_i1, _x_i2) ->
           let o = o#list (fun o -> o#datatype) _x in
           let o = o#row _x_i1 in let o = o#datatype _x_i2 in o
@@ -1043,6 +1063,10 @@ class fold =
 
     method bindingnode : bindingnode -> 'self_type =
       function
+      | `Def (n, b) ->
+          let o = o#name n in
+          let b = o#bindingnode b in
+          o
       | `Val ((_x, _x_i1, _x_i2, _x_i3, _x_i4)) ->
           let o = o#list (fun o -> o#tyvar) _x in
           let o = o#pattern _x_i1 in
@@ -1071,6 +1095,9 @@ class fold =
           let o = o#binder _x in
           let o = o#name _x_i1 in let o = o#datatype' _x_i2 in o
       | `Import _x -> let o = o#string _x in o
+      | `QualifiedImport _xs ->
+          let o = o#list (fun o -> o#name) _xs in
+          o
       | `Type ((_x, _x_i1, _x_i2)) ->
           let o = o#name _x in
           let o =
@@ -1258,6 +1285,9 @@ class fold_map =
       function
       | `Constant _x -> let (o, _x) = o#constant _x in (o, (`Constant _x))
       | `Var _x -> let (o, _x) = o#name _x in (o, (`Var _x))
+      | `QualifiedVar _xs ->
+          let (o, _xs) = o#list (fun o n -> o#name n) _xs in
+          (o, (`QualifiedVar _xs))
       | `FunLit (_x, _x1, _x_i1, _x_i2) ->
         let (o, _x_i1) = o#funlit _x_i1 in
         let (o, _x_i2) = o#location _x_i2 in (o, (`FunLit (_x, _x1, _x_i1, _x_i2)))
@@ -1603,6 +1633,11 @@ class fold_map =
       function
       | `TypeVar _x ->
           let (o, _x) = o#known_type_variable _x in (o, (`TypeVar _x))
+      | `QualifiedTypeVar (ns, sk_opt, frdm) ->
+          let (o, ns) = o#list (fun o -> o#name) ns in
+          let (o, sk_opt) = o#option (fun o -> o#subkind) sk_opt in
+          let (o, frdm) = o#freedom frdm in
+          (o, `QualifiedTypeVar (ns, sk_opt, frdm))
       | `Function (_x, _x_i1, _x_i2) ->
           let (o, _x) = o#list (fun o -> o#datatype) _x in
           let (o, _x_i1) = o#row _x_i1 in
@@ -1686,6 +1721,10 @@ class fold_map =
 
     method bindingnode : bindingnode -> ('self_type * bindingnode) =
       function
+      | `Def (n, b) ->
+          let (o, n) = o#name n in
+          let (o, b) = o#bindingnode b in
+          (o, `Def (n, b))
       | `Val ((_x, _x_i1, _x_i2, _x_i3, _x_i4)) ->
           let (o, _x_i1) = o#pattern _x_i1 in
           let (o, _x_i2) = o#phrase _x_i2 in
@@ -1716,6 +1755,9 @@ class fold_map =
           let (o, _x_i2) = o#datatype' _x_i2
           in (o, (`Foreign ((_x, _x_i1, _x_i2))))
       | `Import _x -> let (o, _x) = o#string _x in (o, (`Import _x))
+      | `QualifiedImport _xs ->
+          let (o, _xs) = o#list (fun o n -> o#name n) _xs in
+          (o, `QualifiedImport _xs)
       | `Type ((_x, _x_i1, _x_i2)) ->
           let (o, _x) = o#name _x in
           let (o, _x_i1) =

--- a/sugarTraversals.ml
+++ b/sugarTraversals.ml
@@ -530,10 +530,6 @@ class map =
 
     method bindingnode : bindingnode -> bindingnode =
       function
-      | `Def (n, b) ->
-          let n = o#name n in
-          let b = o#bindingnode b in
-          `Def (n, b)
       | `Val ((_x, _x_i1, _x_i2, _x_i3, _x_i4)) ->
           let _x_i1 = o#pattern _x_i1 in
           let _x_i2 = o#phrase _x_i2 in
@@ -1063,10 +1059,6 @@ class fold =
 
     method bindingnode : bindingnode -> 'self_type =
       function
-      | `Def (n, b) ->
-          let o = o#name n in
-          let b = o#bindingnode b in
-          o
       | `Val ((_x, _x_i1, _x_i2, _x_i3, _x_i4)) ->
           let o = o#list (fun o -> o#tyvar) _x in
           let o = o#pattern _x_i1 in
@@ -1721,10 +1713,6 @@ class fold_map =
 
     method bindingnode : bindingnode -> ('self_type * bindingnode) =
       function
-      | `Def (n, b) ->
-          let (o, n) = o#name n in
-          let (o, b) = o#bindingnode b in
-          (o, `Def (n, b))
       | `Val ((_x, _x_i1, _x_i2, _x_i3, _x_i4)) ->
           let (o, _x_i1) = o#pattern _x_i1 in
           let (o, _x_i2) = o#phrase _x_i2 in

--- a/sugarTraversals.ml
+++ b/sugarTraversals.ml
@@ -558,7 +558,6 @@ class map =
           let _x = o#binder _x in
           let _x_i1 = o#name _x_i1 in
           let _x_i2 = o#datatype' _x_i2 in `Foreign ((_x, _x_i1, _x_i2))
-      | `Import _x -> let _x = o#string _x in `Import _x
       | `QualifiedImport _xs ->
           let _xs = o#list (fun o -> o#name) _xs in
           `QualifiedImport _xs
@@ -574,10 +573,10 @@ class map =
           in let _x_i2 = o#datatype' _x_i2 in `Type ((_x, _x_i1, _x_i2))
       | `Infix -> `Infix
       | `Exp _x -> let _x = o#phrase _x in `Exp _x
-      | `Module (n, p) ->
+      | `Module (n, bs) ->
           let n = o#name n in
-          let p = o#phrase p in
-          `Module (n, p)
+          let bs = o#list (fun o -> o#binding) bs in
+          `Module (n, bs)
 
     method binding : binding -> binding =
       fun (_x, _x_i1) ->
@@ -1086,7 +1085,6 @@ class fold =
       | `Foreign ((_x, _x_i1, _x_i2)) ->
           let o = o#binder _x in
           let o = o#name _x_i1 in let o = o#datatype' _x_i2 in o
-      | `Import _x -> let o = o#string _x in o
       | `QualifiedImport _xs ->
           let o = o#list (fun o -> o#name) _xs in
           o
@@ -1102,9 +1100,9 @@ class fold =
           in let o = o#datatype' _x_i2 in o
       | `Infix -> o
       | `Exp _x -> let o = o#phrase _x in o
-      | `Module (n, p) ->
+      | `Module (n, bs) ->
           let o = o#name n in
-          let o = o#phrase p in
+          let o = o#list (fun o -> o#binding) bs in
           o
 
     method binding : binding -> 'self_type =
@@ -1742,7 +1740,6 @@ class fold_map =
           let (o, _x_i1) = o#name _x_i1 in
           let (o, _x_i2) = o#datatype' _x_i2
           in (o, (`Foreign ((_x, _x_i1, _x_i2))))
-      | `Import _x -> let (o, _x) = o#string _x in (o, (`Import _x))
       | `QualifiedImport _xs ->
           let (o, _xs) = o#list (fun o n -> o#name n) _xs in
           (o, `QualifiedImport _xs)
@@ -1759,10 +1756,10 @@ class fold_map =
           in (o, (`Type ((_x, _x_i1, _x_i2))))
       | `Infix -> (o, `Infix)
       | `Exp _x -> let (o, _x) = o#phrase _x in (o, (`Exp _x))
-      | `Module (n, p) ->
+      | `Module (n, bs) ->
           let (o, n) = o#string n in
-          let (o, p) = o#phrase p in
-          (o, (`Module (n, p)))
+          let (o, bs) = o#list (fun o -> o#binding) bs in
+          (o, (`Module (n, bs)))
 
     method binding : binding -> ('self_type * binding) =
       fun (_x, _x_i1) ->

--- a/sugartoir.ml
+++ b/sugartoir.ml
@@ -983,7 +983,7 @@ struct
                     (* Ignore type alias and infix declarations - they
                        shouldn't be needed in the IR *)
                     eval_bindings scope env bs e
-                | `Import _ -> assert false
+                | `QualifiedImport _ -> assert false
             end
 
   and evalv env e =

--- a/sugartypes.ml
+++ b/sugartypes.ml
@@ -109,6 +109,7 @@ type fieldconstraint = [ `Readonly | `Default ]
 
 type datatype =
   [ `TypeVar         of known_type_variable
+  | `QualifiedTypeVar of name list * subkind option * freedom
   | `Function        of datatype list * row * datatype
   | `Lolli           of datatype list * row * datatype
   | `Mu              of name * datatype
@@ -198,6 +199,7 @@ and declared_linearity = [ `Lin | `Unl ]
 and phrasenode = [
 | `Constant         of constant
 | `Var              of name
+| `QualifiedVar     of name list
 | `FunLit           of ((Types.datatype * Types.row) list) option * declared_linearity * funlit * location
 | `Spawn            of spawn_kind * location * phrase * Types.row option
 | `Query            of (phrase * phrase) option * phrase * Types.datatype option
@@ -262,6 +264,7 @@ and bindingnode = [
 | `Funs    of (binder * declared_linearity * ((tyvar list * (Types.datatype * Types.quantifier option list) option) * funlit) * location * datatype' option * position) list
 | `Foreign of binder * name * datatype'
 | `Import  of name
+| `QualifiedImport of name list
 | `Type    of name * (quantifier * tyvar option) list * datatype'
 | `Infix
 | `Exp     of phrase

--- a/sugartypes.ml
+++ b/sugartypes.ml
@@ -109,7 +109,7 @@ type fieldconstraint = [ `Readonly | `Default ]
 
 type datatype =
   [ `TypeVar         of known_type_variable
-  | `QualifiedTypeVar of name list * subkind option * freedom
+  | `QualifiedTypeApplication of (name list * type_arg list)
   | `Function        of datatype list * row * datatype
   | `Lolli           of datatype list * row * datatype
   | `Mu              of name * datatype

--- a/sugartypes.ml
+++ b/sugartypes.ml
@@ -256,9 +256,6 @@ and bindingnode = [
      which corresponds to
        let p=/\X.e in ...
 *)
-(* Needed for name resolution -- unordered binding. Needed to disambiguate
- * binding occurrence of a function from declaration which can be used recursively *)
-| `Def     of name * bindingnode
 | `Val     of tyvar list * pattern * phrase * location * datatype' option
 | `Fun     of binder * declared_linearity * (tyvar list * funlit) * location * datatype' option
 | `Funs    of (binder * declared_linearity * ((tyvar list * (Types.datatype * Types.quantifier option list) option) * funlit) * location * datatype' option * position) list

--- a/sugartypes.ml
+++ b/sugartypes.ml
@@ -254,6 +254,9 @@ and bindingnode = [
      which corresponds to
        let p=/\X.e in ...
 *)
+(* Needed for name resolution -- unordered binding. Needed to disambiguate
+ * binding occurrence of a function from declaration which can be used recursively *)
+| `Def     of name * bindingnode
 | `Val     of tyvar list * pattern * phrase * location * datatype' option
 | `Fun     of binder * declared_linearity * (tyvar list * funlit) * location * datatype' option
 | `Funs    of (binder * declared_linearity * ((tyvar list * (Types.datatype * Types.quantifier option list) option) * funlit) * location * datatype' option * position) list

--- a/sugartypes.ml
+++ b/sugartypes.ml
@@ -260,12 +260,11 @@ and bindingnode = [
 | `Fun     of binder * declared_linearity * (tyvar list * funlit) * location * datatype' option
 | `Funs    of (binder * declared_linearity * ((tyvar list * (Types.datatype * Types.quantifier option list) option) * funlit) * location * datatype' option * position) list
 | `Foreign of binder * name * datatype'
-| `Import  of name
 | `QualifiedImport of name list
 | `Type    of name * (quantifier * tyvar option) list * datatype'
 | `Infix
 | `Exp     of phrase
-| `Module  of name * phrase
+| `Module  of name * binding list
 ]
 and binding = bindingnode * position
 and directive = string * string list
@@ -441,7 +440,7 @@ struct
             (empty, []) in
           names, union_map (fun rhs -> diff (funlit rhs) names) rhss
     | `Foreign ((name, _, _), _, _) -> singleton name, empty
-    | `Import _
+    | `QualifiedImport _
     | `Type _
     | `Infix -> empty, empty
     | `Exp p -> empty, phrase p

--- a/test-harness
+++ b/test-harness
@@ -61,7 +61,9 @@ def evaluate(name, code, stdout='', stderr='', exit = '0', flags='-e', env = Non
     if filemode.startswith('true') :
         proc = Popen([links, code], stdout=PIPE, stderr=PIPE, env=env)
     elif filemode.startswith('args'):
-        proc = Popen([links, args, code], stdout=PIPE, stderr=PIPE, env=env)
+        arg_array = str.split(args, ' ')
+        popen_list = [links] + arg_array + [code]
+        proc = Popen(popen_list, stdout=PIPE, stderr=PIPE, env=env)
     else:
         proc = Popen([links, flags, code], stdout=PIPE, stderr=PIPE, env=env)
     passed = True

--- a/tests/modules.tests
+++ b/tests/modules.tests
@@ -55,3 +55,9 @@ Module chasing
 filemode : args
 args : --path=tests/modules
 stdout : "hello from c!" : String
+
+Module chasing via FQ variables
+./tests/modules/varRefA.links
+filemode : args
+args : --path=tests/modules
+stdout : "hello from b!" : String

--- a/tests/modules.tests
+++ b/tests/modules.tests
@@ -65,12 +65,6 @@ filemode : args
 args : -m --path=tests/modules
 stdout : "hello from c!" : String
 
-Module chasing via FQ variables
-./tests/modules/varRefA.links
-filemode : args
-args : -m --path=tests/modules
-stdout : "hello from b!" : String
-
 Basic types in modules
 ./tests/modules/type-sig.links
 filemode : args

--- a/tests/modules.tests
+++ b/tests/modules.tests
@@ -1,75 +1,84 @@
 Modules hide inner definitions
 ./tests/modules/basic-hide.links
-filemode : true
+filemode : args
 stderr : @.*
 exit : 1
 
 Basic qualified binding resolution
 ./tests/modules/basic-qual-resolution.links
-filemode : true
+filemode : args
+args : -m
 stdout : "hello" : String
 
 Inner module qualified binding resolution
 ./tests/modules/basic-inner-qual-resolution.links
-filemode : true
+filemode : args
+args : -m
 stdout : "hi" : String
 
 Open allows basic unqualified binding access
 ./tests/modules/basic-open.links
-filemode : true
+filemode : args
+args : -m
 stdout : "hello!" : String
 
 Module nesting allows partially-qualified names to be used for resolution
 ./tests/modules/basic-partial-qualification.links
-filemode : true
+filemode : args
+args : -m
 stdout : "hello" : String
 
 Open allows partially-qualified names to be used for resolution
 ./tests/modules/basic-partial-qualification-open.links
-filemode : true
+filemode : args
+args : -m
 stdout : "hello" : String
 
 Open still allows fully-qualified names to be used
 ./tests/modules/basic-open-fully-qual.links
-filemode : true
+filemode : args
+args : -m
 stdout : "hello" : String
 
 Opened module does not shadow bindings after opening
 ./tests/modules/basic-open-shadow.links
-filemode : true
+filemode : args
+args : -m
 stdout : "hi" : String
 
 Opened module shadows previous bindings after opening
 ./tests/modules/basic-open-no-shadow.links
-filemode : true
+filemode : args
 stdout : "greetings" : String
+args : -m
 
 Cyclic dependencies outlawed
 ./tests/modules/runmulti cyclicA.links
-filemode : true
+filemode : args
+args : -m
 stderr : @.*
 exit : 1
 
 Module chasing
 ./tests/modules/moduleA.links
 filemode : args
-args : --path=tests/modules
+args : -m --path=tests/modules
 stdout : "hello from c!" : String
 
 Module chasing via FQ variables
 ./tests/modules/varRefA.links
 filemode : args
-args : --path=tests/modules
+args : -m --path=tests/modules
 stdout : "hello from b!" : String
 
 Basic types in modules
 ./tests/modules/type-sig.links
 filemode : args
-args : --path=tests/modules
+args : -m --path=tests/modules
 stdout : 5 : A.AInt
 
 Basic type in session type
 ./tests/modules/session-type.links
 filemode : args
-args : --path=tests/modules
+args : -m --path=tests/modules
 stdout : () : ()

--- a/tests/modules.tests
+++ b/tests/modules.tests
@@ -61,3 +61,15 @@ Module chasing via FQ variables
 filemode : args
 args : --path=tests/modules
 stdout : "hello from b!" : String
+
+Basic types in modules
+./tests/modules/type-sig.links
+filemode : args
+args : --path=tests/modules
+stdout : 5 : A.AInt
+
+Basic type in session type
+./tests/modules/session-type.links
+filemode : args
+args : --path=tests/modules
+stdout : () : ()

--- a/tests/modules/basic-inner-qual-resolution.links
+++ b/tests/modules/basic-inner-qual-resolution.links
@@ -11,4 +11,4 @@ module A {
   }
 }
 
-A:::B:::bar()
+A.B.bar()

--- a/tests/modules/basic-open-fully-qual.links
+++ b/tests/modules/basic-open-fully-qual.links
@@ -6,8 +6,8 @@ module A {
   }
 
   fun foo() {
-    B:::bar()
+    B.bar()
   }
 }
 
-A:::B:::bar()
+A.B.bar()

--- a/tests/modules/basic-open.links
+++ b/tests/modules/basic-open.links
@@ -1,3 +1,4 @@
+fun bar() { () }
 module A {
   fun foo() {
     "hello!"

--- a/tests/modules/basic-partial-qualification-open.links
+++ b/tests/modules/basic-partial-qualification-open.links
@@ -11,4 +11,4 @@ module A {
 }
 
 open A
-B:::bar()
+B.bar()

--- a/tests/modules/basic-partial-qualification.links
+++ b/tests/modules/basic-partial-qualification.links
@@ -6,9 +6,9 @@ module A {
   }
 
   fun foo() {
-    B:::bar()
+    B.bar()
   }
 }
 
 open A
-A:::foo()
+A.foo()

--- a/tests/modules/basic-qual-resolution.links
+++ b/tests/modules/basic-qual-resolution.links
@@ -4,4 +4,4 @@ module A {
   }
 }
 
-A:::foo()
+A.foo()

--- a/tests/modules/session-type.links
+++ b/tests/modules/session-type.links
@@ -1,0 +1,18 @@
+module A {
+  typename AInt = Int;
+  var foo = 5;
+}
+
+typename Sess = ?(A.AInt).EndBang;
+
+sig srv : (Sess) ~> EndBang
+fun srv(c) {
+  var (_, c) = receive(c);
+  c
+}
+
+fun bar() {
+  var c = fork(srv);
+  var c = send(5, c);
+  wait(c)
+}

--- a/tests/modules/type-sig.links
+++ b/tests/modules/type-sig.links
@@ -1,0 +1,11 @@
+module A {
+  typename AInt = Int;
+  var foo = 5;
+}
+
+open A
+sig bar : () -> (AInt)
+fun bar() {
+  A.foo
+}
+bar()

--- a/tests/modules/varRefA.links
+++ b/tests/modules/varRefA.links
@@ -1,0 +1,6 @@
+module A {
+  fun bar() {
+    true
+  }
+}
+VarRefB.bar()

--- a/tests/modules/varRefB.links
+++ b/tests/modules/varRefB.links
@@ -1,0 +1,3 @@
+fun bar() {
+  "hello from b!"
+}

--- a/transformSugar.ml
+++ b/transformSugar.ml
@@ -658,8 +658,6 @@ class transform (env : Types.typing_environment) =
       | `Foreign (f, language, t) ->
           let (o, f) = o#binder f in
             (o, `Foreign (f, language, t))
-      | `Import _ ->
-          failwith "Includes aren't supported yet"
       | `Type (name, vars, (_, Some dt)) as e ->
           let tycon_env = TyEnv.bind tycon_env (name, `Alias (List.map (snd ->- val_of) vars, dt)) in
             {< tycon_env=tycon_env >}, e

--- a/typeSugar.ml
+++ b/typeSugar.ml
@@ -92,7 +92,6 @@ struct
     | `DBUpdate _ -> false
   and is_pure_binding (bind, _ : binding) = match bind with
       (* need to check that pattern matching cannot fail *)
-    | `Def _
     | `QualifiedImport _
     | `Fun _
     | `Funs _
@@ -2528,7 +2527,6 @@ and type_binding : context -> binding -> binding * context * usagemap =
     let typed, ctxt, usage = match def with
       | `Import _ -> assert false
       | `QualifiedImport _ -> assert false
-      | `Def _ -> assert false
       | `Val (_, pat, body, location, datatype) ->
           let body = tc body in
           let pat = tpc pat in

--- a/typeSugar.ml
+++ b/typeSugar.ml
@@ -97,7 +97,6 @@ struct
     | `Funs _
     | `Infix
     | `Type _
-    | `Import _
     | `Foreign _ -> true
     | `Exp p -> is_pure p
     | `Val (_, pat, rhs, _, _) ->
@@ -2525,7 +2524,6 @@ and type_binding : context -> binding -> binding * context * usagemap =
     let empty_context = empty_context (context.Types.effect_row) in
 
     let typed, ctxt, usage = match def with
-      | `Import _ -> assert false
       | `QualifiedImport _ -> assert false
       | `Val (_, pat, body, location, datatype) ->
           let body = tc body in

--- a/typeSugar.ml
+++ b/typeSugar.ml
@@ -37,6 +37,7 @@ struct
   and is_pure (p, _) = match p with
     | `Constant _
     | `Var _
+    | `QualifiedVar _
     | `FunLit _
     | `DatabaseLit _
     | `TableLit _
@@ -91,6 +92,8 @@ struct
     | `DBUpdate _ -> false
   and is_pure_binding (bind, _ : binding) = match bind with
       (* need to check that pattern matching cannot fail *)
+    | `Def _
+    | `QualifiedImport _
     | `Fun _
     | `Funs _
     | `Infix
@@ -2524,6 +2527,8 @@ and type_binding : context -> binding -> binding * context * usagemap =
 
     let typed, ctxt, usage = match def with
       | `Import _ -> assert false
+      | `QualifiedImport _ -> assert false
+      | `Def _ -> assert false
       | `Val (_, pat, body, location, datatype) ->
           let body = tc body in
           let pat = tpc pat in

--- a/uniquify.ml
+++ b/uniquify.ml
@@ -29,20 +29,17 @@ object (self)
     let uniquified_name = make_unique_name name in
     (self#add_name name uniquified_name, (uniquified_name, dt, pos))
 
-  method datatype dt = (self, dt)
-  (* Jettisoned for now until we get the type SG going
-  function
-    | `TypeVar (n, sk_opt, frdm) ->
-        let uniquified_name = make_unique_name n in
-        (self#add_name n uniquified_name, `TypeVar (uniquified_name, sk_opt, frdm))
-    | `QualifiedTypeVar (ns, sk_opt, frdm) ->
-        let (o1, ns1) =
-          self#list (fun o n ->
-            let uniquified_name = make_unique_name n in
-            (o#add_name n uniquified_name, uniquified_name)) ns in
-        (o1, `QualifiedTypeVar (ns1, sk_opt, frdm))
-    | dt -> super#datatype dt
-  *)
+  method datatype = function
+      | `TypeApplication (n, args) ->
+          let uniquified_name = make_unique_name n in
+          (self#add_name n uniquified_name, `TypeApplication (uniquified_name, args))
+      | `QualifiedTypeApplication (ns, args) ->
+          let (o1, ns1) =
+            self#list (fun o n ->
+              let uniquified_name = make_unique_name n in
+              (o#add_name n uniquified_name, uniquified_name)) ns in
+          (o1, `QualifiedTypeApplication (ns1, args))
+      | dt -> super#datatype dt
 
   (* Some names in bindingnode need to be renamed, but aren't referred to using binders *)
   method bindingnode = function
@@ -51,10 +48,10 @@ object (self)
           let uniquified_name = make_unique_name n in
           (o#add_name n uniquified_name, uniquified_name)) ns in
         (o, `QualifiedImport ns1)
-    | `Type (n, xs, dt) -> (self, `Type (n, xs, dt))
-        (*
+    | `Type (n, xs, dt) ->
       let uniquified_name = make_unique_name n in
-      (self#add_name n uniquified_name, `Type (uniquified_name, xs, dt)) *)
+      let (o, dt1) = self#datatype' dt in
+      (o#add_name n uniquified_name, `Type (uniquified_name, xs, dt1))
     | `Module (n, bs) ->
       let uniquified_name = make_unique_name n in
       let o = self#add_name n uniquified_name in

--- a/uniquify.ml
+++ b/uniquify.ml
@@ -29,7 +29,9 @@ object (self)
     let uniquified_name = make_unique_name name in
     (self#add_name name uniquified_name, (uniquified_name, dt, pos))
 
-  method datatype = function
+  method datatype dt = (self, dt)
+  (* Jettisoned for now until we get the type SG going
+  function
     | `TypeVar (n, sk_opt, frdm) ->
         let uniquified_name = make_unique_name n in
         (self#add_name n uniquified_name, `TypeVar (uniquified_name, sk_opt, frdm))
@@ -40,6 +42,7 @@ object (self)
             (o#add_name n uniquified_name, uniquified_name)) ns in
         (o1, `QualifiedTypeVar (ns1, sk_opt, frdm))
     | dt -> super#datatype dt
+  *)
 
   (* Some names in bindingnode need to be renamed, but aren't referred to using binders *)
   method bindingnode = function
@@ -51,9 +54,10 @@ object (self)
     | `Import n ->
       let uniquified_name = make_unique_name n in
       (self#add_name n uniquified_name, `Import uniquified_name)
-    | `Type (n, xs, dt) ->
+    | `Type (n, xs, dt) -> (self, `Type (n, xs, dt))
+        (*
       let uniquified_name = make_unique_name n in
-      (self#add_name n uniquified_name, `Type (uniquified_name, xs, dt))
+      (self#add_name n uniquified_name, `Type (uniquified_name, xs, dt)) *)
     | `Module (n, p) ->
       let uniquified_name = make_unique_name n in
       let o = self#add_name n uniquified_name in

--- a/uniquify.ml
+++ b/uniquify.ml
@@ -1,0 +1,58 @@
+open Utility
+
+(* Maps unique names to original names and an index *)
+
+type unique_name = string
+let make_unique_name name = gensym ~prefix=name ()
+
+type unique_var_map = unique_name stringmap
+type unique_ast = Sugartypes.program * unique_var_map
+
+(* Gets the AST component of a uniquified AST *)
+let get_ast (prog, _) = prog
+
+(* Looks up a uniquified variable from the unique ast, resolves to a plain name *)
+let lookup_var n u_ast =
+  let (_, var_map) = u_ast in
+  StringMap.find n var_map
+
+
+let uniquify ast unique_map =
+object (self)
+  inherit SugarTraversals.fold_map as super
+  val unique_map = unique_map
+  (* Adds a uniquified name to the map *)
+  method add_name old_name new_name = {< unique_map = StringMap.add name unique_map >}
+
+  method binder (name, dt, pos) =
+    let uniquified_name = make_unique_name name in
+    (self#add_name name uniquified_name, uniquified_name)
+
+  (* Some names in bindingnode need to be renamed, but aren't referred to using binders *)
+  method bindingnode = function
+    | `Import n ->
+      let uniquified_name = make_unique_name n in
+      (self#add_name n uniquified_name, `Import uniquified_name)
+    | `Type (n, xs, dt) ->
+      let uniquified_name = make_unique_name n in
+      (self#add_name n uniquified_name, `Type (uniquified_name, xs, dt'))
+    | `Module (n, p) ->
+      let uniquified_name = make_unique_name n in
+      let o = self#add_name n uniquified_name in
+      let (o1, p1) = self#phrase p in
+      (o1, `Module (uniquified_name, p))
+    | bn -> super#bindingnode bn
+
+  method phrasenode = function
+    | `Var name ->
+        let uniquified_name = make_unique_name name in
+        (self#add_name name uniquified_name, `Var uniquified_name)
+    | p -> super#phrasenode p
+end
+
+(* Creates a uniquified AST from a plain AST *)
+let uniquify_ast prog =
+  let (o, prog1) = (uniquify ast StringMap.empty)#program prog in
+  let unique_map = o#get_unique_map in
+  (unique_map, prog1)
+

--- a/uniquify.ml
+++ b/uniquify.ml
@@ -65,7 +65,7 @@ object (self)
       let uniquified_name = make_unique_name n in
       let o = self#add_name n uniquified_name in
       let (o1, p1) = self#phrase p in
-      (o1, `Module (uniquified_name, p))
+      (o1, `Module (uniquified_name, p1))
     | bn -> super#bindingnode bn
 
   method phrasenode = function

--- a/uniquify.ml
+++ b/uniquify.ml
@@ -54,13 +54,6 @@ object (self)
     | `Type (n, xs, dt) ->
       let uniquified_name = make_unique_name n in
       (self#add_name n uniquified_name, `Type (uniquified_name, xs, dt))
-    (* For the algorithm to work in the presence of functions whose order doesn't matter,
-     * we need to disambiguate between the occurrence as a binding, and the
-     * occurrence to be used *within* the function for recursion. Wart, but eh. *)
-    | `Fun (((n, dtopt1, pos), _, _, _, _) as fn_body)  ->
-        let uniquified_name = make_unique_name n in
-        let (o, fn_body1) = super#bindingnode (`Fun fn_body) in
-        (o#add_name n uniquified_name, `Def (uniquified_name, fn_body1))
     | `Module (n, p) ->
       let uniquified_name = make_unique_name n in
       let o = self#add_name n uniquified_name in

--- a/uniquify.ml
+++ b/uniquify.ml
@@ -3,7 +3,7 @@ open Utility
 (* Maps unique names to original names and an index *)
 
 type unique_name = string
-let make_unique_name name = gensym ~prefix=name ()
+let make_unique_name name = gensym ~prefix:name ()
 
 type unique_var_map = unique_name stringmap
 type unique_ast = Sugartypes.program * unique_var_map
@@ -17,33 +17,50 @@ let lookup_var n u_ast =
   StringMap.find n var_map
 
 
-let uniquify ast unique_map =
+let uniquify name_map =
 object (self)
   inherit SugarTraversals.fold_map as super
-  val unique_map = unique_map
+  val unique_map = name_map
   (* Adds a uniquified name to the map *)
-  method add_name old_name new_name = {< unique_map = StringMap.add name unique_map >}
+  method add_name old_name new_name = {< unique_map = StringMap.add new_name old_name unique_map >}
+  method get_unique_map = unique_map
 
   method binder (name, dt, pos) =
     let uniquified_name = make_unique_name name in
-    (self#add_name name uniquified_name, uniquified_name)
+    (self#add_name name uniquified_name, (uniquified_name, dt, pos))
+
+  method datatype = function
+    | `TypeVar (n, sk_opt, frdm) ->
+        let uniquified_name = make_unique_name n in
+        (self#add_name n uniquified_name, `TypeVar (uniquified_name, sk_opt, frdm))
+    | `QualifiedTypeVar (ns, sk_opt, frdm) ->
+        let (o1, ns1) =
+          self#list (fun o n ->
+            let uniquified_name = make_unique_name n in
+            (o#add_name n uniquified_name, uniquified_name)) ns in
+        (o1, `QualifiedTypeVar (ns1, sk_opt, frdm))
+    | dt -> super#datatype dt
 
   (* Some names in bindingnode need to be renamed, but aren't referred to using binders *)
-  (* TODO: QualifiedImport *)
   method bindingnode = function
+    | `QualifiedImport ns ->
+        let (o, ns1) = self#list (fun o n ->
+          let uniquified_name = make_unique_name n in
+          (o#add_name n uniquified_name, uniquified_name)) ns in
+        (o, `QualifiedImport ns1)
     | `Import n ->
       let uniquified_name = make_unique_name n in
       (self#add_name n uniquified_name, `Import uniquified_name)
     | `Type (n, xs, dt) ->
       let uniquified_name = make_unique_name n in
-      (self#add_name n uniquified_name, `Type (uniquified_name, xs, dt'))
+      (self#add_name n uniquified_name, `Type (uniquified_name, xs, dt))
     (* For the algorithm to work in the presence of functions whose order doesn't matter,
      * we need to disambiguate between the occurrence as a binding, and the
      * occurrence to be used *within* the function for recursion. Wart, but eh. *)
     | `Fun (((n, dtopt1, pos), _, _, _, _) as fn_body)  ->
         let uniquified_name = make_unique_name n in
         let (o, fn_body1) = super#bindingnode (`Fun fn_body) in
-        (`Def (uniquified_name, fn_body_1), o#add_name n uniquified_name)
+        (o#add_name n uniquified_name, `Def (uniquified_name, fn_body1))
     | `Module (n, p) ->
       let uniquified_name = make_unique_name n in
       let o = self#add_name n uniquified_name in
@@ -51,8 +68,12 @@ object (self)
       (o1, `Module (uniquified_name, p))
     | bn -> super#bindingnode bn
 
-  (* TODO: QualifiedVar *)
   method phrasenode = function
+    | `QualifiedVar ns ->
+        let (o, ns1) = self#list (fun o n ->
+          let uniquified_name = make_unique_name n in
+          (o#add_name n uniquified_name, uniquified_name)) ns in
+        (o, `QualifiedVar ns1)
     | `Var name ->
         let uniquified_name = make_unique_name name in
         (self#add_name name uniquified_name, `Var uniquified_name)
@@ -61,7 +82,7 @@ end
 
 (* Creates a uniquified AST from a plain AST *)
 let uniquify_ast prog =
-  let (o, prog1) = (uniquify ast StringMap.empty)#program prog in
+  let (o, prog1) = (uniquify StringMap.empty)#program prog in
   let unique_map = o#get_unique_map in
-  (unique_map, prog1)
+  (prog1, unique_map)
 

--- a/uniquify.ml
+++ b/uniquify.ml
@@ -36,6 +36,13 @@ object (self)
     | `Type (n, xs, dt) ->
       let uniquified_name = make_unique_name n in
       (self#add_name n uniquified_name, `Type (uniquified_name, xs, dt'))
+    (* For the algorithm to work in the presence of functions whose order doesn't matter,
+     * we need to disambiguate between the occurrence as a binding, and the
+     * occurrence to be used *within* the function for recursion. Wart, but eh. *)
+    | `Fun (((n, dtopt1, pos), _, _, _, _) as fn_body)  ->
+        let uniquified_name = make_unique_name n in
+        let (o, fn_body1) = super#bindingnode (`Fun fn_body) in
+        (`Def (uniquified_name, fn_body_1), o#add_name n uniquified_name)
     | `Module (n, p) ->
       let uniquified_name = make_unique_name n in
       let o = self#add_name n uniquified_name in

--- a/uniquify.ml
+++ b/uniquify.ml
@@ -57,7 +57,7 @@ object (self)
     | `Module (n, p) ->
       let uniquified_name = make_unique_name n in
       let o = self#add_name n uniquified_name in
-      let (o1, p1) = self#phrase p in
+      let (o1, p1) = o#phrase p in
       (o1, `Module (uniquified_name, p1))
     | bn -> super#bindingnode bn
 

--- a/uniquify.ml
+++ b/uniquify.ml
@@ -29,6 +29,7 @@ object (self)
     (self#add_name name uniquified_name, uniquified_name)
 
   (* Some names in bindingnode need to be renamed, but aren't referred to using binders *)
+  (* TODO: QualifiedImport *)
   method bindingnode = function
     | `Import n ->
       let uniquified_name = make_unique_name n in
@@ -50,6 +51,7 @@ object (self)
       (o1, `Module (uniquified_name, p))
     | bn -> super#bindingnode bn
 
+  (* TODO: QualifiedVar *)
   method phrasenode = function
     | `Var name ->
         let uniquified_name = make_unique_name name in

--- a/uniquify.ml
+++ b/uniquify.ml
@@ -51,18 +51,15 @@ object (self)
           let uniquified_name = make_unique_name n in
           (o#add_name n uniquified_name, uniquified_name)) ns in
         (o, `QualifiedImport ns1)
-    | `Import n ->
-      let uniquified_name = make_unique_name n in
-      (self#add_name n uniquified_name, `Import uniquified_name)
     | `Type (n, xs, dt) -> (self, `Type (n, xs, dt))
         (*
       let uniquified_name = make_unique_name n in
       (self#add_name n uniquified_name, `Type (uniquified_name, xs, dt)) *)
-    | `Module (n, p) ->
+    | `Module (n, bs) ->
       let uniquified_name = make_unique_name n in
       let o = self#add_name n uniquified_name in
-      let (o1, p1) = o#phrase p in
-      (o1, `Module (uniquified_name, p1))
+      let (o1, bs1) = o#list (fun o -> o#binding) bs in
+      (o1, `Module (uniquified_name, bs1))
     | bn -> super#bindingnode bn
 
   method phrasenode = function

--- a/uniquify.ml
+++ b/uniquify.ml
@@ -5,7 +5,7 @@ open Utility
 type unique_name = string
 let make_unique_name name = gensym ~prefix:name ()
 
-type unique_var_map = unique_name stringmap
+type unique_var_map = (unique_name, Sugartypes.name) Hashtbl.t
 type unique_ast = Sugartypes.program * unique_var_map
 
 (* Gets the AST component of a uniquified AST *)
@@ -14,66 +14,72 @@ let get_ast (prog, _) = prog
 (* Looks up a uniquified variable from the unique ast, resolves to a plain name *)
 let lookup_var n u_ast =
   let (_, var_map) = u_ast in
-  StringMap.find n var_map
+  Hashtbl.find var_map n
 
 
 let uniquify name_map =
 object (self)
-  inherit SugarTraversals.fold_map as super
-  val unique_map = name_map
+  inherit SugarTraversals.map as super
   (* Adds a uniquified name to the map *)
-  method add_name old_name new_name = {< unique_map = StringMap.add new_name old_name unique_map >}
-  method get_unique_map = unique_map
+  method add_name old_name new_name =
+    Hashtbl.add name_map new_name old_name
 
   method binder (name, dt, pos) =
     let uniquified_name = make_unique_name name in
-    (self#add_name name uniquified_name, (uniquified_name, dt, pos))
+    self#add_name name uniquified_name;
+    (uniquified_name, dt, pos)
 
   method datatype = function
       | `TypeApplication (n, args) ->
           let uniquified_name = make_unique_name n in
-          (self#add_name n uniquified_name, `TypeApplication (uniquified_name, args))
+          self#add_name n uniquified_name;
+          `TypeApplication (uniquified_name, args)
       | `QualifiedTypeApplication (ns, args) ->
-          let (o1, ns1) =
+          let ns1 =
             self#list (fun o n ->
               let uniquified_name = make_unique_name n in
-              (o#add_name n uniquified_name, uniquified_name)) ns in
-          (o1, `QualifiedTypeApplication (ns1, args))
+              o#add_name n uniquified_name;
+              uniquified_name) ns in
+          `QualifiedTypeApplication (ns1, args)
       | dt -> super#datatype dt
 
   (* Some names in bindingnode need to be renamed, but aren't referred to using binders *)
   method bindingnode = function
     | `QualifiedImport ns ->
-        let (o, ns1) = self#list (fun o n ->
+        let ns1 = self#list (fun o n ->
           let uniquified_name = make_unique_name n in
-          (o#add_name n uniquified_name, uniquified_name)) ns in
-        (o, `QualifiedImport ns1)
+          o#add_name n uniquified_name;
+          uniquified_name) ns in
+        `QualifiedImport ns1
     | `Type (n, xs, dt) ->
       let uniquified_name = make_unique_name n in
-      let (o, dt1) = self#datatype' dt in
-      (o#add_name n uniquified_name, `Type (uniquified_name, xs, dt1))
+      let dt1 = self#datatype' dt in
+      self#add_name n uniquified_name;
+      `Type (uniquified_name, xs, dt1)
     | `Module (n, bs) ->
       let uniquified_name = make_unique_name n in
-      let o = self#add_name n uniquified_name in
-      let (o1, bs1) = o#list (fun o -> o#binding) bs in
-      (o1, `Module (uniquified_name, bs1))
+      self#add_name n uniquified_name;
+      let bs1 = self#list (fun o -> o#binding) bs in
+      `Module (uniquified_name, bs1)
     | bn -> super#bindingnode bn
 
   method phrasenode = function
     | `QualifiedVar ns ->
-        let (o, ns1) = self#list (fun o n ->
+        let ns1 = self#list (fun o n ->
           let uniquified_name = make_unique_name n in
-          (o#add_name n uniquified_name, uniquified_name)) ns in
-        (o, `QualifiedVar ns1)
+          self#add_name n uniquified_name;
+          uniquified_name) ns in
+        `QualifiedVar ns1
     | `Var name ->
         let uniquified_name = make_unique_name name in
-        (self#add_name name uniquified_name, `Var uniquified_name)
+        self#add_name name uniquified_name;
+        `Var uniquified_name
     | p -> super#phrasenode p
 end
 
 (* Creates a uniquified AST from a plain AST *)
 let uniquify_ast prog =
-  let (o, prog1) = (uniquify StringMap.empty)#program prog in
-  let unique_map = o#get_unique_map in
-  (prog1, unique_map)
+  let ht = Hashtbl.create 1000 in
+  let prog1 = (uniquify ht)#program prog in
+  (prog1, ht)
 

--- a/uniquify.mli
+++ b/uniquify.mli
@@ -1,0 +1,10 @@
+type unique_ast
+
+(* Gets the AST component of a uniquified AST *)
+val get_ast : unique_ast -> Sugartypes.program
+
+(* Creates a uniquified AST from a plain AST *)
+val uniquify_ast : Sugartypes.program -> unique_ast
+
+(* Looks up a uniquified variable from the unique ast, resolves to a plain name *)
+val lookup_var : Sugartypes.name -> unique_ast -> Sugartypes.name


### PR DESCRIPTION
This PR adds the newer version of the modules system as described in the Wiki. The name resolution system is an implementation of Neron et al.'s scope graph formalism.

This should be less ad-hoc and cleaner than the previous system.

Additionally, since it's a rather major change, the module system is hidden behind a flag "-m" (or, setting the setting flag modules to true).

Still unsupported is partially-qualified imports from external files -- they all have to be fully-qualified at the moment. It's probable that we'd be looking at some sort of tradeoff here (such as explicit import ordering, or explicit declaration of all imported modules) if we want this, but I don't think it's crucial for the release.