### PR TITLE
Add ability to have a "standard library"

### DIFF
--- a/basicsettings.ml
+++ b/basicsettings.ml
@@ -24,32 +24,36 @@ let concurrent_server = Settings.add_bool ("concurrent_server", true, `System)
 (** Set this to [true] to print types when printing results. *)
 let printing_types = Settings.add_bool ("printing_types", true, `User)
 
+(* Looks for a given file, either in the current directory or in the Links opam path *)
+let locate_file filename =
+  (* If LINKS_LIB is not defined then we search in current directory *)
+  let executable_dir = Filename.dirname Sys.executable_name in
+  if Sys.file_exists (Filename.concat executable_dir filename) then
+    executable_dir
+  else
+    try
+      (* If all else failed we search for OPAM installation of Links and
+         use a prelude that it provides *)
+      let opam_links_lib =
+        input_line (Unix.open_process_in "opam config var links:lib 2>/dev/null") in
+      if Sys.file_exists (Filename.concat opam_links_lib filename) then
+        opam_links_lib
+      else
+        (* But if no OPAM installation exists we fall back to current
+           directory so that user gets a reasonable error message *)
+        executable_dir
+    with End_of_file ->
+      (* User probably does not have OPAM, so fall back to current directory *)
+      executable_dir
+
 (** Name of the file containing the prelude code. *)
 let prelude_file =
-  let prelude_dir = match Utility.getenv "LINKS_LIB" with
+  let prelude_dir =
+    match Utility.getenv "LINKS_LIB" with
     (* If user defined LINKS_LIB then it takes the highest priority *)
     | Some path -> path
-    | None ->
-        (* If LINKS_LIB is not defined then we search in current directory *)
-        let executable_dir = Filename.dirname Sys.executable_name in
-        if Sys.file_exists (Filename.concat executable_dir "prelude.links") then
-          executable_dir
-        else
-          try
-            (* If all else failed we search for OPAM installation of Links and
-               use a prelude that it provides *)
-            let opam_links_lib =
-              input_line (Unix.open_process_in "opam config var links:lib 2>/dev/null") in
-            if Sys.file_exists (Filename.concat opam_links_lib "prelude.links") then
-              opam_links_lib
-            else
-              (* But if no OPAM installation exists we fall back to current
-                 directory so that user gets a reasonable error message *)
-              executable_dir
-          with End_of_file ->
-            (* User probably does not have OPAM, so fall back to current directory *)
-            executable_dir
-  in Settings.add_string ("prelude", Filename.concat prelude_dir "prelude.links", `System)
+    | None -> locate_file "prelude.links" in
+  Settings.add_string ("prelude", Filename.concat prelude_dir "prelude.links", `System)
 
 (** Path to config file *)
 let config_file_path = match Utility.getenv "LINKS_CONFIG" with
@@ -149,3 +153,10 @@ let print_colors = Settings.add_bool ("print_colors", false, `User)
 
 (* Base URL for websocket connections *)
 let websocket_url = Settings.add_string("websocket_url", "/ws/", `User)
+
+(* Should we use the extra standard library definitions? *)
+let use_stdlib = Settings.add_bool ("use_stdlib", true, `User)
+
+(* Standard library path *)
+let stdlib_path = Settings.add_string ("stdlib_path", "", `User)
+

--- a/moduleUtils.ml
+++ b/moduleUtils.ml
@@ -11,15 +11,28 @@ type shadow_table = string list stringmap
 
 let try_parse_file filename =
   (* First, get the list of directories, with trailing slashes stripped *)
+  let check_n_chop path =
+    let dir_sep = Filename.dir_sep in
+    if Filename.check_suffix path dir_sep then
+      Filename.chop_suffix path dir_sep else path in
+
+  let poss_stdlib_dir =
+    let stdlib_path = Settings.get_value Basicsettings.stdlib_path in
+    if Settings.get_value Basicsettings.use_stdlib then
+      if stdlib_path <> "" then
+        [check_n_chop stdlib_path]
+      else
+        (* Otherwise, follow the same logic as for the prelude.
+         * Firstly, check the current directory.
+         * Secondly, check OPAM *)
+        let chopped_path = check_n_chop @@ Basicsettings.locate_file "stdlib" in
+        [Filename.concat chopped_path "stdlib"]
+    else [] in
+
   let poss_dirs =
     let path_setting = Settings.get_value Basicsettings.links_file_paths in
     let split_dirs = Str.split (Str.regexp path_sep) path_setting in
