### PR TITLE
Use deps from opam file for CI build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,7 +17,8 @@ before_install:
   - opam upgrade -y
   - psql -c 'create database links;' -U postgres
 install:
-  - opam install -y --deps-only
+  - opam pin add links-dev . -n
+  - opam install -y --deps-only links-dev
 script:
   - make -j2 nc
   - make tests

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,6 +19,7 @@ before_install:
 install:
   - opam pin add links-dev . -n -y
   - opam install -y --deps-only links-dev
+  - opam pin remove links-dev -y
 script:
   - make -j2 nc
   - make tests

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,7 +17,7 @@ before_install:
   - opam upgrade -y
   - psql -c 'create database links;' -U postgres
 install:
-  - opam pin add links-dev . -n
+  - opam pin add links-dev . -n -y
   - opam install -y --deps-only links-dev
 script:
   - make -j2 nc

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,8 +17,7 @@ before_install:
   - opam upgrade -y
   - psql -c 'create database links;' -U postgres
 install:
-  - opam install -y deriving lwt postgresql sqlite3 mysql cgi base64 cohttp ANSITerminal
-  - opam install -y deriving lwt postgresql sqlite3 mysql cgi base64 cohttp websocket ANSITerminal
+  - opam install -y --deps-only
 script:
   - make -j2 nc
   - make tests


### PR DESCRIPTION
I forgot to update the opam file with dependencies. That should not happen. This would avoid the issue entirely and we only need to maintain one list of dependencies. Let's see whether that works...