### PR TITLE
Add history manipulation to the examples page

### DIFF
--- a/examples/css/doc.css
+++ b/examples/css/doc.css
@@ -173,7 +173,7 @@ main {
   }
 }
 
-iframe {
+iframe, object {
   width: calc(100% + 2rem);
   margin: 0 -1rem;
   height: calc(100vh - 3rem);

--- a/examples/index.html
+++ b/examples/index.html
@@ -7,6 +7,7 @@
     <link rel="stylesheet" type="text/css" href="/examples/css/doc.css" />
     <script>
       window.addEventListener('load', function () {
+        const examples = 'examples/';
         const frame = document.getElementById('exampleFrame');
         const nav = document.querySelector('nav');
 
@@ -15,23 +16,24 @@
         }
 
         function replaceExample (url) {
+          const exampleUrl = '/' + examples + url;
           if (isMobile()) {
-            location = url;
+            location = exampleUrl;
           } else {
-            frame.data = url;
+            frame.data = exampleUrl;
           }
         }
 
         // Set initial example
         if (location.hash) {
-          replaceExample('/' + location.hash.slice(1));
+          replaceExample(location.hash.slice(1));
         }
 
         // Intercept navigation
         window.addEventListener('hashchange', (e) => {
           e.preventDefault();
           if (location.hash) {
-            replaceExample('/' + location.hash.slice(1));
+            replaceExample(location.hash.slice(1));
           }
           history.replaceState({ }, '', location.hash);
         });
@@ -44,7 +46,7 @@
             a.addEventListener('click', function (e) {
               if (!isMobile()) {
                 e.preventDefault();
-                location.hash = a.getAttribute('href').slice(1);
+                location.hash = a.getAttribute('href').slice(1).replace(examples, "");
               }
             });
           }

--- a/examples/index.html
+++ b/examples/index.html
@@ -2,24 +2,53 @@
 <html>
   <head>
     <meta charset="utf-8">
-    <meta name=viewport content="width=device-width, initial-scale=1">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
     <title>Links examples</title>
     <link rel="stylesheet" type="text/css" href="/examples/css/doc.css" />
     <script>
       window.addEventListener('load', function () {
-        const iframe = document.getElementById('exampleFrame');
+        const frame = document.getElementById('exampleFrame');
         const nav = document.querySelector('nav');
-        document.querySelectorAll('nav a.frame-link').forEach(function (a) {
+
+        function isMobile () {
+          return !(nav.getBoundingClientRect().width < document.body.getBoundingClientRect().width / 2);
+        }
+
+        function replaceExample (url) {
+          if (isMobile()) {
+            location = url;
+          } else {
+            frame.data = url;
+          }
+        }
+
+        // Set initial example
+        if (location.hash) {
+          replaceExample('/' + location.hash.slice(1));
+        }
+
+        // Intercept navigation
+        window.addEventListener('hashchange', (e) => {
+          e.preventDefault();
+          if (location.hash) {
+            replaceExample('/' + location.hash.slice(1));
+          }
+          history.replaceState({ }, '', location.hash);
+        });
+
+        const frameLinks = document.querySelectorAll('nav a.frame-link');
+
+        for (let i = 0; i < frameLinks.length; i++) {
+          const a = frameLinks[i];
           if (a.getAttribute('href')) {
             a.addEventListener('click', function (e) {
-              if (nav.getBoundingClientRect().width < document.body.getBoundingClientRect().width / 2) {
-                iframe.setAttribute('src', '');
+              if (!isMobile()) {
                 e.preventDefault();
-                iframe.setAttribute('src', a.getAttribute('href'));
+                location.hash = a.getAttribute('href').slice(1);
               }
             });
           }
-        });
+        }
       });
     </script>
   </head>
@@ -151,7 +180,7 @@
       </section>
     </nav>
     <main>
-      <iframe id="exampleFrame" src=""></iframe>
+      <object type="text/html" id="exampleFrame"></object>
     </main>
   </body>
 </html>


### PR DESCRIPTION
- When viewing on desktop, history is updated for the currently viewed example
- Loading an URL with query parameters loads the example in the frame
- On mobile it redirects to the example page