### PR TITLE
Add explicit error handling for routes.

### DIFF
--- a/evalir.ml
+++ b/evalir.ml
@@ -423,11 +423,11 @@ struct
       unblock out2;
       apply_cont cont env (`Record [])
     (* end of session stuff *)
-    | `PrimitiveFunction ("unsafeAddRoute", _), [pathv; handler] ->
+    | `PrimitiveFunction ("unsafeAddRoute", _), [pathv; handler; error_handler] ->
        let path = Value.unbox_string pathv in
        let is_dir_handler = String.length path > 0 && path.[String.length path - 1] = '/' in
        let path = if String.length path == 0 || path.[0] <> '/' then "/" ^ path else path in
-       Webs.add_route is_dir_handler path (Right (env, handler));
+       Webs.add_route is_dir_handler path (Right {Webs.request_handler = (env, handler); Webs.error_handler = (env, error_handler)});
        apply_cont cont env (`Record [])
     | `PrimitiveFunction ("addStaticRoute", _), [uriv; pathv; mime_typesv] ->
        if not (!allow_static_routes) then

--- a/lib.ml
+++ b/lib.ml
@@ -1570,7 +1570,7 @@ let env : (string * (located_primitive * Types.datatype * pure)) list = [
      IMPURE);
     "unsafeAddRoute",
     (`PFun (fun _ -> assert false),
-     datatype "(String, (String, Location) ~> a) ~> ()",
+     datatype "(String, (String, Location) ~> a, (String, String, Location) ~> a) ~> ()",
      IMPURE);
     "servePages",
     (`PFun (fun _ -> assert false),

--- a/prelude.links
+++ b/prelude.links
@@ -1203,8 +1203,13 @@ sig addRoute : (String, (String) ~> Page) ~> ()
 fun addRoute(path, f) { addLocatedRouteHandler(path, fun(p, _){f(p)}) }
 
 sig defaultErrorPage : (String, String, Location) ~> Page
-fun defaultErrorPage(path, error_string, location) {
-  bodyP(<html><body><h1>Wrong</h1></body></html>)
+fun defaultErrorPage(_, error_string, _) {
+  bodyP(<html>
+        <body>
+        <h1>Wrong</h1>
+        <p>Links has encountered an internal error; the error message is <em>{stringToXml(error_string)}</em></p>
+        </body>
+        </html>)
 }
 
 sig addLocatedRouteHandler : (String, (String, Location) ~> Page) ~> ()

--- a/prelude.links
+++ b/prelude.links
@@ -1197,13 +1197,21 @@ fun assertEq (actual, expected) server {
 #### APP SERVER ####
 
 sig addSimpleRouteHandler : (String, (String) ~> Page) ~> ()
-fun addSimpleRouteHandler(path,f) { unsafeAddRoute(path, fun(p, _){f(p)}) }
+fun addSimpleRouteHandler(path,f) { addRoute(path,f) }
 
 sig addRoute : (String, (String) ~> Page) ~> ()
-fun addRoute(path, f) { unsafeAddRoute(path, fun(p, _){f(p)}) }
+fun addRoute(path, f) { addLocatedRouteHandler(path, fun(p, _){f(p)}) }
+
+sig defaultErrorPage : (String, String, Location) ~> Page
+fun defaultErrorPage(path, error_string, location) {
+  bodyP(<html><body><h1>Wrong</h1></body></html>)
+}
 
 sig addLocatedRouteHandler : (String, (String, Location) ~> Page) ~> ()
-fun addLocatedRouteHandler(path,f) { unsafeAddRoute(path, fun(p, l){f(p, l)}) }
+fun addLocatedRouteHandler(path,f) { addLocatedRouteWithErrors(path, fun(p, l){f(p, l)}, defaultErrorPage) }
+
+sig addLocatedRouteWithErrors : (String, (String, Location) ~> Page, (String, String, Location) ~> Page) ~> ()
+fun addLocatedRouteWithErrors(path, f, error_handler) { unsafeAddRoute(path, f, error_handler) }
 
 sig serveThis : (() ~> Page) ~> ()
 fun serveThis(p) {

--- a/webserver.ml
+++ b/webserver.ml
@@ -66,7 +66,7 @@ struct
   type path = string
   type mime_type = (string * string)
   type static_resource = path * mime_type list
-  type request_handler_fn = Value.env * Value.t
+  type request_handler_fn = { request_handler: Value.env * Value.t; error_handler: Value.env * Value.t }
 
   type provider = (static_resource, request_handler_fn) either option
   type providers = { as_directory: provider; as_page: provider }  (* Really, at least one should be Some *)
@@ -166,12 +166,12 @@ struct
       let path = Uri.path (Request.uri req) in
 
       (* Precondition: valenv has been initialised with the correct request data *)
-      let run_page (valenv, v) () =
+      let run_page (valenv, v) (error_valenv, error_v) () =
         let cid = RequestData.get_client_id (Value.request_data valenv) in
         let ws_conn_url =
           if !accepting_websocket_requests then Some (ws_url) else None in
-        Eval.apply (render_cont ()) valenv
-        (v, [`String path; `SpawnLocation (`ClientSpawnLoc cid)]) >>= fun (valenv, v) ->
+        let applier env vp =
+          Eval.apply (render_cont ()) env vp >>= fun (valenv, v) ->
           let page = Irtojs.generate_real_client_page
                        ~cgi_env:cgi_args
                        (Lib.nenv, Lib.typing_env)
