### PR TITLE
Pretty print values -- updated -- 4th try

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,7 @@ before_install:
   - eval `opam config env`
   - psql -c 'create database links;' -U postgres
 install:
-  - opam install -y deriving lwt postgresql sqlite3 mysql cgi base64 cohttp
+  - opam install -y deriving lwt postgresql sqlite3 mysql cgi base64 cohttp ANSITerminal
 script:
   - make -j2 nc
   - make tests

--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@
 
 OCAMLMAKEFILE = ./OCamlMakefile
 
-PACKS=str deriving.syntax deriving.syntax.classes deriving.runtime lwt lwt.syntax lwt.unix cgi base64 cohttp cohttp.lwt unix
+PACKS=str deriving.syntax deriving.syntax.classes deriving.runtime lwt lwt.syntax lwt.unix cgi base64 cohttp cohttp.lwt unix ANSITerminal
 export OCAMLFLAGS=-syntax camlp4o
 
 PATH := $(PATH):deriving

--- a/basicsettings.ml
+++ b/basicsettings.ml
@@ -142,3 +142,7 @@ let use_keys_in_shredding = Settings.add_bool("use_keys_in_shredding", true, `Us
 
 (* Paths to look for .links files in chasing pass *)
 let links_file_paths = Settings.add_string("links_file_paths", "", `User)
+
+(* Pretty print values (outside web mode) *)
+let print_pretty = Settings.add_bool ("print_pretty", false, `User)
+let print_colors = Settings.add_bool ("print_colors", false, `User)

--- a/links.ml
+++ b/links.ml
@@ -16,10 +16,38 @@ type envs = Value.env * Ir.var Env.String.t * Types.typing_environment
 
 (** Print a value (including its type if `printing_types' is [true]). *)
 let print_value rtype value =
-  print_string (Value.string_of_value value);
-  print_endline (if Settings.get_value(BS.printing_types) then
-		   " : "^ Types.string_of_datatype rtype
-                 else "")
+  if Settings.get_value Basicsettings.web_mode || not (Settings.get_value Basicsettings.print_pretty || Settings.get_value Basicsettings.interacting)
+  then begin
+      print_string (Value.string_of_value value);
+      print_endline (if Settings.get_value(BS.printing_types) then
+		       " : "^ Types.string_of_datatype rtype
+                     else "")
+    end
+  else
+    let (width, _height) = try ANSITerminal.size () with _ -> (80, 24) in
+    let open Format in
+    pp_set_margin std_formatter width;
+    pp_set_tags std_formatter (Settings.get_value Basicsettings.print_colors);
+    pp_set_mark_tags std_formatter (Settings.get_value Basicsettings.print_colors);
+    pp_set_formatter_tag_functions
+      std_formatter
+      {mark_open_tag = (function
+                        | "xmltag" -> "\x1b[32m"
+                        | "constructor" -> "\x1b[32m"
+                        | "xmlattr" -> "\x1b[35m"
+                        | "recordlabel" -> "\x1b[35m"
+                        (* | "string" -> "\x1b[36m" *)
+                        | _ -> "");
+       mark_close_tag  = (fun _ -> "\x1b[39m");
+       print_open_tag  = ignore;
+       print_close_tag = ignore;
+      };
+    fprintf std_formatter "@[%a@;<1 4>: %s@]"
+            Value.p_value value
+            (if Settings.get_value(BS.printing_types) then
+	       Types.string_of_datatype rtype
+             else "");
+    pp_print_newline std_formatter ()
 
 (** optimise and evaluate a program *)
 let process_program ?(printer=print_value) (valenv, nenv, tyenv) (program, t) =

--- a/tests/records.tests
+++ b/tests/records.tests
@@ -1,6 +1,10 @@
 Record printing
 (x=1, y="two")
-stdout : (x=1,y="two") : (x:Int,y:String)
+stdout : (x = 1, y = "two") : (x:Int,y:String)
+
+Quote record labels that are also keywords
+("client"=5, "fun"=7)
+stdout : ("client" = 5, "fun" = 7) : (client:Int,fun:Int)
 
 Record comparisons
 (x=1, y="two") == (y="two", x=1)
@@ -8,7 +12,7 @@ stdout : true : Bool
 
 Record extension
 {var z = (y="three"); (x=4|z) }
-stdout : (x=4,y="three") : (x:Int,y:String)
+stdout : (x = 4, y = "three") : (x:Int,y:String)
 
 Let pattern matching
 {var (x=a,y=(z=b)) = (y=(z=3),x="four"); a}
@@ -45,19 +49,19 @@ stdout : 4 : Int
 
 With syntax (same type)
 ((x = 3) with x = 4)
-stdout : (x=4) : (x:Int)
+stdout : (x = 4) : (x:Int)
 
 With syntax (different type)
 ((x = 3) with x = "four")
-stdout : (x="four") : (x:String)
+stdout : (x = "four") : (x:String)
 
 With syntax: multiple labels (a)
 ((x=3,y=4) with y="four")
-stdout : (x=3,y="four") : (x:Int,y:String)
+stdout : (x = 3, y = "four") : (x:Int,y:String)
 
 With syntax: multiple labels (b)
 ((z='a',x=3,y=4) with x="four",y=3)
-stdout : (x="four",y=3,z='a') : (x:String,y:Int,z:Char)
+stdout : (x = "four", y = 3, z = 'a') : (x:String,y:Int,z:Char)
 
 With syntax (missing label)
 ((x = 3) with y=4)

--- a/tests/tuples.tests
+++ b/tests/tuples.tests
@@ -41,8 +41,9 @@ stdout : true : Bool
 
 1-tuples
 (1="one")
-stdout : (1="one") : (1:String)
+stdout : (1 = "one") : (1:String)
 
 Quasituples
 (1="foo", 3="bar")
-stdout : @.*3=
+stdout : (1 = "foo", 3 = "bar") : (1:String, 3:String)
+ignore : The type is currently printed as (String, String). Is this really what we want?

--- a/value.mli
+++ b/value.mli
@@ -162,13 +162,9 @@ val unbox_access_point : t -> access_point
 
 val intmap_of_record : t -> t Utility.intmap option
 
-val string_as_charlist : string -> t
-val charlist_as_string : t -> string
 val string_of_value : t -> string
 val string_of_xml : ?close_tags:bool -> xml -> string
-val string_of_primitive : primitive_value -> string
-val string_of_tuple : (string * t) list -> string
-val string_of_cont : continuation -> string
+val p_value: Format.formatter -> t -> unit
 
 val marshal_value : t -> string
 val marshal_continuation : continuation -> string


### PR DESCRIPTION
This replaces string_of_value by a custom formatter which ignores
newlines and indentation.

Pretty printing is always disabled in web_mode.
Pretty printing is always enabled in the REPL.
Pretty printing is disabled by default for file/expression input but
can be enabled by setting print_pretty.
Colors are disabled by default, but can be enabled by setting
print_colors. We only print colors when pretty printing.