### PR TITLE
Design things

### DIFF
--- a/examples/css/doc.css
+++ b/examples/css/doc.css
@@ -1,0 +1,234 @@
+body {
+  margin: 0;
+  padding: 0;
+  font-family: 'Segoe UI', Tahoma, Geneva, Verdana, sans-serif;
+}
+
+a {
+  text-decoration: none;
+  color: #091F3F;
+  border-bottom: thin dotted #091F3F;
+}
+
+a:hover {
+  color: #DF1E36;
+  border-color: #DF1E36;
+}
+
+header {
+  z-index: 1;
+  position: fixed;
+  background-color: #333;
+  color: #fff;
+  width: 100%;
+  top: 0;
+  left: 0;
+  height: 2rem;
+  padding: .25rem .5rem;
+  box-sizing: border-box;
+  display: flex;
+  justify-content: flex-start;
+  align-items: center;
+  box-shadow:
+    0 1px 3px rgba(0, 0, 0, .05),
+    0 2px 6px rgba(0, 0, 0, .1),
+    0 3px 12px rgba(0, 0, 0, .15);
+}
+
+header img {
+  height: 1rem;
+  margin-right: .5rem;
+}
+
+header a {
+  outline: none;
+  text-decoration: none;
+  border: none;
+}
+
+header h1 {
+  font-size: .8rem;
+  margin: 0;
+  padding: 0;
+}
+
+h2 {
+  font-size: 2rem;
+  margin: 2rem 0 1rem 0;
+  padding: 0;
+}
+
+h3 {
+  font-size: 1.5rem;
+  padding-top: 2rem;
+}
+
+nav h3 {
+  font-weight: 500;
+  padding: 0;
+  margin: 0 0 .5rem 0;
+  font-size: 1rem;
+}
+
+nav h3 a {
+  background: none;
+  border-bottom-style: dotted;
+  border-bottom-width: thin;
+  border-bottom-width: thin;
+}
+
+nav h3 a:hover {
+  background: none;
+}
+
+header h1 a {
+  color: #fff;
+  text-decoration: none;
+}
+
+nav {
+  position: fixed;
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  left: 0;
+  top: 2rem;
+  bottom: 0;
+  overflow: auto;
+  width: 100vw;
+  background-color: #eee;
+  color: #333;
+  padding-bottom: 2rem;
+  box-sizing: border-box;
+  padding: 1rem;
+}
+
+nav section {
+  width: 100%;
+}
+
+nav ul {
+  padding: 0 0 0 1.5rem;
+  margin: 0 0 1.5rem 0;
+  list-style-type: none;
+}
+
+nav li {
+  padding: .5rem 0;
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-start;
+  width: 100%;
+  box-sizing: border-box;
+}
+
+nav li a {
+  box-sizing: border-box;
+  color: inherit;
+  text-decoration: none;
+  display: inline-block;
+  border: none;
+  padding: 0;
+  font-weight: normal;
+  font-size: 1rem;
+  text-transform: none;
+  flex: 1;
+}
+nav li li a {
+  padding: .25rem .5rem .25rem 2.5rem;
+}
+nav li li li a {
+  padding: .25rem .5rem .25rem 4rem;
+}
+
+nav a:last-child:hover {
+  color: #DF1E36;
+  background-color: rgba(0, 0, 0, .1);
+}
+
+nav li a:last-child:not(:first-child) {
+  font-size: .8rem;
+  width: 100%;
+  text-align: right;
+  flex: 0;
+  padding: .25rem;
+  font-family: monospace;
+}
+
+main {
+  margin-left: 0;
+  margin-top: 2rem;
+  padding: 0 1rem;
+  min-height: initial;
+}
+
+@media (min-width: 48rem) {
+  nav {
+    display: block;
+    width: 33vw;
+  }
+
+  main {
+    margin-left: 33vw;
+  }
+}
+
+iframe {
+  width: calc(100% + 2rem);
+  margin: 0 -1rem;
+  height: calc(100vh - 3rem);
+  box-sizing: border-box;
+  border: none;
+}
+
+code {
+  padding: .1rem .2rem;
+  font-family: Source Code Pro, monospace;
+  border-radius: 2px;
+  line-height: 1.5;
+}
+
+.code-block {
+  display: block;
+  margin: .5rem 1rem;
+  padding: .5rem 1rem;
+  border-left: .25rem solid #DF1E36;
+}
+
+.code-pre {
+  white-space: pre;
+}
+
+blockquote, .warn, .critical, .error, .info, .highlight {
+  border-left-width: .25rem;
+  border-left-style: solid;
+  padding: 1rem;
+  border-radius: 2px;
+  margin: 2rem 1rem;
+}
+
+blockquote {
+  background-color: #f8f8f8;
+  border-color: #ddd;
+}
+
+.warn {
+  background-color: rgba(255, 185, 0, .2);
+  border-color: #FFB900;
+}
+
+.critical, .error {
+  background-color: rgba(255, 51, 51, .2);
+  border-color: #FF4343;
+}
+
+.info {
+  background-color: rgba(0, 120, 215, .2);
+  border-color: #0078D7;
+}
+
+
+.highlight {
+  background-color: rgba(16, 114, 16, .2);
+  border-color: #107C10;
+}

