### PR TITLE
Explicit "event" variable in jslib

### DIFF
--- a/lib/js/jslib.js
+++ b/lib/js/jslib.js
@@ -1,3 +1,6 @@
+// Support events in firefox, which doesn't support window.event.
+var event = undefined;
+
 // set up optimised setZeroTimeout
 (function() {
 	var timeouts = [];
@@ -10,9 +13,10 @@
 		window.postMessage(messageName, "*");
 	}
 
-	function handleMessage(event) {
-		if (event.source == window && event.data == messageName) {
-			event.stopPropagation();
+	function handleMessage(_event) {
+		if (_event.source == window && _event.data == messageName) {
+      event = _event;
+			_event.stopPropagation();
 			//~ if (timeouts.length > offset) { //length > 0) {
 			if (timeouts.length > 0) {
 

--- a/lib/js/jslib.js
+++ b/lib/js/jslib.js
@@ -15,7 +15,7 @@ var event = undefined;
 
 	function handleMessage(_event) {
 		if (_event.source == window && _event.data == messageName) {
-      event = _event;
+			event = _event;
 			_event.stopPropagation();
 			//~ if (timeouts.length > offset) { //length > 0) {
 			if (timeouts.length > 0) {


### PR DESCRIPTION
This is useful for two reasons. Firstly, window.event isn't supported in
Firefox, so this should add support back for some applications.
Secondly, this should fix errors with "getTime" trying to access an
undefined event, for some reason.