### PR TITLE
Hotfix postgres escape_string to work with non-ASCII characters.

### DIFF
--- a/pg_database.ml
+++ b/pg_database.ml
@@ -117,7 +117,7 @@ class pg_database host port dbname user password = object(self)
           failwith("PostgreSQL returned error: " ^Postgresql.string_of_error msg)
 	    )
   method escape_string s =
-    connection#escape_string s
+    connection#escape_string (String.escaped s)
   method quote_field f =
     "\"" ^ Str.global_replace (Str.regexp "\"") "\"\"" f ^ "\""
 


### PR DESCRIPTION
This patch applies `String.escaped` to the given input string and passes the result to the postgres escape_string. `String.escaped` escape any character outside of the ASCII printable range [32-126].

Prior to this patch the postgres driver would blow up when given a non-ASCII string such as yours truly surname.

I have created this PR for informative purposes. I'll self-approve this PR, since the change is minor and needed immediately.