--- a/examples/index.html
+++ b/examples/index.html
@@ -1,128 +1,157 @@
-<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN"
-    "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
-<html xmlns="http://www.w3.org/1999/xhtml">
-<head>
-  <title>Links examples</title>
-  <link rel="stylesheet" type="text/css" href="http://homepages.inf.ed.ac.uk/wadler/style.css" />
-</head>
-<body>
-  <h1>Links examples</h1>
-
-  The following examples are described in <a href="../papers/links-fmco06.pdf">Links: Web Programming Without Tiers</a>
-  <ul>
-  <li>
-    <a href="dictionary/dictSuggestUpdate.links">dictionary suggestion with database update</a>
-    (<a href="../examplessrc/dictionary/dictSuggestUpdate.links">source</a>)
-  </li>
-  <li>
-    <a href="draggable.links">draggable lists (with styles)</a>
-    (<a href="../examplessrc/draggable.links">source</a>)
-  </li>
-  <li>
-    <a href="progress.links">progress bar</a>
-    (<a href="../examplessrc/progress.links">source</a>)
-  </li>
-  </ul>
-  The following examples appeared in earlier drafts of the same paper
-  <ul>
-  <li>
-    <a href="factorial.links">factorial</a>
-    (<a href="../examplessrc/factorial.links">source</a>)
-  </li>
-  <li>
-    <a href="dictionary/dictSuggest.links">dictionary suggestion (with styles)</a>
-    (<a href="../examplessrc/dictionary/dictSuggest.links">source</a>)
-  </li>
-  <li>
-    <a href="dictionary/dictSuggestLite.links">dictionary suggestion (no styles)</a>
-    (<a href="../examplessrc/dictionary/dictSuggestLite.links">source</a>)
-  </li>
-  <li>
-    <a href="draggableDb.links">draggable lists (database version)</a>
-    (<a href="../examplessrc/draggableDb.links">source</a>)
-  </li>
-  </ul>
-
-  Formlets examples
-  <ul>
-  <li>
-    <a href="buttons.links">buttons</a>
-    (<a href="../examplessrc/buttons.links">source</a>)
-  </li>
-  <li>
-    <a href="formsTest.links">a simple test formlet</a>
-    (<a href="../examplessrc/formsTest.links">source</a>)
-  </li>
-  <li>
-    <a href="validate.links">validation</a>
-    (<a href="../examplessrc/validate.links">source</a>)
-  </li>
-  </ul>
-  
-  Other examples
-  <ul>
-  <li>
-    <a href="loginFlow.links">login flow using sendSuspend</a>
-    (<a href="../examplessrc/loginFlow.links">source</a>)
-  </li>
-  <li>
-    <a href="paginate.links">pagination</a>
-    (<a href="../examplessrc/paginate.links">source</a>)
-  </li>
-  <li>
-    <a href="mandelbrot.links">mandelbrot sets</a>
-    (<a href="../examplessrc/mandelbrot.links">source</a>)
-  </li>
-  <li>
-    <a href="mandelcolor.links">multi-coloured mandelbrot set</a>
-    (<a href="../examplessrc/mandelcolor.links">source</a>)
-  </li>
-  <li>
-    <a href="todo.links">todo list (client)</a>
-    (<a href="../examplessrc/todo.links">source</a>)
-  </li>
-  <li>
-    <a href="todoDb.links">todo list (server)</a>
-    (<a href="../examplessrc/todoDb.links">source</a>)
-  </li>
-  <li>
-    <a href="crop.links">draggable Cropping Frame</a>
-    (<a href="../examplessrc/crop.links">source</a>)
-  </li>
-  <li>
-    <a href="wine.links">winestore</a>
-    (<a href="../examplessrc/wine.links">source</a>)
-  </li>
-  <li>
-    <a href="filter.links">dynamic wine filtering</a>
-    (<a href="../examplessrc/filter.links">source</a>)
-  </li>
-  <li>
-    <a href="citations.links">citeseer data</a>
-    (<a href="../examplessrc/citations.links">source</a>)
-  </li>
-  </ul>
-
-  Game examples
-  <ul>
-  <li>
-    <a href="./games/twentyfortyeight.links">2048 in Links</a>
-    (<a href="../examplessrc/games/twentyfortyeight.links">source</a>)
-  </li>
-  <li>
-    <a href="./games/breakout.links">Breakout in Links</a>
-    (<a href="../examplessrc/games/breakout.links">source</a>)
-  </li>
-  <li>
-    <a href="./games/tetris.links">Tetris in Links</a>
-    (<a href="../examplessrc/games/tetris.links">source</a>)
-  </li>
-  <li>
-    <a href="./games/pacman.links">Pillman</a>
-    (<a href="../examplessrc/games/pacman.links">source</a>)
-  </li>
-  </ul>
-
-  <p><a href="http://groups.inf.ed.ac.uk/links/">Links homepage</a></p>
-</body>
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="utf-8">
+    <meta name=viewport content="width=device-width, initial-scale=1">
+    <title>Links examples</title>
+    <link rel="stylesheet" type="text/css" href="/examples/css/doc.css" />
+    <script>
+      window.addEventListener('load', function () {
+        const iframe = document.getElementById('exampleFrame');
+        const nav = document.querySelector('nav');
+        document.querySelectorAll('nav a.frame-link').forEach(function (a) {
+          if (a.getAttribute('href')) {
+            a.addEventListener('click', function (e) {
+              if (nav.getBoundingClientRect().width < document.body.getBoundingClientRect().width / 2) {
+                iframe.setAttribute('src', '');
+                e.preventDefault();
+                iframe.setAttribute('src', a.getAttribute('href'));
+              }
+            });
+          }
+        });
+      });
+    </script>
+  </head>
+  <body>
+    <header>
+      <h1>Links examples</h1>
+    </header>
+    <nav>
+      <section>
+        <h3>The following examples are described in <a href="../papers/links-fmco06.pdf">Links: Web Programming Without Tiers</a></h3>
+        <ul>
+          <li>
+            <a class="frame-link" href="dictionary/dictSuggestUpdate.links">Dictionary suggestion with database update</a>
+            <a href="../examplessrc/dictionary/dictSuggestUpdate.links" target="_blank">source</a>
+          </li>
+          <li>
+            <a class="frame-link" href="draggable.links">Draggable lists</a>
+            <a href="../examplessrc/draggable.links" target="_blank">source</a>
+          </li>
+          <li>
+            <a class="frame-link" href="progress.links">Progress bar</a>
+            <a href="../examplessrc/progress.links" target="_blank">source</a>
+          </li>
+        </ul>
+      </section>
+      <section>
+        <h3>The following examples appeared in earlier drafts of the same paper</h3>
+        <ul>
+          <li>
+            <a class="frame-link" href="factorial.links">Factorial</a>
+            <a href="../examplessrc/factorial.links" target="_blank">source</a>
+          </li>
+          <li>
+            <a class="frame-link" href="dictionary/dictSuggest.links">Dictionary suggestion (with styles)</a>
+            <a href="../examplessrc/dictionary/dictSuggest.links" target="_blank">source</a>
+          </li>
+          <li>
+            <a class="frame-link" href="dictionary/dictSuggestLite.links">Dictionary suggestion (no styles)</a>
+            <a href="../examplessrc/dictionary/dictSuggestLite.links" target="_blank">source</a>
+          </li>
+          <li>
+            <a class="frame-link" href="draggableDb.links">Draggable lists (database version)</a>
+            <a href="../examplessrc/draggableDb.links" target="_blank">source</a>
+          </li>
+        </ul>
+      </section>
+      <section>
+        <h3>Formlets examples</h3>
+        <ul>
+          <li>
+            <a class="frame-link" href="buttons.links">Buttons</a>
+            <a href="../examplessrc/buttons.links" target="_blank">source</a>
+          </li>
+          <li>
+            <a class="frame-link" href="formsTest.links">A simple test formlet</a>
+            <a href="../examplessrc/formsTest.links" target="_blank">source</a>
+          </li>
+          <li>
+            <a class="frame-link" href="validate.links">Validation</a>
+            <a href="../examplessrc/validate.links" target="_blank">source</a>
+          </li>
+        </ul>
+      </section>
+      <section>
+        <h3>Other examples</h3>
+        <ul>
+          <li>
+            <a class="frame-link" href="loginFlow.links">Login flow using <code>sendSuspend</code></a>
+            <a href="../examplessrc/loginFlow.links" target="_blank">source</a>
+          </li>
+          <li>
+            <a class="frame-link" href="paginate.links">Pagination</a>
+            <a href="../examplessrc/paginate.links" target="_blank">source</a>
+          </li>
+          <li>
+            <a class="frame-link" href="mandelbrot.links">Mandelbrot sets</a>
+            <a href="../examplessrc/mandelbrot.links" target="_blank">source</a>
+          </li>
+          <li>
+            <a class="frame-link" href="mandelcolor.links">Multi-coloured mandelbrot set</a>
+            <a href="../examplessrc/mandelcolor.links" target="_blank">source</a>
+          </li>
+          <li>
+            <a class="frame-link" href="todo.links">Todo list (client)</a>
+            <a href="../examplessrc/todo.links" target="_blank">source</a>
+          </li>
+          <li>
+            <a class="frame-link" href="todoDb.links">Todo list (server)</a>
+            <a href="../examplessrc/todoDb.links" target="_blank">source</a>
+          </li>
+          <li>
+            <a class="frame-link" href="crop.links">Draggable Cropping Frame</a>
+            <a href="../examplessrc/crop.links" target="_blank">source</a>
+          </li>
+          <li>
+            <a class="frame-link" href="wine.links">Winestore</a>
+            <a href="../examplessrc/wine.links" target="_blank">source</a>
+          </li>
+          <li>
+            <a class="frame-link" href="filter.links">Dynamic wine filtering</a>
+            <a href="../examplessrc/filter.links" target="_blank">source</a>
+          </li>
+          <li>
+            <a class="frame-link" href="citations.links">Citeseer data</a>
+            <a href="../examplessrc/citations.links" target="_blank">source</a>
+          </li>
+        </ul>
+      </section>
+      <section>
+        <h3>Game examples</h3>
+        <ul>
+          <li>
+            <a class="frame-link" href="games/twentyfortyeight.links">2048 in Links</a>
+            <a href="../examplessrc/games/twentyfortyeight.links" target="_blank">source</a>
+          </li>
+          <li>
+            <a class="frame-link" href="games/breakout.links">Breakout in Links</a>
+            <a href="../examplessrc/games/breakout.links" target="_blank">source</a>
+          </li>
+          <li>
+            <a class="frame-link" href="games/tetris.links">Tetris in Links</a>
+            <a href="../examplessrc/games/tetris.links" target="_blank">source</a>
+          </li>
+          <li>
+            <a class="frame-link" href="games/pacman.links">Pillman</a>
+            <a href="../examplessrc/games/pacman.links" target="_blank">source</a>
+          </li>
+        </ul>
+      </section>
+    </nav>
+    <main>
+      <iframe id="exampleFrame" src=""></iframe>
+    </main>
+  </body>
 </html>


### PR DESCRIPTION
- [ ] ~Add the updated links-lang frontpage so the example server no longer goes "Nope" without `/examples`~
- [x] The example-page now loads the examples as sub-page, keeping the example-list
- [x] Source is opened in new a new window/tab