### PR TITLE
Compatibility with 4.02.x compilers

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ before_install:
   - sudo apt-get -qq update
   - sudo apt-get install -y ocaml-nox ocaml-native-compilers camlp4-extra opam
   - opam init -a
-  - opam switch 4.02.2
+  - opam switch 4.04
   - eval `opam config env`
   - psql -c 'create database links;' -U postgres
 install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,8 @@ before_install:
   - eval `opam config env`
   - psql -c 'create database links;' -U postgres
 install:
-  - opam install -y deriving lwt.2.4.5 postgresql sqlite3 mysql cgi base64 cohttp
+  - opam install -y deriving lwt postgresql sqlite3 mysql cgi base64
+  - opam install -y cohttp
 script:
   - make -j2 nc
   - make tests

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ before_install:
   - sudo apt-get -qq update
   - sudo apt-get install -y ocaml-nox ocaml-native-compilers camlp4-extra opam
   - opam init -a
-  - opam switch 4.04.0
+  - opam switch 4.02.2
   - eval `opam config env`
   - psql -c 'create database links;' -U postgres
 install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,8 @@ before_install:
   - eval `opam config env`
   - psql -c 'create database links;' -U postgres
 install:
-  - opam install -y deriving lwt postgresql sqlite3 mysql cgi base64 cohttp
+  - opam install -y deriving lwt postgresql sqlite3 mysql cgi base64
+  - opam install -y cohttp
 script:
   - make -j2 nc
   - make tests

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,8 +12,7 @@ before_install:
   - eval `opam config env`
   - psql -c 'create database links;' -U postgres
 install:
-  - opam install -y deriving lwt postgresql sqlite3 mysql cgi base64
-  - opam install -y cohttp
+  - opam install -y deriving lwt.2.4.5 postgresql sqlite3 mysql cgi base64 cohttp
 script:
   - make -j2 nc
   - make tests

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,8 +12,7 @@ before_install:
   - eval `opam config env`
   - psql -c 'create database links;' -U postgres
 install:
-  - opam install -y deriving lwt postgresql sqlite3 mysql cgi base64
-  - opam install -y cohttp
+  - opam install -y deriving lwt postgresql sqlite3 mysql cgi base64 cohttp
 script:
   - make -j2 nc
   - make tests

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 Links: Linking Theory to Practice for the Web
 ---------------------------------------------
 
-[![Build Status](https://travis-ci.org/links-lang/links.svg?branch=sessions)](https://travis-ci.org/links-lang/links)
+[![Build Status](https://travis-ci.org/links-lang/links.svg?branch=master)](https://travis-ci.org/links-lang/links)
 
 Links helps to build modern Ajax-style applications: those with
 significant client- and server-side components.

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 Links: Linking Theory to Practice for the Web
 ---------------------------------------------
 
-[![Build Status](https://travis-ci.org/links-lang/links.svg?branch=master)](https://travis-ci.org/links-lang/links)
+[![Build Status](https://travis-ci.org/links-lang/links.svg?branch=sessions)](https://travis-ci.org/links-lang/links)
 
 Links helps to build modern Ajax-style applications: those with
 significant client- and server-side components.

--- a/opam
+++ b/opam
@@ -9,7 +9,7 @@ bug-reports: "https://github.com/links-lang/links/issues"
 license: "GPL-2"
 
 available: [
-  ocaml-version >= "4.04.0"
+  ocaml-version >= "4.02"
 ]
 
 build: [

--- a/opam
+++ b/opam
@@ -9,7 +9,7 @@ bug-reports: "https://github.com/links-lang/links/issues"
 license: "GPL-2"
 
 available: [
-  ocaml-version >= "4.02"
+  ocaml-version >= "4.02.2"
 ]
 
 build: [

--- a/utility.ml
+++ b/utility.ml
@@ -84,11 +84,6 @@ sig
     with type a = A.a t
 end
 
-module String = struct
-  include String
-  module Show_t = Deriving_Show.Show_string
-end
-
 module Int = struct
   type t = int
   (*let compare = Pervasives.compare*)
@@ -117,7 +112,42 @@ struct
   let isDigit = function '0'..'9' -> true | _ -> false
   let isXDigit = function '0'..'9'|'a'..'f'|'A'..'F' -> true | _ -> false
   let isBlank = function ' '|'\t' -> true | _ -> false
+  let lowercase_ascii c =
+    let _A = Char.code 'A' in
+    let _a = Char.code 'a' in
+    let c' = Char.code c in    
+      if c' < _a && c' >= _A then
+        Char.chr @@ c' + (_a - _A)
+       else
+        c
+  let uppercase_ascii c =
+    let _A = Char.code 'A' in
+    let _a = Char.code 'a' in
+    let c' = Char.code c in    
+      if c' >= _a && c' <= Char.code 'z' then
+        Char.chr @@ c' - (_a - _A)
+       else
+        c
 end
+
+module String = struct
+  include String
+  module Show_t = Deriving_Show.Show_string
+
+  let uncapitalize_ascii s =    
+    let bs = Bytes.of_string s in
+    ignore (
+      if bs <> Bytes.empty
+      then Bytes.set bs 0 (Char.lowercase_ascii @@ Bytes.get bs 0));
+    Bytes.to_string bs
+
+  let capitalize_ascii s =
+    let bs = Bytes.of_string s in
+    ignore (
+      if bs <> Bytes.empty
+      then Bytes.set bs 0 (Char.uppercase_ascii @@ Bytes.get bs 0));
+    Bytes.to_string bs
+end  
 
 module Map :
 sig

--- a/utility.ml
+++ b/utility.ml
@@ -112,6 +112,7 @@ struct
   let isDigit = function '0'..'9' -> true | _ -> false
   let isXDigit = function '0'..'9'|'a'..'f'|'A'..'F' -> true | _ -> false
   let isBlank = function ' '|'\t' -> true | _ -> false
+  (* Defined in OCaml 4.03 *)
   let lowercase_ascii c =
     let _A = Char.code 'A' in
     let _a = Char.code 'a' in
@@ -120,6 +121,8 @@ struct
         Char.chr @@ c' + (_a - _A)
        else
         c
+
+  (* Defined in OCaml 4.03 *)
   let uppercase_ascii c =
     let _A = Char.code 'A' in
     let _a = Char.code 'a' in
@@ -134,6 +137,7 @@ module String = struct
   include String
   module Show_t = Deriving_Show.Show_string
 
+  (* Defined in OCaml 4.03 *)
   let uncapitalize_ascii s =    
     let bs = Bytes.of_string s in
     ignore (
@@ -141,6 +145,7 @@ module String = struct
       then Bytes.set bs 0 (Char.lowercase_ascii @@ Bytes.get bs 0));
     Bytes.to_string bs
 
+  (* Defined in OCaml 4.03 *)
   let capitalize_ascii s =
     let bs = Bytes.of_string s in
     ignore (


### PR DESCRIPTION
This patch lowers the dependency from OCaml 4.04 to OCaml 4.02.x (at least, I haven't tested with earlier compilers). The motivation for this patch is that the `multicore-compiler` branch depends on the Multicore OCaml compiler which is based upon the stock OCaml 4.02.2 compiler.

In this patch I simply define some utility functions which are otherwise available in OCaml 4.03+.

I have updated the `opam` file accordingly.