### PR TITLE
Always display fresh variables in error messages

### DIFF
--- a/typeSugar.ml
+++ b/typeSugar.ml
@@ -335,12 +335,15 @@ end
     (* New line with indentation *)
     let nli () = nl () ^ tab ()
 
+    (* Always display fresh variables when printing error messages *)
+    let error_policy () = { (Types.Print.default_policy ()) with hide_fresh = false }
+
     (* Do not automatically refresh type variable names when pretty-printing
        types in error messages.  This will be done manually by calling
        build_tyvar_names in the gripers.
        See Notes [Variable names in error messages] and [Refreshing type variable names] *)
-    let show_type   = Types.string_of_datatype ~refresh_tyvar_names:false
-    let show_row    = Types.string_of_row      ~refresh_tyvar_names:false
+    let show_type   = Types.string_of_datatype ~policy:error_policy ~refresh_tyvar_names:false
+    let show_row    = Types.string_of_row      ~policy:error_policy ~refresh_tyvar_names:false
 
     (* Wrappers for generating type variable names *)
     let build_tyvar_names =

--- a/types.ml
+++ b/types.ml
@@ -2036,23 +2036,6 @@ let string_of_tycon_spec ?(policy=Print.default_policy) ?(refresh_tyvar_names=tr
     build_tyvar_names free_bound_tycon_type_vars [tycon];
   Print.tycon_spec TypeVarSet.empty (policy (), Vars.tyvar_name_map) tycon
 
-(* HACK:
-   Just use the default policy. At some point we might want to export
-   the printing policy in types.mli.
- *)
-let string_of_datatype ?(refresh_tyvar_names=true) t
-  = string_of_datatype ~refresh_tyvar_names t
-let string_of_row ?(refresh_tyvar_names=true) r
-  = string_of_row ~refresh_tyvar_names r
-let string_of_presence ?(refresh_tyvar_names=true) f
-  = string_of_presence ~refresh_tyvar_names f
-let string_of_type_arg ?(refresh_tyvar_names=true) arg
-  = string_of_type_arg ~refresh_tyvar_names arg
-let string_of_row_var ?(refresh_tyvar_names=true) r
-  = string_of_row_var ~refresh_tyvar_names r
-let string_of_tycon_spec ?(refresh_tyvar_names=true) s
-  = string_of_tycon_spec ~refresh_tyvar_names s
-
 module Show_datatype =
   Deriving_Show.Defaults
     (struct

--- a/types.mli
+++ b/types.mli
@@ -65,6 +65,13 @@ module Vars : sig
   type vars_list = (int * (flavour * kind * scope)) list
 end
 
+module Print : sig
+  type policy = {quantifiers:bool; flavours:bool; hide_fresh:bool; kinds:string}
+
+  val default_policy : unit -> policy
+end
+
+
 val process      : Abstype.t
 val list         : Abstype.t
 val event        : Abstype.t
@@ -337,12 +344,18 @@ val make_wobbly_envs : datatype -> datatype Utility.IntMap.t * row Utility.IntMa
 val show_mailbox_annotations : bool Settings.setting
 
 (** pretty printing *)
-val string_of_datatype   : ?refresh_tyvar_names:bool -> datatype   -> string
-val string_of_row        : ?refresh_tyvar_names:bool -> row        -> string
-val string_of_presence   : ?refresh_tyvar_names:bool -> field_spec -> string
-val string_of_type_arg   : ?refresh_tyvar_names:bool -> type_arg   -> string
-val string_of_row_var    : ?refresh_tyvar_names:bool -> row_var    -> string
-val string_of_tycon_spec : ?refresh_tyvar_names:bool -> tycon_spec -> string
+val string_of_datatype   : ?policy:(unit -> Print.policy)
+                        -> ?refresh_tyvar_names:bool -> datatype   -> string
+val string_of_row        : ?policy:(unit -> Print.policy)
+                        -> ?refresh_tyvar_names:bool -> row        -> string
+val string_of_presence   : ?policy:(unit -> Print.policy)
+                        -> ?refresh_tyvar_names:bool -> field_spec -> string
+val string_of_type_arg   : ?policy:(unit -> Print.policy)
+                        -> ?refresh_tyvar_names:bool -> type_arg   -> string
+val string_of_row_var    : ?policy:(unit -> Print.policy)
+                        -> ?refresh_tyvar_names:bool -> row_var    -> string
+val string_of_tycon_spec : ?policy:(unit -> Print.policy)
+                        -> ?refresh_tyvar_names:bool -> tycon_spec -> string
 val string_of_environment        : environment -> string
 val string_of_typing_environment : typing_environment -> string
 


### PR DESCRIPTION
This is a follow-up on my earlier fix to #43. During discussion between @slindley, @dhil and me we concluded that it is really difficult to come up with a general and simple rule when to hide fresh variables in error messages. It seems that the easiest and safest thing to do is to always display all the variables in error messages.