-    "" :: "." :: (List.map (fun path ->
-      let dir_sep = Filename.dir_sep in
-      if Filename.check_suffix path dir_sep then
-        Filename.chop_suffix path dir_sep
-      else
-        path) split_dirs) in
+    "" :: "." :: poss_stdlib_dir @ (List.map (check_n_chop) split_dirs) in
 
   (* Loop through, trying to open the module with each path *)
   let rec loop = (function
@@ -32,7 +45,6 @@ let try_parse_file filename =
         else
           loop xs) in
   loop poss_dirs
-
 
 let has_no_modules =
 object

--- a/opam
+++ b/opam
@@ -24,6 +24,7 @@ install: [
   [ "./links" "%{links:lib}%/prelude.links"                           ]
 # Install JS libraries
   [ "cp" "-r" "lib/js" "%{links:lib}%"                                ]
+  [ "cp" "-r" "stdlib" "%{links:lib}%"                                ]
 # Install documentation
   [ "mkdir" "-p" "%{links:doc}%"                                      ]
   [ "cp" "INSTALL" "%{links:doc}%/README"                             ]

--- a/stdlib/binaryTree.links
+++ b/stdlib/binaryTree.links
@@ -1,0 +1,116 @@
+# Node-indexed binary trees. Very incomplete; just a demonstration we can now
+# have a standard library.
+
+typename BinaryTree(a) = [| Leaf | Node: (BinaryTree(a), a, BinaryTree(a)) |];
+
+sig empty : () -> (BinaryTree(a))
+fun empty() {
+  Leaf
+}
+
+sig invert : (BinaryTree(a)) ~> BinaryTree(a)
+fun invert(t) {
+  switch(t) {
+    case Leaf -> Leaf
+    case Node(t1, x, t2) -> Node(invert(t2), x, invert(t1))
+  }
+}
+
+sig traverse_preorder : (BinaryTree(a)) ~> List(a)
+fun traverse_preorder(t) {
+  switch(t) {
+    case Leaf -> []
+    case Node(t1, x, t2) -> [x] ++ traverse_preorder(t1) ++ traverse_preorder(t2)
+  }
+}
+
+sig traverse_inorder : (BinaryTree(a)) ~> List(a)
+fun traverse_inorder(t) {
+  switch(t) {
+    case Leaf -> []
+    case Node(t1, x, t2) -> traverse_inorder(t1) ++ [x] ++ traverse_inorder(t2)
+  }
+}
+
+sig traverse_postorder : (BinaryTree(a)) ~> List(a)
+fun traverse_postorder(t) {
+  switch(t) {
+    case Leaf -> []
+    case Node(t1, x, t2) -> traverse_postorder(t1) ++ traverse_postorder(t2) ++ [x]
+  }
+}
+
+# Adds a value to a binary search tree. No rebalancing. O(log(n)).
+# Args:
+# comp: a function taking two values x1 and x2 of type a, returning:
+#  - A negative integer if x1 is less than x2
+#  - Zero if they are the same
+#  - A positive integer if x1 is greater than x2
+# to_add : term to add
+# t: a binary search tree
+sig add : (((a, a) ~%~> Int), a, BinaryTree(a)) ~%~> BinaryTree(a)
+fun add(comp, to_add, t) {
+  switch(t) {
+    case Leaf -> Node(Leaf, to_add, Leaf)
+    case Node(t1, x, t2) ->
+      var comp_result = comp(to_add, x);
+      if (comp_result < 0) {
+        Node(add(comp, to_add, t1), x, t2)
+      } else if (comp_result == 0) {
+        Node(t1, x, t2)
+      } else {
+        Node(t1, x, add(comp, to_add, t2))
+      }
+  }
+}
+
+
+sig leftmost_child : (((a, a) ~%~> Int), BinaryTree(a)) ~%~> BinaryTree(a)
+fun leftmost_child(comp, t) {
+  switch(t) {
+    case Leaf -> Leaf # Shouldn't occur unless we're passed a leaf
+    case Node(t1, x, t2) ->
+      switch (t1) {
+        case Leaf -> Node(t1, x, t2) # We're the leftmost child
+        case Node(t1_1, x_1, t1_2) ->
+          # We're not the leftmost child; recurse
+          leftmost_child(comp, Node(t1_1, x_1, t1_2))
+      }
+  }
+}
+
+# Removes a value from a binary searh tree. No rebalancing. Returns
+# tree unchanged if the value isn't found. O(log(n)).
+# Args:
+# comp: a function taking two values x1 and x2 of type a, returning:
+#  - A negative integer if x1 is less than x2
+#  - Zero if they are the same
+#  - A positive integer if x1 is greater than x2
+# to_remove : term to add
+# t: a binary search tree
+sig remove : (((a, a) ~%~> Int), a, BinaryTree(a)) ~%~> BinaryTree(a)
+fun remove(comp, to_remove, t) {
+  switch(t) {
+    case Leaf -> Leaf
+    case Node(t1, x, t2) ->
+      var comp_result = comp(to_remove, x);
+      if (comp_result < 0) {
+        Node(remove(comp, to_remove, t1), x, t2)
+      } else if (comp_result == 0) {
+        switch ((t1, t2)) {
+          case ((Leaf, Leaf)) -> Leaf
+          case ((Node(t1_1, x, t1_2), Leaf)) -> Node(t1_1, x, t1_2)
+          case ((Leaf, Node(t2_1, x, t2_2))) -> Node(t2_1, x, t2_2)
+          case ((Node(_, _, _), Node(_, _, _))) ->
+            var new_node = leftmost_child(comp, t2);
+            switch(new_node) {
+              case Leaf -> error("Impossible case in binary tree remove") # Bleh
+              case Node(_, lmc_key, _) ->
+                Node(t1, lmc_key, remove(comp, lmc_key, t1))
+            }
+        }
+      } else {
+        Node(t1, x, remove(comp, to_remove, t2))
+      }
+  }
+}

--- a/stdlib/comparators.links
+++ b/stdlib/comparators.links
@@ -1,0 +1,3 @@
+fun intComparator(i1, i2) {
+  i1 - i2
+}

--- a/tests/binaryTrees.tests
+++ b/tests/binaryTrees.tests
@@ -1,0 +1,29 @@
+Tree construction and postorder traversal
+./tests/stdlibtests/binaryTree/postorder.links
+filemode : args
+args : -m
+stdout : "[1,4,3,2]" : String
+
+Tree construction and inorder traversal
+./tests/stdlibtests/binaryTree/inorder.links
+filemode : args
+args : -m
+stdout : "[1,2,3,4]" : String
+
+Tree construction and preorder traversal
+./tests/stdlibtests/binaryTree/preorder.links
+filemode : args
+args : -m
+stdout : "[2,1,3,4]" : String
+
+Deletion (1 node)
+./tests/stdlibtests/binaryTree/remove1.links
+filemode : args
+args : -m
+stdout : BinaryTree.Node(BinaryTree.Node(BinaryTree.Leaf, 1, BinaryTree.Leaf), 3, BinaryTree.Node(BinaryTree.Leaf, 4, BinaryTree.Leaf)) : BinaryTree.BinaryTree (Int)
+
+Deletion (2 nodes)
+./tests/stdlibtests/binaryTree/remove2.links
+filemode : args
+args : -m
+stdout : BinaryTree.Node(BinaryTree.Node(BinaryTree.Node(BinaryTree.Leaf, 1, BinaryTree.Leaf), 2, BinaryTree.Leaf), 4, BinaryTree.Node(BinaryTree.Node(BinaryTree.Leaf, 1, BinaryTree.Leaf), 2, BinaryTree.Leaf)) : BinaryTree.BinaryTree (Int)

--- a/tests/stdlibtests/binaryTree/inorder.links
+++ b/tests/stdlibtests/binaryTree/inorder.links
@@ -1,0 +1,25 @@
+open Comparators
+open BinaryTree
+
+fun print_list(xs) {
+  fun print_list_inner(xs) {
+    switch(xs) {
+      case [] -> ""
+      case [x] -> intToString(x)
+      case x::xs -> intToString(x) ^^ "," ^^ print_list_inner(xs)
+    }
+  }
+  "[" ^^ print_list_inner(xs) ^^ "]"
+}
+
+fun test() {
+  var t = empty();
+  var t = add(intComparator, 2, t);
+  var t = add(intComparator, 3, t);
+  var t = add(intComparator, 1, t);
+  var t = add(intComparator, 4, t);
+  var xs_inorder = traverse_inorder(t);
+  print_list(xs_inorder)
+}
+
+test()

--- a/tests/stdlibtests/binaryTree/postorder.links
+++ b/tests/stdlibtests/binaryTree/postorder.links
@@ -1,0 +1,25 @@
+open Comparators
+open BinaryTree
+
+fun print_list(xs) {
+  fun print_list_inner(xs) {
+    switch(xs) {
+      case [] -> ""
+      case [x] -> intToString(x)
+      case x::xs -> intToString(x) ^^ "," ^^ print_list_inner(xs)
+    }
+  }
+  "[" ^^ print_list_inner(xs) ^^ "]"
+}
+
+fun test() {
+  var t = empty();
+  var t = add(intComparator, 2, t);
+  var t = add(intComparator, 3, t);
+  var t = add(intComparator, 1, t);
+  var t = add(intComparator, 4, t);
+  var xs_postorder = traverse_postorder(t);
+  print_list(xs_postorder)
+}
+
+test()

--- a/tests/stdlibtests/binaryTree/preorder.links
+++ b/tests/stdlibtests/binaryTree/preorder.links
@@ -1,0 +1,25 @@
+open Comparators
+open BinaryTree
+
+fun print_list(xs) {
+  fun print_list_inner(xs) {
+    switch(xs) {
+      case [] -> ""
+      case [x] -> intToString(x)
+      case x::xs -> intToString(x) ^^ "," ^^ print_list_inner(xs)
+    }
+  }
+  "[" ^^ print_list_inner(xs) ^^ "]"
+}
+
+fun test() {
+  var t = empty();
+  var t = add(intComparator, 2, t);
+  var t = add(intComparator, 3, t);
+  var t = add(intComparator, 1, t);
+  var t = add(intComparator, 4, t);
+  var xs_preorder = traverse_preorder(t);
+  print_list(xs_preorder)
+}
+
+test()

--- a/tests/stdlibtests/binaryTree/remove1.links
+++ b/tests/stdlibtests/binaryTree/remove1.links
@@ -1,0 +1,24 @@
+open Comparators
+open BinaryTree
+
+fun print_list(xs) {
+  fun print_list_inner(xs) {
+    switch(xs) {
+      case [] -> ""
+      case [x] -> intToString(x)
+      case x::xs -> intToString(x) ^^ "," ^^ print_list_inner(xs)
+    }
+  }
+  "[" ^^ print_list_inner(xs) ^^ "]"
+}
+
+fun test() {
+  var t = empty();
+  var t = add(intComparator, 3, t);
+  var t = add(intComparator, 2, t);
+  var t = add(intComparator, 1, t);
+  var t = add(intComparator, 4, t);
+  remove(intComparator, 2, t)
+}
+
+test()

--- a/tests/stdlibtests/binaryTree/remove2.links
+++ b/tests/stdlibtests/binaryTree/remove2.links
@@ -1,0 +1,24 @@
+open Comparators
+open BinaryTree
+
+fun print_list(xs) {
+  fun print_list_inner(xs) {
+    switch(xs) {
+      case [] -> ""
+      case [x] -> intToString(x)
+      case x::xs -> intToString(x) ^^ "," ^^ print_list_inner(xs)
+    }
+  }
+  "[" ^^ print_list_inner(xs) ^^ "]"
+}
+
+fun test() {
+  var t = empty();
+  var t = add(intComparator, 3, t);
+  var t = add(intComparator, 2, t);
+  var t = add(intComparator, 1, t);
+  var t = add(intComparator, 4, t);
+  remove(intComparator, 3, t)
+}
+
+test()


### PR DESCRIPTION
All this essentially does is adds a distinguished directory which is (by
default) included in the module path. The key idea is that we should be
able to import things from the standard library when we need them,
rather than having things in the prelude which are there all the time.

(also, have a basic binary tree library as a freebie...)