### PR TITLE
Phase 1: Abstract names

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -54,6 +54,7 @@ SOURCES = $(OPC)                                \
           multipart.ml                          \
           notfound.ml                           \
           utility.ml                            \
+					processTypes.mli processTypes.ml      \
           env.mli env.ml                        \
           settings.mli settings.ml              \
           basicsettings.ml                      \

--- a/jsonparse.mly
+++ b/jsonparse.mly
@@ -1,6 +1,6 @@
 %{
+open ProcessTypes
 open Utility
-
 (* let unparse_label = function *)
 (*   | `Char c -> String.make 1 c *)
 (*   | `List (`Char _::_) as s -> Value.unbox_string s *)
@@ -32,6 +32,15 @@ object_:
                             | ["_c", c] -> Value.box_char ((Value.unbox_string c).[0])
                             | ["_label", l; "_value", v]
                             | ["_value", v; "_label", l] -> `Variant (Value.unbox_string l, v)
+                            | ["_sessEP1", ep1_str; "_sessEP2", ep2_str]
+                            | ["_sessEP2", ep2_str; "_sessEP1", ep1_str] ->
+                                let ep1 = ChannelID.of_string @@ Value.unbox_string ep1_str in
+                                let ep2 = ChannelID.of_string @@ Value.unbox_string ep2_str in
+                                `SessionChannel (ep1, ep2)
+                            | ["apid", apid] ->
+                                `AccessPointID (AccessPointID.of_string @@ Value.unbox_string apid)
+                            | ["pid", pid] ->
+                                `Pid (ProcessID.of_string @@ Value.unbox_string pid, `Client)
                             | ["_db", db] ->
                                 begin
                                   match db with

--- a/proc.mli
+++ b/proc.mli
@@ -1,24 +1,23 @@
 (** Process management *)
+open ProcessTypes
 
 type abort_type = string * string
 exception Aborted of abort_type  (* This sucks *)
 
 module Proc :
 sig
-  type pid = int (* leaky abstraction what *)
   type thread_result = (Value.env * Value.t)
   type thread = unit -> thread_result Lwt.t
 
   val debug_process_status : unit -> unit
 
-  val string_of_pid : pid -> string
-  val get_current_pid : unit -> pid
+  val get_current_pid : unit -> process_id
 
-  val lookup_client_process : pid -> Value.t option
+  val lookup_client_process : process_id -> Value.t option
 
-  val create_process : bool -> thread -> pid
-  val create_client_process : Value.t -> pid
-  val awaken : pid -> unit
+  val create_process : bool -> thread -> process_id
+  val create_client_process : Value.t -> process_id
+  val awaken : process_id -> unit
 
   val finish : Value.env * Value.t -> thread_result Lwt.t
   val yield : thread -> thread_result Lwt.t
@@ -34,33 +33,27 @@ end
 
 module Mailbox :
 sig
-  val pop_message_for : Proc.pid -> Value.t option
-  val pop_all_messages_for : Proc.pid -> Value.t list
+  val pop_message_for : process_id -> Value.t option
+  val pop_all_messages_for : process_id -> Value.t list
   val pop_message : unit -> Value.t option
-  val send_message : Value.t -> Proc.pid -> unit
+  val send_message : Value.t -> process_id -> unit
 end
 
-exception UnknownProcessID of Proc.pid
+exception UnknownProcessID of process_id
 
 module Session :
 sig
-  type apid = int
-  type portid = int
-  type chan = portid * portid
+  type chan = Value.chan
 
   val new_access_point : unit -> apid
   val accept : apid -> chan * bool
   val request : apid -> chan * bool
 
-  val block : portid -> Proc.pid -> unit
-  val unblock : portid -> Proc.pid option
+  val block : channel_id -> process_id -> unit
+  val unblock : channel_id -> process_id option
 
-  val send : Value.t -> portid -> unit
-  val receive : portid -> Value.t option
+  val send : Value.t -> channel_id -> unit
+  val receive : channel_id -> Value.t option
 
   val link : chan -> chan -> unit
-
-  val unbox_port : Value.t -> portid
-  val unbox_chan' : Value.t -> int * int
-  val unbox_chan : Value.t -> chan
 end

--- a/processTypes.ml
+++ b/processTypes.ml
@@ -1,0 +1,148 @@
+(*pp deriving *)
+open Lwt
+open Utility
+
+module type NAME = sig
+  type t
+  val create : unit -> t Lwt.t
+  val create_unsafe : unit -> t
+  val compare : t -> t -> int
+  val equal : t -> t -> bool
+  val to_string : t -> string
+  val of_string : string -> t
+  val to_json : t -> string
+  module Show_t : Deriving_Show.Show with type a = t
+end
+
+let name_source : int ref = ref 0
+let name_mutex = Lwt_mutex.create ()
+
+let get_and_increment_id_unsafe = fun () ->
+    let ret = !name_source in
+    incr name_source;
+    ret
+
+let get_and_increment_id : unit -> int Lwt.t = fun () ->
+  Lwt_mutex.with_lock name_mutex (fun () ->
+    Lwt.return (get_and_increment_id_unsafe ()))
+
+  (*
+let _ = ignore @@ Nocrypto_entropy_lwt.initialize (
+module Random_string_name = struct
+  type t = string
+  let gen_random_int = fun () -> Nocrypto.Rng.Int.gen max_int
+
+  let create_name () =
+    (get_and_increment_id ()) >>= fun id ->
+    Lwt.return (make_name_with_id id)
+
+  let make_name_with_id id =
+    Cstruct.to_string @@
+      Nocrypto.Base64.encode @@
+      Nocrypto.Hash.digest `SHA256 @@
+      Cstruct.of_string @@
+      "srv_" ^ (string_of_int id) ^ "_" ^ (string_of_int @@ gen_random_int ())
+
+  let create_name_unsafe () =
+    make_name_with_id (get_and_increment_id_unsafe ())
+
+  let create = create_name
+  let create_unsafe = create_name_unsafe
+  let compare n1 n2 = Pervasives.compare n1 n2
+  let equal n1 n2 = (compare n1 n2) = 0
+  let to_string n = n
+  let of_string n = n
+  let to_json n = "\"" ^ n ^ "\""
+  module Show_t = Deriving_Show.Show_string
+end
+
+module Int_name = struct
+  type t = int
+  let create = get_and_increment_id
+  let create_unsafe = get_and_increment_id_unsafe
+  let compare n1 n2 = Pervasives.compare n1 n2
+  let equal n1 n2 = (compare n1 n2) = 0
+  let to_string = string_of_int
+  let of_string = int_of_string
+  let to_json = to_string
+  module Show_t = Deriving_Show.Show_int
+end
+*)
+
+module type NAMEINFO = sig
+  val prefix : string
+end
+
+module Simple_string_name = functor ( NameInfo : NAMEINFO ) ->
+struct
+  type t = string
+
+  let make_name_with_id id = NameInfo.prefix ^ (string_of_int id)
+
+  let create_name () =
+    (get_and_increment_id ()) >>= fun id ->
+    Lwt.return (make_name_with_id id)
+
+  let create_name_unsafe () =
+    make_name_with_id (get_and_increment_id_unsafe ())
+
+  let create = create_name
+  let create_unsafe = create_name_unsafe
+  let compare n1 n2 = Pervasives.compare n1 n2
+  let equal n1 n2 = (compare n1 n2) = 0
+  let to_string n = n
+  let of_string n = n
+  let to_json n = "\"" ^ n ^ "\""
+  module Show_t = Deriving_Show.Show_string
+end
+
+module ClientID  : NAME = Simple_string_name(struct let prefix = "cid_" end)
+module ProcessID : NAME = Simple_string_name(struct let prefix = "srvPid_" end)
+module AccessPointID : NAME = Simple_string_name(struct let prefix = "srvAp_" end)
+module ChannelID : NAME = Simple_string_name(struct let prefix = "chan_" end)
+
+let main_process_pid = ProcessID.of_string "MAIN"
+let dummy_client_id = ClientID.of_string "DUMMY_CLIENT"
+
+module type PIDMAP = Utility.Map with type key = ProcessID.t
+module type CLIENTIDMAP = Utility.Map with type key = ClientID.t
+module type ACCESSPOINTIDMAP = Utility.Map with type key = AccessPointID.t
+module type CHANNELIDMAP = Utility.Map with type key = ChannelID.t
+
+module PidMap : PIDMAP = Map.Make(ProcessID)
+module ClientIDMap : CLIENTIDMAP = Map.Make(ClientID)
+module AccessPointIDMap : ACCESSPOINTIDMAP = Map.Make(AccessPointID)
+module ChannelIDMap : CHANNELIDMAP = Map.Make(ChannelID)
+
+module type PIDSET = Utility.Set with type elt = ProcessID.t
+module type CLIENTIDSET = Utility.Set with type elt = ClientID.t
+module type ACCESSPOINTIDSET = Utility.Set with type elt = AccessPointID.t
+module type CHANNELIDSET = Utility.Set with type elt = ChannelID.t
+
+module PidSet : PIDSET = Set.Make(ProcessID)
+module ClientIDSet : CLIENTIDSET = Set.Make(ClientID)
+module AccessPointIDSet : ACCESSPOINTIDSET = Set.Make(AccessPointID)
+module ChannelIDSet: CHANNELIDSET = Set.Make(ChannelID)
+
+
+type client_id = ClientID.t
+  deriving (Show)
+
+type process_id = ProcessID.t
+  deriving (Show)
+
+type apid = AccessPointID.t
+  deriving (Show)
+
+type channel_id = ChannelID.t
+  deriving (Show)
+
+type 'a pid_map = 'a PidMap.t
+type 'a client_id_map = 'a ClientIDMap.t
+type 'a apid_map = 'a AccessPointIDMap.t
+type 'a channel_id_map = 'a ChannelIDMap.t
+
+type pid_set = PidSet.t
+type client_id_set = ClientIDSet.t
+type apid_set = AccessPointIDSet.t
+type channelid_set = ChannelIDSet.t

--- a/processTypes.mli
+++ b/processTypes.mli
@@ -1,0 +1,69 @@
+(*pp deriving *)
+
+module type NAME = sig
+  type t
+  val create : unit -> t Lwt.t
+  val create_unsafe : unit -> t
+  val compare : t -> t -> int
+  val equal : t -> t -> bool
+  val to_string : t -> string
+  val of_string : string -> t
+  val to_json : t -> string
+  module Show_t : Deriving_Show.Show with type a = t
+end
+
+
+module ClientID : NAME
+module ProcessID : NAME
+module AccessPointID : NAME
+module ChannelID : NAME
+
+type client_id = ClientID.t
+  deriving (Show)
+
+type process_id = ProcessID.t
+  deriving (Show)
+
+type apid = AccessPointID.t
+  deriving (Show)
+
+type channel_id = ChannelID.t
+  deriving (Show)
+
+(* Distinguished PID for main thread *)
+val main_process_pid : process_id
+
+(* Dummy client ID *)
+val dummy_client_id : client_id
+
+(* Maps *)
+module type PIDMAP = Utility.Map with type key = ProcessID.t
+module type CLIENTIDMAP = Utility.Map with type key = ClientID.t
+module type ACCESSPOINTIDMAP = Utility.Map with type key = AccessPointID.t
+module type CHANNELIDMAP = Utility.Map with type key = ChannelID.t
+
+module PidMap : PIDMAP
+module ClientIDMap : CLIENTIDMAP
+module AccessPointIDMap : ACCESSPOINTIDMAP
+module ChannelIDMap : CHANNELIDMAP
+
+type 'a pid_map = 'a PidMap.t
+type 'a client_id_map = 'a ClientIDMap.t
+type 'a apid_map = 'a AccessPointIDMap.t
+type 'a channel_id_map = 'a ChannelIDMap.t
+
+(* Sets *)
+module type PIDSET = Utility.Set with type elt = ProcessID.t
+module type CLIENTIDSET = Utility.Set with type elt = ClientID.t
+module type ACCESSPOINTIDSET = Utility.Set with type elt = AccessPointID.t
+module type CHANNELIDSET = Utility.Set with type elt = ChannelID.t
+
+module PidSet : PIDSET
+module ClientIDSet : CLIENTIDSET
+module AccessPointIDSet : ACCESSPOINTIDSET
+module ChannelIDSet: CHANNELIDSET
+
+type pid_set = PidSet.t
+type client_id_set = ClientIDSet.t
+type apid_set = AccessPointIDSet.t
+type channelid_set = ChannelIDSet.t

--- a/value.mli
+++ b/value.mli
@@ -1,5 +1,6 @@
 (*pp deriving *)
 (* Values and environments *)
+open ProcessTypes
 
 class type otherfield
  = object method show : string end
@@ -63,6 +64,9 @@ type primitive_value = [
 
 module Show_primitive_value : Deriving_Show.Show with type a = primitive_value
 
+type chan = channel_id * channel_id (* a channel is a pair of ports *)
+  deriving(Show)
+
 (* jcheney: Added value function component to PrimitiveFunction *)
 type t = [
 | primitive_value
@@ -73,7 +77,9 @@ type t = [
 | `PrimitiveFunction of string * Var.var option
 | `ClientFunction of string
 | `Continuation of continuation
-| `Pid of int * Sugartypes.location
+| `AccessPointID of apid
+| `Pid of process_id * Sugartypes.location
+| `SessionChannel of chan
 | `Socket of in_channel * out_channel
 ]
 and continuation = (Ir.scope * Ir.var * env * Ir.computation) list
@@ -124,10 +130,14 @@ val box_unit : unit -> t
 val unbox_unit : t -> unit
 val box_pair : t -> t -> t
 val unbox_pair : t -> (t * t)
-val box_pid : int * Sugartypes.location -> t
-val unbox_pid : t -> int * Sugartypes.location
+val box_pid : process_id * Sugartypes.location -> t
+val unbox_pid : t -> process_id * Sugartypes.location
 val box_socket : in_channel * out_channel -> t
 val unbox_socket : t -> in_channel * out_channel
+val box_channel : chan -> t
+val unbox_channel : t -> chan
+val box_apid : apid -> t
+val unbox_apid : t -> apid
 
 val intmap_of_record : t -> t Utility.intmap option
 


### PR DESCRIPTION
This commit abstracts away from the current representation of names.

Instead of treating everything as integers, we now have:

  * ProcessID
  * ChannelID
  * AccessPointID
  * (ClientID -- unused in this commit)

This helps with distribution, and is the first phase of merging
everything in.