### PR TITLE
Made addRoute take a single parameter again (Fix #199)

### DIFF
--- a/examples/distribution/chatserver/chatServer.links
+++ b/examples/distribution/chatserver/chatServer.links
@@ -111,7 +111,7 @@ fun main() {
   var (clientAP:AP(ChatServer)) = new();
   var loopPid = spawn { serverLoop(Topic("Hello, ABCD!"), [], []) };
   var _ = spawn { acceptor(clientAP, loopPid) };
-  addRoute("/", fun (_, _) { ChatClient.mainPage(clientAP) } );
+  addRoute("/", fun(_) { ChatClient.mainPage(clientAP) } );
   addStaticRoute("/css", "css", [("css", "text/css")]);
   serveWebsockets();
   servePages()

--- a/examples/distribution/clientProcessOnServer.links
+++ b/examples/distribution/clientProcessOnServer.links
@@ -26,7 +26,7 @@ fun mainPage() {
 }
 
 fun main() {
-  addRoute("/", fun (_, _) { mainPage() } );
+  addRoute("/", fun(_) { mainPage() } );
   servePages()
 }
 

--- a/examples/distribution/clientProcessOnServer2.links
+++ b/examples/distribution/clientProcessOnServer2.links
@@ -26,7 +26,7 @@ fun mainPage(loc) {
 }
 
 fun main() {
-  addRoute("/", fun (_, loc) { mainPage(loc) } );
+  addLocatedRouteHandler("/", fun (_, loc) { mainPage(loc) } );
   serveWebsockets();
   servePages()
 }

--- a/examples/distribution/clientToClient.links
+++ b/examples/distribution/clientToClient.links
@@ -61,7 +61,7 @@ fun mainPage(regPid) {
 
 fun main() {
   var registryPid = spawn { clientRegProcess([]) };
-  addRoute("/x", fun (_, _) { mainPage(registryPid) });
+  addRoute("/x", fun(_) { mainPage(registryPid) });
   serveWebsockets();
   servePages()
 }

--- a/examples/distribution/clientToClientDeleg.links
+++ b/examples/distribution/clientToClientDeleg.links
@@ -45,8 +45,8 @@ module Client2 {
 
 fun main() {
   var ap = new();
-  addRoute("/c1", fun(_, _) { Client1.mainPage(ap) });
-  addRoute("/c2", fun(_, _) { Client2.mainPage(ap) });
+  addRoute("/c1", fun(_) { Client1.mainPage(ap) });
+  addRoute("/c2", fun(_) { Client2.mainPage(ap) });
   serveWebsockets();
   servePages();
 }

--- a/examples/distribution/clientToServerDeleg.links
+++ b/examples/distribution/clientToServerDeleg.links
@@ -39,7 +39,7 @@ module Server {
 fun main() {
   var ap = new();
   var _ = spawn { Server.go(ap) };
-  addRoute("/", fun(_, _) { Client.mainPage(ap) });
+  addRoute("/", fun(_) { Client.mainPage(ap) });
   serveWebsockets();
   servePages();
 }

--- a/examples/distribution/serverToClient.links
+++ b/examples/distribution/serverToClient.links
@@ -20,7 +20,7 @@ fun mainPage(serverPid) {
 
 fun main() {
   var serverPid = spawn { serverProc(0) };
-  addRoute("/", fun(_, _) { mainPage(serverPid) });
+  addRoute("/", fun(_) { mainPage(serverPid) });
   serveWebsockets();
   servePages()
 }

--- a/examples/distribution/serverToClient2.links
+++ b/examples/distribution/serverToClient2.links
@@ -19,7 +19,7 @@ fun mainPage(serverPid) {
 
 fun main() {
   var serverPid = spawn { serverProc(0) };
-  addRoute("/", fun(_, _) { mainPage(serverPid) });
+  addRoute("/", fun(_) { mainPage(serverPid) });
   serveWebsockets();
   servePages()
 }

--- a/examples/distribution/simpleServerAP.links
+++ b/examples/distribution/simpleServerAP.links
@@ -98,7 +98,7 @@ module Setup {
 
 fun main() {
   var srvAP = new();
-  addRoute("/", fun(_, clientLoc) { Setup.mainPage(clientLoc, srvAP) });
+  addLocateRouteHandler("/", fun(_, clientLoc) { Setup.mainPage(clientLoc, srvAP) });
   serveWebsockets();
   servePages();
 }

--- a/examples/sessions/bookshop-cp.links
+++ b/examples/sessions/bookshop-cp.links
@@ -140,7 +140,7 @@ fun main() {
 }
 
 
-fun mainPage(_,_) {
+fun mainPage(_) {
   var pid = spawnClient { receive { case _ -> main() } };
   fun trigger() { pid ! () }
   page

--- a/examples/sessions/bookshopAppServer.links
+++ b/examples/sessions/bookshopAppServer.links
@@ -43,7 +43,7 @@ fun mainPage(_, clientLoc) {
 }
 
 fun main() server {
-  addRoute("/", mainPage);
+  addLocatedRouteHandler("/", mainPage);
   servePages();
 }
 

--- a/examples/sessions/draggable.links
+++ b/examples/sessions/draggable.links
@@ -108,7 +108,7 @@ fun mainPage(_, loc) {
 
 
 fun main() {
-  addRoute("/", mainPage);
+  addLocatedRouteHandler("/", mainPage);
   servePages()
 }
 

--- a/examples/webserver/draggable.links
+++ b/examples/webserver/draggable.links
@@ -65,7 +65,7 @@ fun mainPage(pg, loc) {
 }
 
 fun main() {
-  addRoute("/", mainPage);
+  addLocatedRouteHandler("/", mainPage);
   servePages()
 }
 

--- a/examples/webserver/examples-nodb.links
+++ b/examples/webserver/examples-nodb.links
@@ -20,25 +20,25 @@ fun main() {
   addStaticRoute("/examples/", "examples/", [("links", "text/plain")]);
   addStaticRoute("/examplessrc/", "examples/", [("links", "text/plain")]);
 
-  addRoute("/examples/draggable.links", fun (_, _) {Draggable.main()});
-  addRoute("/examples/progress.links", fun (_, _) {Progress.main()});
+  addRoute("/examples/draggable.links", fun(_) {Draggable.main()});
+  addRoute("/examples/progress.links", fun(_) {Progress.main()});
 
-  addRoute("/examples/buttons.links", fun (_, _) {Buttons.main()});
-  addRoute("/examples/formsTest.links", fun (_, _) {FormsTest.main()});
+  addRoute("/examples/buttons.links", fun(_) {Buttons.main()});
+  addRoute("/examples/formsTest.links", fun(_) {FormsTest.main()});
 
-  addRoute("/examples/validate.links", fun (_, _) {Validate.main()});
+  addRoute("/examples/validate.links", fun(_) {Validate.main()});
 
-  addRoute("/examples/loginFlow.links", fun (_, _) {LoginFlow.main()});
-  addRoute("/examples/mandelbrot.links", fun (_, _) {Mandelbrot.main()});
-  addRoute("/examples/mandelcolor.links", fun (_, _) {Mandelcolor.main()});
-  addRoute("/examples/todo.links", fun (_, _) {Todo.main()});
-  addRoute("/examples/crop.links", fun (_, _) {Crop.main()});
+  addRoute("/examples/loginFlow.links", fun(_) {LoginFlow.main()});
+  addRoute("/examples/mandelbrot.links", fun(_) {Mandelbrot.main()});
+  addRoute("/examples/mandelcolor.links", fun(_) {Mandelcolor.main()});
+  addRoute("/examples/todo.links", fun(_) {Todo.main()});
+  addRoute("/examples/crop.links", fun(_) {Crop.main()});
 
   # games
-  addRoute("/examples/games/twentyfortyeight.links", fun (_, _) {Twentyfortyeight.main()});
-  addRoute("/examples/games/breakout.links", fun (_, _) {Breakout.main()});
-  addRoute("/examples/games/tetris.links", fun (_, _) {Tetris.main()});
-  addRoute("/examples/games/pacman.links", fun (_, _) {Pacman.main()});
+  addRoute("/examples/games/twentyfortyeight.links", fun(_) {Twentyfortyeight.main()});
+  addRoute("/examples/games/breakout.links", fun(_) {Breakout.main()});
+  addRoute("/examples/games/tetris.links", fun(_) {Tetris.main()});
+  addRoute("/examples/games/pacman.links", fun(_) {Pacman.main()});
 
   servePages()
 }

--- a/examples/webserver/examples.links
+++ b/examples/webserver/examples.links
@@ -31,36 +31,36 @@ fun main() {
   addStaticRoute("/examples/", "examples/", [("links", "text/plain")]);
   addStaticRoute("/examplessrc/", "examples/", [("links", "text/plain")]);
 
-  addRoute("/examples/dictionary/dictSuggestUpdate.links", fun (_, _){DictSuggestUpdate.main()});
-  addRoute("/examples/draggable.links", fun (_, _) {Draggable.main()});
-  addRoute("/examples/progress.links", fun (_, _) {Progress.main()});
+  addRoute("/examples/dictionary/dictSuggestUpdate.links", fun(_){DictSuggestUpdate.main()});
+  addRoute("/examples/draggable.links", fun(_) {Draggable.main()});
+  addRoute("/examples/progress.links", fun(_) {Progress.main()});
 
-  addRoute("/examples/factorial.links", fun (_, _) {Factorial.main()});
-  addRoute("/examples/dictionary/dictSuggest.links", fun (_, _){DictSuggest.main()});
-  addRoute("/examples/dictionary/dictSuggestLite.links", fun (_, _){DictSuggestLite.main()});
-  addRoute("/examples/draggableDb.links", fun (_, _) {DraggableDb.main()});
+  addRoute("/examples/factorial.links", fun(_) {Factorial.main()});
+  addRoute("/examples/dictionary/dictSuggest.links", fun(_){DictSuggest.main()});
+  addRoute("/examples/dictionary/dictSuggestLite.links", fun(_){DictSuggestLite.main()});
+  addRoute("/examples/draggableDb.links", fun(_) {DraggableDb.main()});
 
-  addRoute("/examples/buttons.links", fun (_, _) {Buttons.main()});
-  addRoute("/examples/formsTest.links", fun (_, _) {FormsTest.main()});
+  addRoute("/examples/buttons.links", fun(_) {Buttons.main()});
+  addRoute("/examples/formsTest.links", fun(_) {FormsTest.main()});
 
-  addRoute("/examples/validate.links", fun (_, _) {Validate.main()});
+  addRoute("/examples/validate.links", fun(_) {Validate.main()});
 
-  addRoute("/examples/loginFlow.links", fun (_, _) {LoginFlow.main()});
-  addRoute("/examples/paginate.links", fun (_, _) {Paginate.main()});
-  addRoute("/examples/mandelbrot.links", fun (_, _) {Mandelbrot.main()});
-  addRoute("/examples/mandelcolor.links", fun (_, _) {Mandelcolor.main()});
-  addRoute("/examples/todo.links", fun (_, _) {Todo.main()});
-  addRoute("/examples/todoDb.links", fun (_, _) {TodoDb.showList()});
-  addRoute("/examples/crop.links", fun (_, _) {Crop.main()});
-  addRoute("/examples/wine.links", fun (_, _) {Wine.main()});
-  addRoute("/examples/filter.links", fun (_, _) {Filter.main()});
-  addRoute("/examples/citations.links", fun (_, _) {Citations.main()});
+  addRoute("/examples/loginFlow.links", fun(_) {LoginFlow.main()});
+  addRoute("/examples/paginate.links", fun(_) {Paginate.main()});
+  addRoute("/examples/mandelbrot.links", fun(_) {Mandelbrot.main()});
+  addRoute("/examples/mandelcolor.links", fun(_) {Mandelcolor.main()});
+  addRoute("/examples/todo.links", fun(_) {Todo.main()});
+  addRoute("/examples/todoDb.links", fun(_) {TodoDb.showList()});
+  addRoute("/examples/crop.links", fun(_) {Crop.main()});
+  addRoute("/examples/wine.links", fun(_) {Wine.main()});
+  addRoute("/examples/filter.links", fun(_) {Filter.main()});
+  addRoute("/examples/citations.links", fun(_) {Citations.main()});
 
   # games
-  addRoute("/examples/games/twentyfortyeight.links", fun (_, _) {Twentyfortyeight.main()});
-  addRoute("/examples/games/breakout.links", fun (_, _) {Breakout.main()});
-  addRoute("/examples/games/tetris.links", fun (_, _) {Tetris.main()});
-  addRoute("/examples/games/pacman.links", fun (_, _) {Pacman.main()});
+  addRoute("/examples/games/twentyfortyeight.links", fun(_) {Twentyfortyeight.main()});
+  addRoute("/examples/games/breakout.links", fun(_) {Breakout.main()});
+  addRoute("/examples/games/tetris.links", fun(_) {Tetris.main()});
+  addRoute("/examples/games/pacman.links", fun(_) {Pacman.main()});
 
   servePages()
 }

--- a/examples/webserver/progress.links
+++ b/examples/webserver/progress.links
@@ -23,7 +23,7 @@ fun showAnswer(answer) client {
 	)
 }
 
-fun mainPage(_, _) {
+fun mainPage(_) {
   page
    <html>
     <body>

--- a/examples/webserver/wsocket_conn.links
+++ b/examples/webserver/wsocket_conn.links
@@ -4,7 +4,7 @@ fun mainPage() {
 }
 
 fun main() {
-  addRoute("/", fun (_, _) { mainPage() });
+  addRoute("/", fun(_) { mainPage() });
   serveWebsockets();
   servePages();
 }

--- a/prelude.links
+++ b/prelude.links
@@ -1195,17 +1195,24 @@ fun assertEq (actual, expected) server {
 }
 
 #### APP SERVER ####
-sig addRoute : (String, (String, Location) ~> Page) ~> ()
-fun addRoute(path,f) { unsafeAddRoute(path, fun(p, loc){f(p, loc)}) }
+
+sig addSimpleRouteHandler : (String, (String) ~> Page) ~> ()
+fun addSimpleRouteHandler(path,f) { unsafeAddRoute(path, fun(p, _){f(p)}) }
+
+sig addRoute : (String, (String) ~> Page) ~> ()
+fun addRoute(path, f) { unsafeAddRoute(path, fun(p, _){f(p)}) }
+
+sig addLocatedRouteHandler : (String, (String, Location) ~> Page) ~> ()
+fun addLocatedRouteHandler(path,f) { unsafeAddRoute(path, fun(p, l){f(p, l)}) }
 
 sig serveThis : (() ~> Page) ~> ()
 fun serveThis(p) {
-  addRoute("/",fun (_,_) {p()});
+  addRoute("/",fun (_) {p()});
   servePages()
 }
 
 sig serveThese : ([(String,() ~> Page)]) ~> ()
 fun serveThese(routes) {
-  var _ = map(fun ((s,p)) {addRoute(s,fun (_,_) {p()})}, routes);
+  var _ = map(fun ((s,p)) {addRoute(s,fun (_) {p()})}, routes);
   servePages()
 }


### PR DESCRIPTION
As per the discussion in issue #199, revises addRoute to take a single parameter again.

Adds:
  - addRoute : (String, (String) ~> Page) ~> ()
  - addSimpleRouteHandler : (String, (String) ~> Page) ~> ()
  - addLocatedRouteHandler : (String, (String, Location) ~> Page) ~> ()

addRoute and addSimpleRouteHandler have the same behaviour.

addLocatedRouteHandler allows the page render function to be passed an
explicit location, for use in things like spawnAt.