@@ -179,9 +179,15 @@ struct
                         * they should all end up in valenv... *)
                        (!prelude @ !globals)
                        (valenv, v)
-                       ws_conn_url
-          in
-        Lwt.return ("text/html", page) in
+                       ws_conn_url in
+          Lwt.return ("text/html", page) in
+        try
+          applier valenv (v, [`String path; `SpawnLocation (`ClientSpawnLoc cid)])
+        with
+        | Eval.Wrong ->
+           applier error_valenv (error_v, [`String path; `String "Error in string matching (perhaps you have an over-specific route function)."; `SpawnLocation (`ClientSpawnLoc cid)])
+        | Eval.EvaluationError s ->
+           applier error_valenv (error_v, [`String path; `String s; `SpawnLocation (`ClientSpawnLoc cid)]) in
 
       let render_servercont_cont valenv v =
         let ws_conn_url =
@@ -225,16 +231,17 @@ struct
              serve_static file_path (String.concat "/" remaining) mime_types
           | (remaining, { as_directory = Some (Left (file_path, mime_types)); _ }) :: _, false ->
              serve_static file_path (String.concat "/" remaining / "index.html") mime_types
-          | ([], { as_page = Some (Right (valenv, v)); _ }) :: _, true
-          | (_, { as_directory = Some (Right (valenv, v)); _ }) :: _, _ ->
+          | ([], { as_page = Some (Right { request_handler = (valenv, v); error_handler = (error_valenv, error_v) }); _}) :: _, true
+          | (_, { as_directory = Some (Right { request_handler = (valenv, v); error_handler = (error_valenv, error_v) }); _}) :: _, _ ->
              let (_, nenv, tyenv) = !env in
              let cid = get_or_make_client_id cgi_args in
              let req_data = RequestData.new_request_data cgi_args cookies cid in
              let req_env = Value.set_request_data (Value.shadow tl_valenv ~by:valenv) req_data in
+             let req_error_env = Value.set_request_data (Value.shadow tl_valenv ~by:error_valenv) req_data in
              Webif.do_request
                (req_env, nenv, tyenv)
                cgi_args
-               (run_page (req_env, v))
+               (run_page (req_env, v) (req_error_env, error_v))
                (render_cont ())
                (render_servercont_cont req_env)
                (fun hdrs bdy -> Lib.cohttp_server_response hdrs bdy req_data)

--- a/webserver_types.ml
+++ b/webserver_types.ml
@@ -5,9 +5,11 @@ let webs_running = Settings.add_bool ("webs_running", false, `System)
 
 module type WEBSERVER =
 sig
+  type request_handler_fn = { request_handler: Value.env * Value.t; error_handler: Value.env * Value.t }
+
   val init : (Value.env * Ir.var Env.String.t * Types.typing_environment) -> Ir.binding list -> unit
   val set_prelude : Ir.binding list -> unit
-  val add_route : bool -> string -> (string * (string * string) list, Value.env * Value.t) either -> unit
+  val add_route : bool -> string -> (string * (string * string) list, request_handler_fn) either -> unit
   val start : Value.env -> unit Lwt.t
 
   (* Returns whether the server is accepting websocket requests. *)

--- a/webserver_types.mli
+++ b/webserver_types.mli
@@ -3,11 +3,15 @@ open Utility
 type websocket_url = string
 val webs_running : bool Settings.setting
 
+
+
 module type WEBSERVER =
 sig
+  type request_handler_fn = { request_handler: Value.env * Value.t; error_handler: Value.env * Value.t }
+
   val init : (Value.env * Ir.var Env.String.t * Types.typing_environment) -> Ir.binding list -> unit
   val set_prelude : Ir.binding list -> unit
-  val add_route : bool -> string -> (string * (string * string) list, Value.env * Value.t) either -> unit
+  val add_route : bool -> string -> (string * (string * string) list, request_handler_fn) either -> unit
 
   val start : Value.env -> unit Lwt.t
 


### PR DESCRIPTION
Adds an error hander per route, called should the route throw an `EvaluationError` or `Wrong` exception, and updates the existing route adding functions to use a default error handler, providing an informative error message.