### PR TITLE
Constrain Postgres bindings to 4.0.1.

### DIFF
--- a/opam
+++ b/opam
@@ -75,3 +75,7 @@ depopts: [
   "postgresql" { <= "4.0.1" }
   "sqlite3"
 ]
+
+conflicts: [
+  "postgresql" { >= "4.1" }
+]

--- a/opam
+++ b/opam
@@ -72,6 +72,6 @@ depends: [
 
 depopts: [
   "mysql"
-  "postgresql"
+  "postgresql" { <= "4.0.1" }
   "sqlite3"
 ]


### PR DESCRIPTION
It's not playing nicely with 4.1 at the moment, so constraining for now.