### PR TITLE
Improve JavaScript printing

### DIFF
--- a/lib/js/jslib.js
+++ b/lib/js/jslib.js
@@ -52,8 +52,6 @@ var jslib = function () {
   };
 }();
 
-var _dwindow = DEBUGGING ? open('', 'debugwindow','width=550,height=800,toolbar=0,scrollbars=yes') : null;
-
 // (IE) these aren't defined in IE
 document.ELEMENT_NODE = 1;
 document.ATTRIBUTE_NODE = 2;
@@ -1292,14 +1290,10 @@ var LINKS = function() {
   return LINKS;
 } ();
 
-function _debug(msg) {
-   if (DEBUGGING) {
-     if(DEBUG.is_charlist(msg))
-       _dwindow.document.write('<b>' + _current_pid + '</b> : ' + msg + '<br/>');
-     else
-       _dwindow.document.write('<b>' + _current_pid + '</b> : ' + msg + '<br/>');
-   _dwindow.scroll(0, _dwindow.scrollMaxY);
-   }
+function _debug(...msg) {
+  if (DEBUGGING) {
+    console.debug(...msg);
+  }
 }
 
 var debug = LINKS.kify(_debug);
@@ -1486,6 +1480,12 @@ function _dump(obj) {
 }
 var dump = LINKS.kify(_dump);
 
+function _show(obj) {
+  return JSON.stringify(obj, null, 2);
+}
+
+var show = LINKS.kify(_show);
+
 function _negate(x) { return -x }
 var negate = LINKS.kify(_negate);
 
@@ -1493,7 +1493,7 @@ var _negatef = _negate;
 var negatef = negate;
 
 function _error(msg) {
-  alert(msg);
+  console.error(msg);
   throw ("Error: " + msg);
 }
 
@@ -3069,8 +3069,8 @@ function _yieldCont(k, arg) {
 //  };
 //}
 
-function _print(str) {
-  alert(str);
+function _print(...str) {
+  console.info(...str);
   return 0;
 }
 


### PR DESCRIPTION
- Remove the debug popup
- Replace debug, print, and dump implementations to use `console`
- Add `show` implementation