### PR TITLE
Add int case for float unboxing (Fix #206)

### DIFF
--- a/json.ml
+++ b/json.ml
@@ -62,7 +62,7 @@ let jsonize_location : Ir.location -> string = function
   | `Native  -> "native"
   | `Unknown -> "unknown"
 
-let rec jsonize_value : Value.t -> json_string =
+let rec jsonize_value' : Value.t -> json_string =
   function
   | `PrimitiveFunction _
   | `Continuation _
@@ -76,14 +76,14 @@ let rec jsonize_value : Value.t -> json_string =
       match fvs with
       | None     -> ""
       | Some fvs ->
-        let s = jsonize_value fvs in
+        let s = jsonize_value' fvs in
         ", \"environment\":" ^ s in
     "{\"func\":\"" ^ Js.var_name_var f ^ "\"," ^
     " \"location\":\"" ^ location ^ "\"" ^ env_string ^ "}"
   | `ClientFunction name -> "{\"func\":\"" ^ name ^ "\"}"
   | #Value.primitive_value as p -> jsonize_primitive p
   | `Variant (label, value) ->
-    let s = jsonize_value value in
+    let s = jsonize_value' value in
     "{\"_label\":\"" ^ label ^ "\",\"_value\":" ^ s ^ "}"
   | `Record fields ->
     let ls, vs = List.split fields in
@@ -144,7 +144,7 @@ and jsonize_values : Value.t list -> string list  =
     let ss =
       List.fold_left
         (fun ss v ->
-           let s = jsonize_value v in
+           let s = jsonize_value' v in
            s::ss) [] vs in
     List.rev ss
 
@@ -156,8 +156,8 @@ let value_with_state v s =
 let show_processes procs =
   (* Show the JSON for a prcess, including the PID, process to be run, and mailbox *)
   let show_process (pid, (proc, msgs)) =
-    let ps = jsonize_value proc in
-    let ms = jsonize_value (`List msgs) in
+    let ps = jsonize_value' proc in
+    let ms = jsonize_value' (`List msgs) in
     "{\"pid\":" ^ (ProcessID.to_json pid) ^ "," ^
     " \"process\":" ^ ps ^ "," ^
     " \"messages\":" ^ ms ^ "}" in
@@ -167,7 +167,7 @@ let show_processes procs =
 let show_handlers evt_handlers =
   (* Show the JSON for an event handler: the evt handler key, and the associated process *)
   let show_evt_handler (key, proc) =
-    let h_proc_json = jsonize_value proc in
+    let h_proc_json = jsonize_value' proc in
     "{\"key\": " ^ string_of_int key ^ "," ^
     " \"eventHandlers\":" ^ h_proc_json ^ "}" in
   let bnds = IntMap.bindings evt_handlers in
@@ -230,10 +230,18 @@ type json_state = JsonState.t
 let jsonize_value_with_state value state =
   Debug.if_set show_json
       (fun () -> "jsonize_value_with_state => " ^ Value.string_of_value value);
-  let jv = jsonize_value value in
+  let jv = jsonize_value' value in
   let jv_s = value_with_state jv (JsonState.to_string state) in
   Debug.if_set show_json (fun () -> "jsonize_value_with_state <= " ^ jv_s);
   jv_s
+
+let jsonize_value v =
+  Debug.if_set show_json
+      (fun () -> "jsonize_value => " ^ Value.string_of_value v);
+  let jv = jsonize_value' v in
+  Debug.if_set show_json (fun () -> "jsonize_value <= " ^ jv);
+  jv
+
 
 let encode_continuation (cont : Value.continuation) : string =
   Value.marshal_continuation cont

--- a/value.ml
+++ b/value.ml
@@ -608,7 +608,14 @@ and unbox_int  : t -> int    = function
   | _other -> failwith("Type error unboxing int")
 and box_float f = `Float f
 and unbox_float : t -> float = function
-  | `Float f -> f | _ -> failwith "Type error unboxing float"
+  | `Float f -> f
+  (* This case happens due to the fact that JS serialises "1.0" as "1".
+   * Therefore, JSONParse will deserialise something that has Float type
+   * and box it as an integer. The alternative would be to box all floats
+   * on the client, but this is easier and more performant (if a little hacky)
+   *)
+  | `Int i -> float_of_int i
+  | _ -> failwith "Type error unboxing float"
 and box_char c = `Char c
 and unbox_char :  t -> char = function
   | `Char f -> f | _ -> failwith "Type error unboxing char"


### PR DESCRIPTION
As per #206, floats can be incorrectly boxed as integers upon deserialisation from JSON. 

This patch adds an ``` `Int ``` case in `value.ml`'s `unbox_float` which rectifies this, and should be a cheap way to fix the issue.