### PR TITLE
Support for using environment variables in Links configuration files

### DIFF
--- a/notfound.ml
+++ b/notfound.ml
@@ -230,6 +230,30 @@ struct
   let getenv name =
     try getenv name
     with Not_found -> not_found "Sys.getenv" name
+
+  (* Windows shell identifier names: [][A-Za-z0-9#~.,$'()*+?@_`{} -]+
+     Portable Unix shell identifier names: $[A-Za-z_][A-Za-z0-9_]*
+  *)
+  let shell_var_regexp =
+    if Sys.win32 then
+      Str.regexp "%[][A-Za-z0-9#~.,$'()*+?@_`{} -]+%"
+    else
+      Str.regexp "\\$[A-Za-z_]\\([A-Za-z0-9_]*\\)"
+
+  let normalize_env_var =
+    if Sys.win32 then
+      (fun var -> String.sub var 1 (String.length var - 2))
+    else
+      (fun var -> String.sub var 1 (String.length var - 1))
+      
+  (*  Expands any environmental variables in [string] *)
+  let expand string =
+    Pervasives.(
+      Str.full_split shell_var_regexp string
+   |> List.map (function | Str.Delim v -> Sys.getenv @@ normalize_env_var v | Str.Text v -> v)
+   |> String.concat ""
+    )
+
 end
 
 module Unix =

--- a/settings.ml
+++ b/settings.ml
@@ -81,7 +81,12 @@ let parse_and_set' : [`Any | `OnlyUser] -> (string * string) -> unit = fun kind 
 		        output_string stderr ("Setting '" ^ name ^ "' expects a boolean\n"); flush stderr
 	            end
 	        | `String setting ->
-	            set_value setting (Utility.Sys.expand value)
+                   let expanded_value =
+                     try Utility.Sys.expand value
+                     with Utility.Sys.Unknown_environment_variable v ->
+                       failwith (Printf.sprintf "failed to expand environment variable '%s' in value '%s' while setting '%s'.\n" v value setting.name)
+                   in
+	           set_value setting expanded_value
             end
         | _ ->
 	    output_string stderr ("Cannot change system setting '" ^ name ^ "'\n"); flush stderr;
@@ -176,7 +181,7 @@ let from_argv : string array -> string list =
 
 
 let load_file filename =
-  let file = open_in (Utility.Sys.expand filename) in
+  let file = open_in filename in
 
   let strip_comment s =
     if String.contains s '#' then

--- a/settings.ml
+++ b/settings.ml
@@ -81,7 +81,7 @@ let parse_and_set' : [`Any | `OnlyUser] -> (string * string) -> unit = fun kind 
 		        output_string stderr ("Setting '" ^ name ^ "' expects a boolean\n"); flush stderr
 	            end
 	        | `String setting ->
-	            set_value setting value
+	            set_value setting (Utility.Sys.expand value)
             end
         | _ ->
 	    output_string stderr ("Cannot change system setting '" ^ name ^ "'\n"); flush stderr;
@@ -176,7 +176,7 @@ let from_argv : string array -> string list =
 
 
 let load_file filename =
-  let file = open_in filename in
+  let file = open_in (Utility.Sys.expand filename) in
 
   let strip_comment s =
     if String.contains s '#' then


### PR DESCRIPTION
This PR enables the use of environment variables in configuration files. E.g. one might have `mylinks.config` containing:
```
cache_directory=$HOME/links/cache
prelude=$HOME/links/prelude.links
```
when loaded using `--config=mylinks.config` switch the `Settings` module will automatically expand the variable `HOME` accordingly. The PR also include minimal error handling -- that is, it prints a helpful message such as
```
failed to expand environment variable 'MY_HOME' in value '$MY_HOME/links/cache' while setting 'cache_directory'.
```
whenever one attempts to expand an undefined environment variable.