### PR TITLE
Fix mysterious postgresql 4.1.0 build failure

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,31 +7,21 @@ export OCAMLFLAGS=-syntax camlp4o
 
 PATH := $(PATH):deriving
 
-POSTGRESQL_LIBDIR=$(shell ocamlfind query postgresql)
-SQLITE3_LIBDIR=$(shell ocamlfind query sqlite3)
-MYSQL_LIBDIR=$(shell ocamlfind query mysql)
-
-ifneq ($(SQLITE3_LIBDIR),)
-   DB_CODE    += lite3_database.ml
-   DB_AUXLIBS += $(SQLITE3_LIBDIR)
-   DB_CLIBS   += sqlite3
-   DB_LIBS    += sqlite3
+ifneq ($(shell ocamlfind query sqlite3),)
+   DB_CODE += lite3_database.ml
+   PACKS   += sqlite3
 endif
 
-ifneq ($(MYSQL_LIBDIR),)
-   DB_CODE    += mysql_database.ml
-   DB_AUXLIBS += $(MYSQL_LIBDIR)
-   DB_LIBS    += mysql
+ifneq ($(shell ocamlfind query mysql),)
+   DB_CODE += mysql_database.ml
+   PACKS   += mysql
 endif
 
-ifneq ($(POSTGRESQL_LIBDIR),)
-   DB_CODE    += pg_database.ml
-   DB_AUXLIBS += $(POSTGRESQL_LIBDIR)
-   DB_LIBS    += postgresql
+ifneq ($(shell ocamlfind query postgresql),)
+   DB_CODE += pg_database.ml
+   PACKS   += postgresql
    THREADS = yes
 endif
-
-AUXLIB_DIRS = $(DB_AUXLIBS)
 
 ifdef PROF
 OCAMLOPT := ocamlopt -p -inline 0
@@ -141,13 +131,7 @@ SOURCES = $(OPC)                                \
 #          test.ml                               \
 #          tests.ml                              \
 
-LIBS    = $(DB_LIBS)
-
 RESULT  = links
-CLIBS 	= $(DB_CLIBS)
-
-INCDIRS = $(AUXLIB_DIRS) $(EXTRA_INCDIRS)
-LIBDIRS = $(AUXLIB_DIRS) $(EXTRA_LIBDIRS)
 
 include $(OCAMLMAKEFILE)
 

--- a/Makefile.sample.config
+++ b/Makefile.sample.config
@@ -2,9 +2,3 @@
 LINKS_PREFIX=/usr/local
 LINKS_BIN=$(LINKS_PREFIX)/bin
 LINKS_LIB=$(LINKS_PREFIX)/lib/links
-
-# EXTRA_LIBDIRS gives the paths of any additional libraries that need to be
-# linked for your particular database library to work.
-#   (e.g. /usr/local/mysql/lib)
-# If building using OPAM and Ocamlfind, this should not need to be changed
-EXTRA_LIBDIRS=

--- a/opam
+++ b/opam
@@ -72,10 +72,6 @@ depends: [
 
 depopts: [
   "mysql"
-  "postgresql" { <= "4.0.1" }
+  "postgresql"
   "sqlite3"
-]
-
-conflicts: [
-  "postgresql" { >= "4.1" }
 ]


### PR DESCRIPTION
Turns out we were trying to recompile the OPAM-installed version of postgresql. I still don't know why it started breaking now, but we shouldn't do that. See here for the full story: https://github.com/mmottl/postgresql-ocaml/issues/21

This PR assumes that we will only ever use the OPAM-installed version. This way we can use the regular mechanism for linking with OPAM-installed dependencies. We don't require the whole CLIBS, EXTRA_LIBDIR, and stuff anymore, I think.

I only tested the postgresql backend.

Someone who knows anything about Makefiles should check whether this makes sense.
Anyone who cares about MySQL/SQLite should check them.