### PR TITLE
dbs other than postgres do not support shredding, so raise an error

### DIFF
--- a/evalir.ml
+++ b/evalir.ml
@@ -465,6 +465,8 @@ struct
            | None -> computation env cont e
            | Some (db, p) ->
                begin
+		 if db#driver_name() <> "postgresql"
+		 then raise (Errors.Runtime_error "Only PostgreSQL database driver supports shredding");
 		 let get_fields t =
                    match t with
                    | `Record fields ->


### PR DESCRIPTION
This is to do the final bullet point of #76, raising a dynamic error if we attempt to use shredding with a database driver other than postgresql.  

I propose to merge this as soon as the CI tests pass.