### PR TITLE
Add crypt hash and verification functions

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@
 
 OCAMLMAKEFILE = ./OCamlMakefile
 
-PACKS=str deriving unix cgi base64 ANSITerminal linenoise cohttp lwt websocket websocket-lwt.cohttp
+PACKS=str deriving unix cgi base64 ANSITerminal linenoise cohttp lwt websocket websocket-lwt.cohttp safepass
 export OCAMLFLAGS=-syntax camlp4o
 
 PATH := $(PATH):deriving

--- a/lib.ml
+++ b/lib.ml
@@ -1657,7 +1657,19 @@ let env : (string * (located_primitive * Types.datatype * pure)) list = [
     "serveWebsockets",
     (`PFun (fun _ -> assert false),
     datatype "() ~> ()",
-    IMPURE)
+    IMPURE);
+
+    (* Crypt API *)
+
+    "crypt",
+    (`Server (p1 (Value.box_string -<- Bcrypt.string_of_hash -<-  (Bcrypt.hash ?count:None ?seed:None) -<- Value.unbox_string)),
+    datatype "(String) ~> String",
+    PURE);
+
+    "verify",
+    (`Server (p2 (fun str -> Value.box_bool -<- (Bcrypt.verify (Value.unbox_string str)) -<- Bcrypt.hash_of_string -<- Value.unbox_string)),
+    datatype "(String, String) ~> Bool",
+    PURE)
 ]
 
 (* HACK

--- a/opam
+++ b/opam
@@ -70,6 +70,7 @@ depends: [
   "lwt"
   "cohttp"
   "websocket-lwt"
+  "safepass"
 ]
 
 depopts: [

--- a/tests/crypt.tests
+++ b/tests/crypt.tests
@@ -1,0 +1,8 @@
+Crypt accepts correct passwords
+verify("correcthorsebatterystaple", crypt("correcthorsebatterystaple"))
+stdout : true : Bool
+
+Crypt rejects incorrect passwords
+verify("password", crypt("correcthorsebatterystaple"))
+stdout : false : Bool
+


### PR DESCRIPTION
Whenever there is a login or something to build, password really shouldn't end up in the DB in plain text !

This PR adds
- [x] `crypt : (String) ~> String` which hashes a password so it can be safely stored in the database
- [x] `verify : (String, String) ~> Bool` which verifies that a password matches a hash

Please especially check whether there are changes missing for the added dependency.

(Also: What is the correct OCaml way to get rid of the warning `implicit elimination of optional arguments ?count, ?seed` ?)