### PR TITLE
Remove stray debug statement

### DIFF
--- a/links.ml
+++ b/links.ml
@@ -56,7 +56,6 @@ let process_program ?(printer=print_value) (valenv, nenv, tyenv) (program, t) =
   in
 
   let program = Closures.program tenv Lib.primitive_vars program in
-  Debug.print ("Closure converted program: " ^ Ir.Show_program.show program);
   BuildTables.program tenv Lib.primitive_vars program;
   let (globals, _) = program in
   Webserver.init (valenv, nenv, tyenv) globals;


### PR DESCRIPTION
This was causing the IR to be printed regardless of whether the
"show_compiled_ir" flag was set to true. I'm assuming this is a remnant
of closure conversion debugging, and the same effect can now be achieved
with show_compiled_ir?