### PR TITLE
Emulate DOM reference serialisation (fix #207)

### DIFF
--- a/json.ml
+++ b/json.ml
@@ -80,6 +80,7 @@ let rec jsonize_value' : Value.t -> json_string =
         ", \"environment\":" ^ s in
     "{\"func\":\"" ^ Js.var_name_var f ^ "\"," ^
     " \"location\":\"" ^ location ^ "\"" ^ env_string ^ "}"
+  | `ClientDomRef i -> "{\"_domRefKey\":" ^ (string_of_int i) ^ "}"
   | `ClientFunction name -> "{\"func\":\"" ^ name ^ "\"}"
   | #Value.primitive_value as p -> jsonize_primitive p
   | `Variant (label, value) ->

--- a/jsonparse.mly
+++ b/jsonparse.mly
@@ -213,6 +213,8 @@ object_:
                             | ["_serverFunc", id; "_env", fvs]
                             | ["_env", fvs; "_serverFunc", id] ->
                               `FunctionPtr(Value.unbox_int id, Some fvs)
+                            | ["_domRefKey", id] ->
+                              `ClientDomRef(Value.unbox_int id)
                             | _ -> `Record (List.rev $2)
                         }
 

--- a/lib/js/jslib.js
+++ b/lib/js/jslib.js
@@ -613,6 +613,11 @@ var LINKS = function() {
          //   resolveServerValue(state, hs);
          //   delete _obj[i].eventHandlers;
          //   _obj[i].key = _registerEventHandlers(hs);
+         } else if (_obj[i]._domRefKey !== undefined) {
+           const ref_key = _obj[i]._domRefKey;
+           const ref = domRefs[ref_key];
+           delete domRefs[ref_key];
+           _obj[i] = ref;
          }
          // Removed: PID resolution.
       }
@@ -708,6 +713,17 @@ var LINKS = function() {
 
   var nextFuncID = 0;
 
+  // Used to emulate DOMRef serialisation
+  var domRefId = 0;
+  var domRefs = { };
+
+  function storeDomRef(ref) {
+    const id = domRefId++;
+    domRefs[id] = ref;
+    return { _domRefKey : id };
+  }
+
+
   function replacer(key, value) {
       _debug("In replacer with key: " + key);
       _debug("typeof value: " + typeof value);
@@ -728,6 +744,8 @@ var LINKS = function() {
                    (value.length == 2 && value[0] == 'TEXT' ||
                     value.length == 4 && value[0] == 'ELEMENT')) {
         return {_xml:value}
+      } else if (value.nodeType !== undefined) {
+        return storeDomRef(value);
       }
       return value;
   };

--- a/resolveJsonState.ml
+++ b/resolveJsonState.ml
@@ -14,7 +14,8 @@ let rec event_handlers_from_value : Value.t -> handler_id_set =
 
   (* Empties *)
   | `List [] | `SpawnLocation _ | `Pid _
-  | `AccessPointID _ | `ClientFunction _ | `SessionChannel _ -> empty_state
+  | `AccessPointID _ | `ClientDomRef _
+  | `ClientFunction _ | `SessionChannel _ -> empty_state
 
   (* Homomorphisms *)
   | `FunctionPtr (_f, fvs) ->

--- a/value.ml
+++ b/value.ml
@@ -232,6 +232,7 @@ and t = [
 | `Variant of string * t
 | `FunctionPtr of (Ir.var * t option)
 | `PrimitiveFunction of string * Var.var option
+| `ClientDomRef of int
 | `ClientFunction of string
 | `Continuation of continuation
 | `Pid of dist_pid
@@ -304,6 +305,7 @@ and compressed_t = [
 | `Variant of string * compressed_t
 | `FunctionPtr of (Ir.var * compressed_t option)
 | `PrimitiveFunction of string
+| `ClientDomRef of int
 | `ClientFunction of string
 | `Continuation of compressed_continuation ]
 and compressed_env = (Ir.var * compressed_t) list
@@ -345,6 +347,7 @@ and compress_t (v : t) : compressed_t =
       | `FunctionPtr(x, fvs) ->
         `FunctionPtr (x, opt_map compress_t fvs)
       | `PrimitiveFunction (f,_op) -> `PrimitiveFunction f
+      | `ClientDomRef i -> `ClientDomRef i
       | `ClientFunction f -> `ClientFunction f
       | `Continuation cont -> `Continuation (compress_continuation cont)
       | `Pid _ -> assert false (* mmmmm *)
@@ -398,6 +401,7 @@ and uncompress_t globals (v : compressed_t) : t =
       | `Variant (name, v) -> `Variant (name, uv v)
       | `FunctionPtr (x, fvs) -> `FunctionPtr (x, opt_map uv fvs)
       | `PrimitiveFunction f -> `PrimitiveFunction (f,None)
+      | `ClientDomRef i -> `ClientDomRef i
       | `ClientFunction f -> `ClientFunction f
       | `Continuation cont -> `Continuation (uncompress_continuation globals cont)
 and uncompress_env globals env : env =
@@ -436,6 +440,7 @@ let rec p_value (ppf : formatter) : t -> 'a = function
   | `List [v] -> fprintf ppf "[%a]" p_value v
   | `List l -> fprintf ppf "[@[<hov 0>";
                p_list_elements ppf l
+  | `ClientDomRef i -> fprintf ppf "%i" i
   | `ClientFunction n -> fprintf ppf "%s" n
   | `PrimitiveFunction (name, _op) -> fprintf ppf "%s" name
   | `Variant (label, `Record []) -> fprintf ppf "@{<constructor>%s@}" label

--- a/value.mli
+++ b/value.mli
@@ -91,6 +91,7 @@ type t = [
 | `Variant of string * t
 | `FunctionPtr of (Ir.var * t option)
 | `PrimitiveFunction of string * Var.var option
+| `ClientDomRef of int
 | `ClientFunction of string
 | `Continuation of continuation
 | `Pid of dist_pid


### PR DESCRIPTION
This assigns a unique reference to serialised DOM nodes and stores them in
a dictionary, allowing them to be serialised and deserialised correctly.

This should fix #207.