### PR TITLE
Fixed Issue 35 (use linked lists in JS)

### DIFF
--- a/examples/games/pacman.links
+++ b/examples/games/pacman.links
@@ -3,32 +3,32 @@
 #
 
 fun lsMap(f, l) {
-    if (lsEmpty(l)) lsNilF()
-    else lsCons(f(lsHead(l)), lsMap(f, lsTail(l)))
+    if (empty(l)) []
+    else f(hd(l)) :: lsMap(f, tl(l))
 }
 
 fun lsFilter(p, l) {
-    if (lsEmpty(l)) lsNilF()
-    else if (p(lsHead(l))) lsCons(lsHead(l), lsFilter(p, lsTail(l)))
-    else lsFilter(p, lsTail(l))
+    if (empty(l)) []
+    else if (p(hd(l))) hd(l) :: lsFilter(p, tl(l))
+    else lsFilter(p, tl(l))
 }
 
 fun lsMapIgnore(f, l) {
-    if (lsEmpty(l)) ()
-    else { var _ = f(lsHead(l)); lsMapIgnore(f, lsTail(l)) }
+    if (empty(l)) ()
+    else { var _ = f(hd(l)); lsMapIgnore(f, tl(l)) }
 }
 
 fun lsCatMaybes(l) {
-    if (lsEmpty(l)) lsNilF()
-    else switch (lsHead(l)) {
-        case Just(x) -> lsCons(x, lsCatMaybes(lsTail(l)))
-        case Nothing -> lsCatMaybes(lsTail(l))
+    if (empty(l)) []
+    else switch (hd(l)) {
+        case Just(x) -> x :: lsCatMaybes(tl(l))
+        case Nothing -> lsCatMaybes(tl(l))
     }
 }
 
 fun lsFoldLeft(f, i, l) {
-    if (lsEmpty(l)) i
-    else lsFoldLeft(f, f(i, lsHead(l)), lsTail(l))
+    if (empty(l)) i
+    else lsFoldLeft(f, f(i, hd(l)), tl(l))
 }
 
 #
@@ -244,10 +244,10 @@ typename Timeouts = (eaten: Int, trapped: Int, vulnerable: Int, transition: Int,
 
 typename GameMetaState = [| Run | Download | Restart |];
 typename GameState = [| On | Eaten | Eaten2 | Ate | Over | NextLevel | NextLevel2 | Won |];
-typename Ls = Float; # THIS SHOULDN'T WORK, BUT OH WELL
+typename Pill = (Planet,[(Float,Float,PillType)]);
 typename Game = (pillman: EntityDescription, roger: EntityDescription,
                  johnny: EntityDescription, greg: EntityDescription,
-                 bill: EntityDescription, pills: Ls, pillCount: Int, score: Int,
+                 bill: EntityDescription, pills: [Pill], pillCount: Int, score: Int,
                  lives: Int, level: Int, state: GameState, timeout: Int,
                  timeouts: Timeouts, metaState: GameMetaState);
 
@@ -265,7 +265,7 @@ fun main() {
 
     var initializeProcId = spawnClient {
         # LIST STUFF
-        var lsNil = lsNilF();
+        var lsNil = [];
         
         #
         # CONSTANTS
@@ -358,7 +358,7 @@ fun main() {
         var rightBottomPlanet          = (x = innerRightBottomPlanet.x +. 64.0, y = innerRightBottomPlanet.y, r = smallR );
 
         
-        var planets = ls([
+        var planets = [
             innerLeftTopPlanet        ,
             innerRightTopPlanet       ,
             leftTopPlanet             ,
@@ -386,9 +386,9 @@ fun main() {
             leftBottomPlanet          ,
             rightBottomPlanet         ,
             bottomPlanet
-        ]);
+        ];
 
-        var connections = ls([
+        var connections = [
             (ghostPlanet, innerLeftGhostPlanet),
             (ghostPlanet, innerRightGhostPlanet),
             (innerLeftGhostPlanet, leftGhostPlanet),
@@ -423,51 +423,49 @@ fun main() {
             (innerLeftTopPlanet, topPlanet),
             (innerRightTopPlanet, topPlanet),
             (topPlanet, overGhostPlanet)
-        ]);
+        ];
 
         # pills
         var initialPills = lsMap(fun (x) {
             var rr2 = (x.r +. 5.0 +. margin);
-            if (x == ghostPlanet || x == leftPortal || x == rightPortal) (x, lsNil)
-            else {# if (x == bottomPlanet) {
-                
+            var dummy = (0.0,0.0,Regular);
+            if (x == ghostPlanet || x == leftPortal || x == rightPortal) (x, [])
+            else {
                 var (specialPill, pillRange) =
                     if (x == leftBottomPlanet) {
-                        ((x.x +. rr2 *. sin(-.0.5 *. pi), x.y +. rr2 *. cos(-.0.5 *. pi), Power), lsRange(-4, 15))
+                        ((x.x +. rr2 *. sin(-.0.5 *. pi), x.y +. rr2 *. cos(-.0.5 *. pi), Power), intRange(-4, 15))
                     }
                     else if (x == rightBottomPlanet)
-                        ((x.x +. rr2 *. sin(-.1.5 *. pi), x.y +. rr2 *. cos(-.1.5 *. pi), Power), lsRange(-15, 4))
-    #~              else if (x == bottomPlanet)
-    #~                  ((x.x +. rr2 *. sin(-.1.5 *. pi), x.y +. rr2 *. cos(-.1.5 *. pi), Power), lsRange(-15, 4))
+                        ((x.x +. rr2 *. sin(-.1.5 *. pi), x.y +. rr2 *. cos(-.1.5 *. pi), Power), intRange(-15, 4))
                     else if (x == leftOverGhostPlanet)
-                        ((x.x +. rr2 *. sin(-.0.5 *. pi), x.y +. rr2 *. cos(-.0.5 *. pi), Power), lsRange(-4, 15))
+                        ((x.x +. rr2 *. sin(-.0.5 *. pi), x.y +. rr2 *. cos(-.0.5 *. pi), Power), intRange(-4, 15))
                     else if (x == rightOverGhostPlanet)
-                        ((x.x +. rr2 *. sin(-.1.5 *. pi), x.y +. rr2 *. cos(-.1.5 *. pi), Power), lsRange(-15, 4))
-                    else (lsNil, lsRange(0, 21));
+                        ((x.x +. rr2 *. sin(-.1.5 *. pi), x.y +. rr2 *. cos(-.1.5 *. pi), Power), intRange(-15, 4))
+                    else (dummy, intRange(0, 21));
 
                 var regularPills = lsMap(fun (y) {
                         (x.x +. rr2 *. sin(intToFloat(y) /. 11.0 *. pi),
                             x.y +. rr2 *. cos(intToFloat(y) /. 11.0 *. pi), Regular)
                     }, pillRange);
 
-                (x, if (specialPill == lsNil) regularPills else lsCons(specialPill, regularPills))
-            }# else (x, lsNil) 
+                (x, if (specialPill == dummy) regularPills else specialPill :: regularPills)
+            }
         }, planets);
 
         fun countPills(l, n) {
             fun pillLength(l, n) {
-                if (lsEmpty(l)) n
+                if (empty(l)) n
                 else {
-                    var p = lsHead(l);
-                    if (p.3 == Regular) pillLength(lsTail(l), n + 1)
-                    else pillLength(lsTail(l), n)
+                    var p = hd(l);
+                    if (p.3 == Regular) pillLength(tl(l), n + 1)
+                    else pillLength(tl(l), n)
                 }
             }
         
-            if (lsEmpty(l)) n
+            if (empty(l)) n
             else {
-                var p = lsHead(l);
-                countPills(lsTail(l), n + pillLength(p.2, 0))
+                var p = hd(l);
+                countPills(tl(l), n + pillLength(p.2, 0))
             }
         }
         
@@ -722,7 +720,7 @@ fun main() {
                     var x = intToFloat(x);
                     var pos = (20.0 +. x *. 2.5 *. pillmanR, 90.0);
                     drawPillman((pillmanDescription with position = pos, planet = (x = pos.1, y = pos.2, r = -.10.0)), (gameState with state = On))
-                }, lsRange(0, gameState.lives - 1))
+                }, intRange(0, gameState.lives - 1))
             };
         
             # draw the game area
@@ -930,14 +928,14 @@ fun main() {
 
         # entity manipulation
         fun getNextPlanet(entity, connections) {
-            if (lsEmpty(connections)) entity.planet
+            if (empty(connections)) entity.planet
             else {
-                var x = lsHead(connections);
+                var x = hd(connections);
                 if(lineCircleCollision(((x.1.x, x.1.y), (x.2.x, x.2.y)),
                                         (entity.position, entity.r)))
                     if (entity.planet == x.2) x.1
                     else x.2
-                else getNextPlanet(entity, lsTail(connections))
+                else getNextPlanet(entity, tl(connections))
             }
         }
 
@@ -1027,9 +1025,9 @@ fun main() {
         # eats a pill if possible and updates the game state
         fun getNewPillPlanets(l, headPlanets, gameState) {
             fun getNewPills(l, headPills, gameState) {
-                if (lsEmpty(l)) (gameState, headPills)
+                if (empty(l)) (gameState, headPills)
                 else {
-                    var pill = lsHead(l);
+                    var pill = hd(l);
                     
                     if (circleCircleCollision(((pill.1, pill.2), pillR), (gameState.pillman.position, pillmanR))) {
                         var gameState = switch (pill.3) {
@@ -1046,26 +1044,26 @@ fun main() {
                                         bill = transformGhost(gameState.bill, gameState))
                             case _ -> gameState
                         };
-                        (gameState, lsAppend(headPills, lsTail(l)))
+                        (gameState, headPills ++ tl(l))
                     }
                     else
-                        getNewPills(lsTail(l), lsAppend(headPills, lsCons(pill, lsNil)), gameState)
+                        getNewPills(tl(l), headPills ++ [pill], gameState)
                 }
             }
 
-            if (lsEmpty(l)) gameState
+            if (empty(l)) gameState
             else {
-                var pillPlanet = lsHead(l);
+                var pillPlanet = hd(l);
                 
                 if (gameState.pillman.planet == pillPlanet.1) {
                     var (gameState, newPills) = getNewPills(pillPlanet.2, lsNil, gameState);
-                    var t = ls([(gameState.pillman.planet, newPills)]);
-                    var d = lsAppend(t, lsTail(l));
+                    var t = [(gameState.pillman.planet, newPills)];
+                    var d = t ++ tl(l);
 
-                    (gameState with pills = lsAppend(headPlanets, d))
+                    (gameState with pills = headPlanets ++ d)
                 }
                 else
-                    getNewPillPlanets(lsTail(l), lsAppend(headPlanets, ls([pillPlanet])), gameState)
+                    getNewPillPlanets(tl(l), headPlanets ++ [pillPlanet], gameState)
             }
         }
 
@@ -1231,7 +1229,7 @@ fun main() {
                         );
 
                     # handle pill collisions
-                    var gameState = getNewPillPlanets(gameState.pills, lsNilF(), gameState);
+                    var gameState = getNewPillPlanets(gameState.pills, [], gameState);
 
                     # handle ghost collisions
                     var ghostScore =

--- a/examples/games/tetris.links
+++ b/examples/games/tetris.links
@@ -3,37 +3,37 @@
 #
 
 fun lsMap(f, l) {
-    if (lsEmpty(l)) lsNilF()
-    else lsCons(f(lsHead(l)), lsMap(f, lsTail(l)))
+    if (empty(l)) []
+    else f(hd(l)) :: lsMap(f, tl(l))
 }
 
 fun lsFilter(p, l) {
-    if (lsEmpty(l)) lsNilF()
-    else if (p(lsHead(l))) lsCons(lsHead(l), lsFilter(p, lsTail(l)))
-    else lsFilter(p, lsTail(l))
+    if (empty(l)) []
+    else if (p(hd(l))) hd(l) :: lsFilter(p, tl(l))
+    else lsFilter(p, tl(l))
 }
 
 fun lsMapIgnore(f, l) {
-    if (lsEmpty(l)) ()
-    else { var _ = f(lsHead(l)); lsMapIgnore(f, lsTail(l)) }
+    if (empty(l)) ()
+    else { var _ = f(hd(l)); lsMapIgnore(f, tl(l)) }
 }
 
 fun lsCatMaybes(l) {
-    if (lsEmpty(l)) lsNilF()
-    else switch (lsHead(l)) {
-        case Just(x) -> lsCons(x, lsCatMaybes(lsTail(l)))
-        case Nothing -> lsCatMaybes(lsTail(l))
+    if (empty(l)) []
+    else switch (hd(l)) {
+        case Just(x) -> x :: lsCatMaybes(tl(l))
+        case Nothing -> lsCatMaybes(tl(l))
     }
 }
 
 fun lsFoldLeft(f, i, l) {
-    if (lsEmpty(l)) i
-    else lsFoldLeft(f, f(i, lsHead(l)), lsTail(l))
+    if (empty(l)) i
+    else lsFoldLeft(f, f(i, hd(l)), tl(l))
 }
 
 #~ fun lsReplicate(n, item) {
-#~   if (n == 0) lsNilF()
-#~   else lsCons(item, lsReplicate(n - 1, item))
+#~   if (n == 0) []
+#~   else item ::  lsReplicate(n - 1, item)
 #~ }
 
 #

--- a/irtojs.ml
+++ b/irtojs.ml
@@ -54,6 +54,8 @@ module VEnv = Env.Int
 (** Type of environments mapping IR variables to source variables *)
 type venv = string VEnv.t
 
+let nilLiteral = "[]"
+
 
 (** Continuation parameter name (convention) *)
 let __kappa = "__kappa"
@@ -141,8 +143,8 @@ struct
         | Dict (elems) -> "{" ^ String.concat ", " (List.map (fun (name, value) -> "'" ^  name ^ "':" ^ show value) elems) ^ "}"
         | Arr elems -> 
           let rec show_list = function 
-            | [] ->  "Nil"
-            | x :: xs -> "{_head:" ^ (show x) ^ ",_tail:" ^ (show_list xs) ^ "}" in 
+            | [] ->  Json.nil_literal
+            | x :: xs -> "{\"_head\":" ^ (show x) ^ ",\"_tail\":" ^ (show_list xs) ^ "}" in 
           show_list elems
         | Bind (name, value, body) ->  name ^" = "^ show value ^"; "^ show body
         | Return expr -> "return " ^ (show expr) ^ ";"
@@ -234,8 +236,8 @@ struct
                                   elems)))
         | Arr elems -> 
             let rec show_list = function 
-              | [] -> PP.text "Nil"
-              | x :: xs -> PP.braces (PP.text "_head:" ^+^ (show x) ^^ (PP.text ",") ^|  PP.nest 1 (PP.text "_tail:" ^+^  (show_list xs))) in 
+              | [] -> PP.text Json.nil_literal
+              | x :: xs -> PP.braces (PP.text "\"_head\":" ^+^ (show x) ^^ (PP.text ",") ^|  PP.nest 1 (PP.text "\"_tail\":" ^+^  (show_list xs))) in 
             show_list elems
         | Bind (name, value, body) ->
             PP.text "var" ^+^ PP.text name ^+^ PP.text "=" ^+^ show value ^^ PP.text ";" ^^

--- a/irtojs.ml
+++ b/irtojs.ml
@@ -492,10 +492,10 @@ module Higher_Order_Continuation : CONTINUATION = struct
          | Identity
 
   (* Auxiliary functions for manipulating the continuation stack *)
-  let nil = Var "lsNil"
-  let cons x xs = Call (Var "_lsCons", [x; xs])
-  let head xs = Call (Var "_lsHead", [xs])
-  let tail xs = Call (Var "_lsTail", [xs])
+  let nil = Var "Nil"
+  let cons x xs = Call (Var "_Cons", [x; xs])
+  let head xs = Call (Var "_hd", [xs])
+  let tail xs = Call (Var "_tl", [xs])
   let toplevel = Cons (Var "_idk", Cons (Var "_efferr", Reflect nil))
 
   let reflect x = Reflect x
@@ -550,13 +550,13 @@ module Higher_Order_Continuation : CONTINUATION = struct
 
   let primitive_bindings =
     "function _makeCont(k) {\n" ^
-      "  return _lsCons(k, _lsSingleton(_efferr));\n" ^
+      "  return _Cons(k, _singleton(_efferr));\n" ^
       "}\n" ^
       "var _idy = _makeCont(function(x, ks) { return; }); var _idk = function(x,ks) { };\n" ^
       "var _applyCont = _applyCont_HO; var _yieldCont = _yieldCont_HO;\n" ^
         "var _cont_kind = \"Higher_Order_Continuation\";\n" ^
           "function is_continuation(kappa) {\n" ^
-            "return kappa !== null && typeof kappa === 'object' && _lsHead(kappa) !== undefined && _lsTail(kappa) !== undefined;\n" ^
+            "return kappa !== null && typeof kappa === 'object' && _hd(kappa) !== undefined && _tl(kappa) !== undefined;\n" ^
               "}"
 
   let contify_with_env fn =
@@ -929,9 +929,9 @@ end = functor (K : CONTINUATION) -> struct
            Dict (List.mapi (fun i v -> (string_of_int @@ i + 1, gv v)) vs)
          in
          let cons k ks =
-           Call (Var "_lsCons", [k;ks])
+           Call (Var "_Cons", [k;ks])
          in
-         let nil = Var "lsNil" in
+         let nil = Var "Nil" in
          K.bind kappa
            (fun kappas ->
              let bind_skappa, skappa, kappas = K.pop kappas in
@@ -994,9 +994,9 @@ end = functor (K : CONTINUATION) -> struct
                  let bind2, h', ks' = K.pop ks' in
                  let bind code = bind1 (bind2 code) in
                  let resumption =
-                   Fn (["s"], Return (Call (Var "_lsCons",
+                   Fn (["s"], Return (Call (Var "_Cons",
                                             [K.reify h';
-                                             Call (Var "_lsCons", [K.reify k'; Var "s"])])))
+                                             Call (Var "_Cons", [K.reify k'; Var "s"])])))
                  in
                  let vmap = Call (Var "_vmapOp", [resumption; Var z_name]) in
                  bind (apply_yielding (K.reify h') [vmap] ks'))

--- a/irtojs.ml
+++ b/irtojs.ml
@@ -114,6 +114,7 @@ struct
         StringMap.fold (fun l c s ->
                           s ^ show_case v l c)
           cases "" in
+    
     let show_default v = opt_app
       (fun (x, e) ->
          "default:{var " ^ x ^ "=" ^ v ^ ";" ^ show e ^ ";" ^ "break;}") "" in
@@ -138,7 +139,11 @@ struct
         | Case (v, cases, default) ->
             "switch (" ^ v ^ "._label) {" ^ show_cases v cases ^ show_default v default ^ "}"
         | Dict (elems) -> "{" ^ String.concat ", " (List.map (fun (name, value) -> "'" ^  name ^ "':" ^ show value) elems) ^ "}"
-        | Arr elems -> "[" ^ arglist elems ^ "]"
+        | Arr elems -> 
+          let rec show_list = function 
+            | [] ->  "Nil"
+            | x :: xs -> "{_head:" ^ (show x) ^ ",_tail:" ^ (show_list xs) ^ "}" in 
+          show_list elems
         | Bind (name, value, body) ->  name ^" = "^ show value ^"; "^ show body
         | Return expr -> "return " ^ (show expr) ^ ";"
         | Nothing -> ""
@@ -227,7 +232,11 @@ struct
                                        group (PP.text "'" ^^ PP.text name ^^
                                                 PP.text "':" ^^ show value))
                                   elems)))
-        | Arr elems -> brackets(hsep(punctuate "," (List.map show elems)))
+        | Arr elems -> 
+            let rec show_list = function 
+              | [] -> PP.text "Nil"
+              | x :: xs -> PP.braces (PP.text "_head:" ^+^ (show x) ^^ (PP.text ",") ^|  PP.nest 1 (PP.text "_tail:" ^+^  (show_list xs))) in 
+            show_list elems
         | Bind (name, value, body) ->
             PP.text "var" ^+^ PP.text name ^+^ PP.text "=" ^+^ show value ^^ PP.text ";" ^^
               break ^^ show body

--- a/irtojs.ml
+++ b/irtojs.ml
@@ -54,7 +54,6 @@ module VEnv = Env.Int
 (** Type of environments mapping IR variables to source variables *)
 type venv = string VEnv.t
 
-let nilLiteral = "[]"
 
 
 (** Continuation parameter name (convention) *)

--- a/irtojs.ml
+++ b/irtojs.ml
@@ -128,8 +128,8 @@ struct
         | LetRec (defs, rest) ->
             String.concat ";\n" (List.map (fun (name, vars, body, _loc) -> show_func name (Fn (vars, body))) defs) ^ show rest
         | Call (Var "LINKS.project", [record; label]) -> (paren record) ^ "[" ^ show label ^ "]"
-        | Call (Var "hd", [list;kappa]) -> Printf.sprintf "%s(%s[0])" (paren kappa) (paren list)
-        | Call (Var "tl", [list;kappa]) -> Printf.sprintf "%s(%s.slice(1))" (paren kappa) (paren list)
+        | Call (Var "hd", [list;kappa]) -> Printf.sprintf "%s(hd(%s))" (paren kappa) (paren list)
+        | Call (Var "tl", [list;kappa]) -> Printf.sprintf "%s(tl(%s)" (paren kappa) (paren list)
         | Call (Var "_yield", fn :: args) -> Printf.sprintf "_yield(function() { %s(%s) })" (paren fn) (arglist args)
         | Call (fn, args) -> paren fn ^ "(" ^ arglist args  ^ ")"
         | Unop (op, body) -> op ^ paren body
@@ -205,10 +205,10 @@ struct
         | Fn _ as f -> show_func "" f
         | Call (Var "LINKS.project", [record; label]) ->
             maybe_parenise record ^^ (brackets (show label))
-        | Call (Var "hd", [list;kappa]) ->
-            (maybe_parenise kappa) ^^ (parens (maybe_parenise list ^^ PP.text "[0]"))
-        | Call (Var "tl", [list;kappa]) ->
-            (maybe_parenise kappa) ^^ (parens (maybe_parenise list ^^ PP.text ".slice(1)"))
+        | Call (Var "hd", [list;kappa]) -> 
+            (maybe_parenise kappa) ^^ PP.text "hd" ^^ (parens (  maybe_parenise list))
+        | Call (Var "tl", [list;kappa]) -> 
+            (maybe_parenise kappa) ^^ PP.text "tl" ^^ (parens (  maybe_parenise list))
         | Call (Var "_yield", (fn :: args)) ->
             PP.text "_yield" ^^ (parens (PP.text "function () { " ^^ maybe_parenise fn ^^
                                     parens (hsep(punctuate "," (List.map show args))) ^^ PP.text " }"))

--- a/json.ml
+++ b/json.ml
@@ -17,9 +17,7 @@ let parse_json str =
 
 let parse_json_b64 str = parse_json(Utility.base64decode str)
 
-let rec string_listify : string list -> string = function
-  | [] -> "Nil"
-  | x::xs -> Printf.sprintf "{_head:%s, _tail:%s}" x (string_listify xs)
+let nil_literal = "[]"
 
 (* Helper functions for jsonization *)
 (*
@@ -96,7 +94,11 @@ let rec jsonize_value' : Value.t -> json_string =
       "{" ^
         mapstrcat "," (fun (kj, s) -> "\"" ^ kj ^ "\":" ^ s) (List.combine ls ss)
       ^ "}"
-  | `List l -> string_listify (List.map jsonize_value' l)
+  | `List l -> 
+    let rec string_listify : string list -> string = function
+    | [] -> nil_literal
+    | x::xs -> Printf.sprintf "{\"_head\":%s, \"_tail\":%s}" x (string_listify xs) in
+    string_listify (List.map jsonize_value' l)
   | `AccessPointID (`ClientAccessPoint (cid, apid)) ->
       "{\"_clientAPID\": " ^ (AccessPointID.to_json apid) ^
       ", \"_clientId\":" ^ (ClientID.to_json cid) ^  "}"

--- a/json.ml
+++ b/json.ml
@@ -183,7 +183,7 @@ let show_handlers evt_handlers =
        JS Array. This Array is supposed to be processes  by jslib code only*)
     let jsonize_to_array_if_list = function
       | `List elems -> "["^ String.concat "," (List.map jsonize_value' elems) ^ "]"
-      | other ->  jsonize_value' proc in
+      | _ ->  jsonize_value' proc in
     "{\"key\": " ^ string_of_int key ^ "," ^
     " \"eventHandlers\":" ^ jsonize_to_array_if_list proc ^ "}" in
   let bnds = IntMap.bindings evt_handlers in

--- a/json.ml
+++ b/json.ml
@@ -17,7 +17,7 @@ let parse_json str =
 
 let parse_json_b64 str = parse_json(Utility.base64decode str)
 
-let nil_literal = "[]"
+let nil_literal = "null"
 
 (* Helper functions for jsonization *)
 (*

--- a/json.ml
+++ b/json.ml
@@ -17,6 +17,9 @@ let parse_json str =
 
 let parse_json_b64 str = parse_json(Utility.base64decode str)
 
+let rec string_listify : string list -> string = function
+  | [] -> "Nil"
+  | x::xs -> Printf.sprintf "{_head:%s, _tail:%s}" x (string_listify xs)
 
 (* Helper functions for jsonization *)
 (*
@@ -93,10 +96,7 @@ let rec jsonize_value' : Value.t -> json_string =
       "{" ^
         mapstrcat "," (fun (kj, s) -> "\"" ^ kj ^ "\":" ^ s) (List.combine ls ss)
       ^ "}"
-  | `List [] -> "[]"
-  | `List (elems) ->
-    let ss = jsonize_values elems in
-      "[" ^ String.concat "," ss ^ "]"
+  | `List l -> string_listify (List.map jsonize_value' l)
   | `AccessPointID (`ClientAccessPoint (cid, apid)) ->
       "{\"_clientAPID\": " ^ (AccessPointID.to_json apid) ^
       ", \"_clientId\":" ^ (ClientID.to_json cid) ^  "}"
@@ -167,19 +167,23 @@ let show_processes procs =
   (* Show the JSON for a prcess, including the PID, process to be run, and mailbox *)
   let show_process (pid, (proc, msgs)) =
     let ps = jsonize_value' proc in
-    let ms = jsonize_value' (`List msgs) in
+    let ms = String.concat "," (List.map jsonize_value' msgs) in
     "{\"pid\":" ^ (ProcessID.to_json pid) ^ "," ^
     " \"process\":" ^ ps ^ "," ^
-    " \"messages\":" ^ ms ^ "}" in
+    " \"messages\": [" ^ ms ^ "]}" in
   let bnds = PidMap.bindings procs in
   String.concat "," (List.map show_process bnds)
 
 let show_handlers evt_handlers =
-  (* Show the JSON for an event handler: the evt handler key, and the associated process *)
+  (* Show the JSON for an event handler: the evt handler key, and the associated process(es) *)
   let show_evt_handler (key, proc) =
-    let h_proc_json = jsonize_value' proc in
+    (* If the list of processes handling each key is represented by a 'List term, we translate it to a 
+       JS Array. This Array is supposed to be processes  by jslib code only*)
+    let jsonize_to_array_if_list = function
+      | `List elems -> "["^ String.concat "," (List.map jsonize_value' elems) ^ "]"
+      | other ->  jsonize_value' proc in
     "{\"key\": " ^ string_of_int key ^ "," ^
-    " \"eventHandlers\":" ^ h_proc_json ^ "}" in
+    " \"eventHandlers\":" ^ jsonize_to_array_if_list proc ^ "}" in
   let bnds = IntMap.bindings evt_handlers in
   String.concat "," (List.map show_evt_handler bnds)
 

--- a/json.mli
+++ b/json.mli
@@ -29,6 +29,7 @@ end
 type json_state = JsonState.t
 
 (* Parsing *)
+val nil_literal : string
 
 (** Parses a JSON string into a value *)
 val parse_json : json_string -> Value.t

--- a/jsonparse.mly
+++ b/jsonparse.mly
@@ -243,7 +243,7 @@ value:
 | array                              { $1 }
 | TRUE                               { `Bool true }
 | FALSE                              { `Bool false }
-| NULL                               { `Record [] (* Or an error? *) }
+| NULL                               { `List [] }
 
 string:
 | STRING                             { Value.box_string $1 }

--- a/jsonparse.mly
+++ b/jsonparse.mly
@@ -100,6 +100,7 @@ object_:
 | LBRACE RBRACE         { `Record [] }
 | LBRACE members RBRACE { match $2 with
                             | ["_c", c] -> Value.box_char ((Value.unbox_string c).[0])
+                            | ["_tail", xs; "_head", x] -> `List (x :: (Value.unbox_list xs))
                             | ["_label", l; "_value", v]
                             | ["_value", v; "_label", l] ->
                                 Value.box_variant (Value.unbox_string l) v
@@ -229,8 +230,7 @@ members:
 | members COMMA id  COLON value      { ($3, $5) :: $1 }
 
 array:
-| LBRACKET RBRACKET                  { `List ([]) }
-| LBRACKET elements RBRACKET         { `List (List.rev $2) }
+| LBRACKET RBRACKET                  { `List ([]) (* For now, we denote Nil as [] *) }
 
 elements:
 | value                              { [$1] }

--- a/lib.ml
+++ b/lib.ml
@@ -1482,65 +1482,6 @@ let env : (string * (located_primitive * Types.datatype * pure)) list = [
 
 	(* END OF DEBUGGING FUNCTIONS *)
 
-	(* FOR MANIPULATING LISTS *)
-
-	"lsTake",
-	(`Client, datatype "(Int, a) -> a", PURE);
-
-	"lsDrop",
-	(`Client, datatype "(Int, a) -> a", PURE);
-
-	(* 1 *)
-
-	"lsLength",
-	(`Client, datatype "(a) -> Int", PURE);
-
-	"lsHead",
-	(`Client, datatype "(a) -> b", PURE);
-
-	"lsTail",
-	(`Client, datatype "(a) -> a", PURE);
-
-	"lsLast",
-	(`Client, datatype "(a) -> b", PURE);
-
-
-	"lsNilF",
-	(`Client, datatype "() -> a", PURE);
-
-	"lsCons",
-	(`Client, datatype "(a, b) -> c", PURE);
-
-	"lsAt",
-	(`Client, datatype "(a, Int) -> c", PURE);
-
-	"lsEmpty",
-	(`Client, datatype "(a) -> Bool", PURE);
-
-	"lsZip",
-	(`Client, datatype "(a, b) -> c", PURE);
-(*
-	"lsMap",
-	(`Client, datatype "((a) -b-> c, d) -b-> e", IMPURE);
-
-	"lsFilter",
-	(`Client, datatype "((a) -> Bool, b) -> b", PURE);
-
-	"lsMapIgnore",
-	(`Client, datatype "((a) -b-> c, d) -b-> ()", IMPURE);
-*)
-	(*("map", datatype "((a) -b-> c, [a]) -b-> [c]");  *)
-
-	"lsAppend",
-	(`Client, datatype "(a, a) -> a", PURE);
-
-	"lsRange",
-	(`Client, datatype "(Int, Int) -> a", PURE);
-
-	"ls",
-	(`Client, datatype "([a]) -> b", PURE);
-
-	(* END OF LIST MANIPULATING FUNCTIONS *)
 
 	(* EQUALITY *)
 

--- a/lib/js/jslib.js
+++ b/lib/js/jslib.js
@@ -5,13 +5,12 @@ const LINKEDLIST =  new function(){
   
   return Object.freeze({
 
-    //Constant representing the Nil Object
-    //the JS constructor goes out of scope after this, so we can construct just one
-    //This allows us to see a difference between undefined/null and the empty list
-    Nil: "nil",//;new NilConstructor(),
+    //Using [] here for easier parsing (if we used e.g. a string, JSON parsing would become ambiguous)
+    Nil: [],
+
+    //Use this to check if something is Nil (using == or === may fail, since we have e.g. that  [] === [] is false in JavaScript)
+    isNil: function(n) {return n !== undefined && Array.isArray(n) && n.length === 0},
   
-    //Not a JS constructor, but a function calling it 
-    //(i.e., it behaves like one excepts when calling "Cons(x,xs)")
     Cons: function(x,xs) {DEBUG.assert(LINKEDLIST.isLinkedList(xs), "Second argument must be linked list"); return {_head: x, _tail: xs}},
 
 
@@ -20,7 +19,7 @@ const LINKEDLIST =  new function(){
      * but this would return false for objects created for deserialized objects
      */
     isLinkedList: function(v) {
-      return v === Nil 
+      return LINKEDLIST.isNil(v)
         || v.hasOwnProperty("_head") && v.hasOwnProperty("_tail");
         //could test list-property recursively, but seems overly expensive
         //&& LINKEDLIST.isLinkedList(v._tail) 
@@ -28,7 +27,7 @@ const LINKEDLIST =  new function(){
     },
 
     forEach: function(list, f) {
-      while(list != Nil) {
+      while(!LINKEDLIST.isNil(list)) {
         var cur = list._head;
         f(cur);
         list = list._tail;
@@ -38,7 +37,7 @@ const LINKEDLIST =  new function(){
     toArray: function(list) {
       var res = [];
       var cur = list;
-      while(cur !== Nil) {
+      while(!LINKEDLIST.isNil(cur)) {
         res.push(cur._head);
         cur = cur._tail;
       }
@@ -62,7 +61,7 @@ const LINKEDLIST =  new function(){
 
     take: function (n, xs) {
       var arr = [ ];
-      while (xs !== Nil && n > 0) {
+      while (!LINKEDLIST.isNil(xs) && n > 0) {
         arr.push(xs._head);
         xs = xs._tail;
         --n;
@@ -71,7 +70,7 @@ const LINKEDLIST =  new function(){
     },
 
     drop: function(n, xs) {
-      while (xs !== Nil && n > 0) {
+      while (!LINKEDLIST.isNil(xs) && n > 0) {
         xs = xs._tail;
         --n;
       }
@@ -80,7 +79,7 @@ const LINKEDLIST =  new function(){
 
     length: function (xs) {
       var out = 0;
-      while (xs !== Nil) {
+      while (!LINKEDLIST.isNil(xs)) {
         out += 1;
         xs = xs._tail;
       }
@@ -89,20 +88,20 @@ const LINKEDLIST =  new function(){
 
     head: function(v) {
       DEBUG.assert(TYPES.isLinkedList(v), "Not a linked list"); 
-      return v === Nil ? _error('head') : v._head; 
+      return LINKEDLIST.isNil(v) ? _error('head') : v._head; 
       }, 
 
     tail: function(v) {
       DEBUG.assert(TYPES.isLinkedList(v), "Not a linked list"); 
-      return v === Nil ? _error('tail') : v._tail; 
+      return LINKEDLIST.isNil(v) ? _error('tail') : v._tail; 
       },
 
     last: function(xs) {
-      if (xs === Nil) {
+      if (LINKEDLIST.isNil(xs)) {
         return _error('last');
       }
       var out = xs._head;
-      while (xs !== Nil) {
+      while (!LINKEDLIST.isNil(xs)) {
         out = xs._head;
         xs = xs._tail;
       }
@@ -111,7 +110,7 @@ const LINKEDLIST =  new function(){
 
       revAppend: function(xs, ys) {
         var out = ys;
-        while (xs !== Nil) {
+        while (!LINKEDLIST.isNil(xs)) {
           out = LINKEDLIST.Cons(head(xs), out);
           xs = LINKEDLIST.tail(xs);
         }
@@ -120,14 +119,14 @@ const LINKEDLIST =  new function(){
 
     append: function(xs, ys) {
       DEBUG.assert(TYPES.isLinkedList(xs) && TYPES.isLinkedList(ys), "Not linked lists"); 
-      if (xs === Nil) {
+      if (LINKEDLIST.isNil(xs)) {
         return ys;
       }
       const origxs = xs;
       const rootEl = _Cons(xs._head, Nil);
       let curr = rootEl;
       xs = xs._tail;
-      while (xs !== Nil) {
+      while (!LINKEDLIST.isNil(xs)) {
         curr._tail = _Cons(xs._head, Nil);
         xs = xs._tail;
         curr = curr._tail;
@@ -138,7 +137,7 @@ const LINKEDLIST =  new function(){
 
     at: function(xs, i) {
       var out;
-      while (xs !== Nil && i >= 0) {
+      while (!LINKEDLIST.isNil(xs) && i >= 0) {
         out = xs._head;
         xs = xs._tail;
         --i;
@@ -148,12 +147,12 @@ const LINKEDLIST =  new function(){
     },
 
     empty: function(xs) {
-      return xs === Nil;
+      return LINKEDLIST.isNil(xs);
     },
 
     zip: function(xs, ys) {
       var arr = [ ];
-      while (xs !== Nil && ys !== Nil) {
+      while (!LINKEDLIST.isNil(xs) && !LINKEDLIST.isNil(ys)) {
         arr.push({ "1": xs._head, "2": ys._head }); // { ctor:"_Tuple2", _0:x, _1:y }
         xs = xs._tail;
         ys = ys._tail;
@@ -202,7 +201,7 @@ const LINKEDLIST =  new function(){
 
     min: function(xs) {
       var currentMin = LINKEDLIST.head(xs);
-      while (xs !== Nil) {
+      while (!LINKEDLIST.isNil(xs)) {
         if (xs._head < currentMin) currentMin = xs._head;
         xs = xs._tail;
       }
@@ -211,7 +210,7 @@ const LINKEDLIST =  new function(){
 
     max: function(xs) {
       var currentMax = LINKEDLIST.head(xs);
-      while (xs !== Nil) {
+      while (!LINKEDLIST.isNil(xs)) {
         if (xs._head > currentMax) currentMax = xs._head;
         xs = xs._tail;
       }
@@ -1375,12 +1374,9 @@ var stringToFloat = LINKS.kify(_stringToFloat);
 function _not(x) { return !x; } // should be inlined
 var _Concat = LINKEDLIST.append;
 var _Cons = LINKEDLIST.Cons;
-
-
 var _empty = LINKEDLIST.empty;
 var _hd = LINKEDLIST.head;
 var _tl = LINKEDLIST.tail;
-
 var _length = LINKEDLIST.length;
 var _take = LINKEDLIST.take;
 var _drop = LINKEDLIST.drop;
@@ -1390,7 +1386,6 @@ var _min = LINKEDLIST.min;
 
 
 var not    = LINKS.kify(_not);
-
 var Nil    = LINKEDLIST.Nil;
 var Cons   = LINKS.kify(LINKEDLIST.Cons);
 var Concat = LINKS.kify(LINKEDLIST.Concat);

--- a/lib/js/jslib.js
+++ b/lib/js/jslib.js
@@ -31,6 +31,28 @@ const LINKEDLIST =  new function(){
       }
     },
 
+    map: function(list, f) {
+      var cur = LINKEDLIST.singleton(null);
+      var res = cur;
+      while(!LINKEDLIST.isNil(list)) {
+        cur._tail = LINKEDLIST.Cons(f(list._head),Nil);
+        cur = cur.tail;
+        list = list._tail;
+      }
+      return res._tail;
+    },
+
+    mapFromArray: function(array, f) {
+      var cur = LINKEDLIST.singleton(null);
+      var res = cur;
+      for(var i = 0; i < array.length; i++) {
+        cur._tail = LINKEDLIST.Cons(f(array[i]),Nil);
+        cur = cur.tail;
+        list = list._tail;
+      }
+      return res._tail;
+    },
+
     toArray: function(list) {
       var res = [];
       var cur = list;
@@ -81,6 +103,19 @@ const LINKEDLIST =  new function(){
         xs = xs._tail;
       }
       return out;
+    },
+
+    equal: function(l,r) {
+      var curL = l;
+      var curR = r;
+      while(!LINKEDLIST.isNil(curL) && !LINKEDLIST.isNil(curR)) {
+        if(!LINKS.eqal(curL._head,curR._head))
+          return false;
+        curL = curL._tail;
+        curR = curR._tail;
+
+      }
+      return LINKEDLIST.isNil(curL) && LINKEDLIST.isNil(curR)
     },
 
     head: function(v) {
@@ -176,7 +211,7 @@ const LINKEDLIST =  new function(){
       return out;
     },
 
-    // faster than _lsReplicate? not really?
+    // faster than _replicate? not really?
     repeat: function(n, x) {
       var arr = [ ];
       var pattern = [ x ];
@@ -1322,6 +1357,12 @@ const LINKS = new (function() {
 
       return true;
     }
+    if (TYPES.isLinkedList(l) && l != null &&
+        TYPES.isLinkedList(r) && r != null) {
+      return LINKEDLIST.equal(l,r)
+
+    return true;
+  }
     else if(typeof(l) == 'object' && l != undefined && l != null &&
             typeof(r) == 'object' && r != undefined && r != null) {
       if(l.constructor != r.constructor)
@@ -1382,6 +1423,7 @@ var _take = LINKEDLIST.take;
 var _drop = LINKEDLIST.drop;
 var _max = LINKEDLIST.max;
 var _min = LINKEDLIST.min;
+var _singleton = LINKEDLIST.singleton;
 
 
 
@@ -1816,28 +1858,28 @@ var domReplaceChildren = LINKS.kify(_domReplaceChildren);
 
 // for server generated event handlers
 function _registerMobileEventHandlers(key, handlers) {
-  for (var i = 0; i < handlers.length; i++) {
-    var event = handlers[i][1];
-    var handler =_wrapEventHandler(handlers[i][2]);
+  LINKEDLIST.forEach(handlers, function(h){
+    var event = h[1];
+    var handler =_wrapEventHandler(h[2]);
     if (!_eventHandlers[key]) {
       _eventHandlers[key] = {};
     }
     _eventHandlers[key][event] = handler;
-  }
+  });
   return key;
 }
 
 function _registerEventHandlers(handlers) {
   var key = '_key' + _get_fresh_node_key();
 
-  for (var i = 0; i < handlers.length; i++) {
-    var event = handlers[i][1];
-    var handler = _wrapEventHandler(handlers[i][2]);
+  LINKEDLIST.forEach(handlers, function(h) {
+    var event = h[1];
+    var handler = _wrapEventHandler(h[2]);
     if (!_eventHandlers[key]) {
       _eventHandlers[key] = {};
     }
     _eventHandlers[key][event] = handler;
-  }
+  });
   return key;
 }
 
@@ -1957,11 +1999,11 @@ function _isXmlItem(obj) {
 }
 
 function _isXml(obj) {
-  if (!TYPES.isArray(obj)) return false;
-  for (i in obj) {
-    if (!_isXmlItem(obj[i]))
-      return false;
-  }
+  if (!TYPES.isLinkedList(obj)) return false;
+  var childrenOkay = true;
+  LINKEDLIST.forEach(obj, function(c) {
+    childrenOkay &= _isXmlItem(c);
+  });
 }
 
 function _stringToXml(s) {
@@ -1985,74 +2027,82 @@ var floatToXml = LINKS.kify(_floatToXml);
 
 
 function _getTagName(xml) {
-  if (xml[0].type !== "ELEMENT") {
+  var first = LINKEDLIST.head(xml);
+  if (first.type !== "ELEMENT") {
     throw new Error("getTagName() applied to non-element node");
   }
-  return xml[0].tagName;
+  return first.tagName;
 }
 
 function _getNamespace (xml) {
-  if (xml[0].type !== 'ELEMENT') {
+  var first = LINKEDLIST.head(xml);
+  if (first.type !== 'ELEMENT') {
     throw new Error('getNameSpace applied to non-element node');
   }
-  return xml[0].namespace || '';
+  return first.namespace || '';
 }
 
 function _getChildNodes(xml) {
-  if (xml[0].type !== "ELEMENT") {
+  var first = LINKEDLIST.head(xml);
+  if (first.type !== "ELEMENT") {
     throw new Error("getChildNodes() applied to non-element node");
   }
-  return xml[0].children || [ ];
+  return first.children || [ ];
 }
 
 function _getTextContent(xml) {
-  if (xml[0].type !== "TEXT") {
+  var first = LINKEDLIST.head(xml);
+  if (first.type !== "TEXT") {
     throw new Error("getTextContent() applied to non-text node");
   }
-  return xml[0].text || '';
+  return first.text || '';
 }
 
 function _getAttributes(xml) {
-  if (xml[0].type !== "ELEMENT") {
+  var first = LINKEDLIST.head(xml);
+  if (first.type !== "ELEMENT") {
     throw new Error("getAttributes() applied to non-element node");
   }
 
-  return Object.keys(xml[0].attrs).map(function (key) {
+  return Object.keys(first.attrs).map(function (key) {
     return {
       1: key,
-      2: xml[0].attrs[key],
+      2: first.attrs[key],
     };
   });
 }
 
 function _hasAttribute(xml, attrName) {
-  if (xml[0].type !== "ELEMENT") {
+  var first = LINKEDLIST.head(xml);
+  if (first.type !== "ELEMENT") {
     throw new Error("hasAttribute() applied to non-element node");
   }
 
-  return Boolean(xml[0].attrs[attrName]);
+  return Boolean(first.attrs[attrName]);
 }
 
 function _getAttribute(xml, attrName) {
-  if (xml[0].type !== "ELEMENT") {
+  var first = LINKEDLIST.head(xml);
+  if (first.type !== "ELEMENT") {
     throw new Error("getAttribute() applied to non-element node");
   }
-  return xml[0].attrs[attrName];
+  return first.attrs[attrName];
 }
 
 // addAttributes : (Xml, [(String, String)]) -> Xml
 function _addAttributes(xml, attrs) {
-  if(xml[0].type != "ELEMENT") {
+  var first = LINKEDLIST.head(xml);
+  if(first.type != "ELEMENT") {
     throw new Error("addAttributes() applied to non-element node");
   }
 
-  const xmlItem = JSON.parse(JSON.stringify(xml[0]));
+  const xmlItem = JSON.parse(JSON.stringify(first));
 
   for (let attr in attrs) {
     xmlItem.attrs[attr] = attrs[attr];
   }
 
-  return [ xmlItem ];
+  return LINKEDLIST.singleton( xmlItem );
 }
 
 const getTagName = LINKS.kify(_getTagName);
@@ -2158,9 +2208,10 @@ function _focus() {
 //    Replace the current page with `tree'.
 function _replaceDocument(tree) {
   DEBUG.assert(tree != null, "No argument given to _replaceDocument");
-  DEBUG.assert(tree[0] != null, "Null tree passed to _replaceDocument");
+  var firstChild = LINKEDLIST.head(tree);
+  DEBUG.assert(firstChild != null, "Null tree passed to _replaceDocument");
   DEBUG.assert(
-    tree[0].type === "ELEMENT",
+    firstChild.type === "ELEMENT",
     "New document value was not an XML element (it was non-XML or was an XML text node)."
   );
   tree = LINKS.XmlToDomNodes(tree);
@@ -2322,7 +2373,7 @@ function _efferr(z, ks) { return _error("Unhandled operation `" + z._label + "'.
 
 function _makeFun (s) {
   return function (x, ks) {
-    return _yieldCont(_lsRevAppend(s, ks), x);
+    return _yieldCont(LINKEDLIST.revAppend(s, ks), x);
   }
 }
 
@@ -3181,8 +3232,8 @@ function _yieldCont_Default(k, arg) {
 function _applyCont_Default(k, arg) { return k(arg); }
 
 function _yieldCont_HO(ks, arg) {
-  var k = _lsHead(ks);
-  var ks = _lsTail(ks);
+  var k = _hd(ks);
+  var ks = _tl(ks);
   ++_yieldCount;
   if (_yieldCount == _yieldGranularity) {
     _yieldCount = 0;
@@ -3198,8 +3249,8 @@ function _yieldCont_HO(ks, arg) {
 }
 
 function _applyCont_HO(ks, arg) {
-  var k = _lsHead(ks);
-  var ks = _lsTail(ks);
+  var k = _hd(ks);
+  var ks = _tl(ks);
 
   return k(arg, ks);
 }
@@ -3838,7 +3889,7 @@ const variantToXml = LINKS.kify(_variantToXml);
 /**
  * Converts a single XmlItem to its variant type equivalent
  *
- * @param {{ namespace?: string, tagName?: string, text?: string, attrs?: Object, children?: any[] }} xmlItem
+ * @param {{ namespace?: string, tagName?: string, text?: string, attrs?: Object, children?: linked list }} xmlItem
  * @returns {{ _label: string, _value: Object }}
  */
 function _xmlItemToVariant (xmlItem) {
@@ -3851,7 +3902,7 @@ function _xmlItemToVariant (xmlItem) {
       xmlItem.tagName && xmlItem.children && xmlItem.attrs,
       'Malformed element passed to xmlItemToVariant'
     );
-    const attrs = Object.keys(xmlItem.attrs).map(function (name) {
+    const attrs = LINKEDLIST.mapFromArray(Object.keys(xmlItem.attrs),function (name) {
       const splitIndex = name.indexOf(':');
       if (splitIndex > -1) {
         const ns = name.slice(0, splitIndex);
@@ -3875,7 +3926,7 @@ function _xmlItemToVariant (xmlItem) {
       }
     });
 
-    const children = xmlItem.children.map(_xmlItemToVariant);
+    const children = LINKEDLIST.map(xmlItem.children,_xmlItemToVariant);
 
     if (xmlItem.namespace) {
       return {
@@ -3883,7 +3934,7 @@ function _xmlItemToVariant (xmlItem) {
         '_value': {
           1: xmlItem.namespace,
           2: xmlItem.tagName,
-          3: attrs.concat(children),
+          3: LINKEDLIST.append(attrs,children),
         }
       };
     } else {
@@ -3891,7 +3942,7 @@ function _xmlItemToVariant (xmlItem) {
         '_label': 'Node',
         '_value': {
           1: xmlItem.tagName,
-          2: attrs.concat(children),
+          2: LINKEDLIST.append(attrs,children),
         }
       };
     }
@@ -3917,11 +3968,12 @@ function _variantToXmlItem (variant) {
 
   const attrs = {};
 
+  var valueAsArray = LINKEDLIST.toArray(variant['_value']);
   if (variant['_label'] === 'Node' || variant['_label'] === 'NsNode') {
-    variant['_value'][2]
+    valueAsArray[2]
       .filter(function (c) { return (c['_label'] === 'Attr'); })
       .forEach(function (a) { attrs[a['_value'][1]] = a['_value'][2]; return; });
-    variant['_value'][2]
+      valueAsArray[2]
       .filter(function (c) { return (c['_label'] === 'NsAttr'); })
       .forEach(function (a) { attrs[a['_value'][1] + ':' + a['_value'][2]] = a['_value'][3]; return; });
   }
@@ -3930,26 +3982,24 @@ function _variantToXmlItem (variant) {
     case 'Text':
       return {
         type: 'TEXT',
-        text: variant['_value'][1],
+        text: valueAsArray[1],
       };
     case 'Node':
       return {
         type: 'ELEMENT',
-        tagName: variant['_value'][1],
+        tagName: valueAsArray[1],
         attrs: attrs,
-        children: variant['_value'][2]
-          .filter(function (c) { return (c['_label'] === 'Node' || c['_label'] === 'NsNode'); })
-          .map(_variantToXmlItem),
+        children: 
+        LINKEDLIST.map(LINKEDLIST.filter(valueAsArray[2],function (c) { return (c['_label'] === 'Node' || c['_label'] === 'NsNode'); }),_variantToXmlItem)
       };
     case 'NsNode':
       return {
         type: 'ELEMENT',
-        namespace: variant['_value'][1],
-        tagName: variant['_value'][2],
+        namespace: valueAsArray[1],
+        tagName: valueAsArray[2],
         attrs: attrs,
-        children: variant['_value'][2]
-          .filter(function (c) { return (c['_label'] === 'Node' || c['_label'] === 'NsNode'); })
-          .map(_variantToXmlItem),
+        children: 
+        LINKEDLIST.map(LINKEDLIST.filter(valueAsArray[2],function (c) { return (c['_label'] === 'Node' || c['_label'] === 'NsNode');}),_variantToXmlItem)
       };
     case 'Attr':
     case 'NsAttr':

--- a/lib/js/jslib.js
+++ b/lib/js/jslib.js
@@ -2,188 +2,241 @@
 
 /* LIST MANIPULATING FUNCTIONS */
 const LINKEDLIST =  new function(){
-  var LL = {};
   
-   LL.Nil =  "Nil";
+  //Common prototype Object for linked lists
+  var LinkedList = function()  {}
 
-   LL.nilF =  function() { return Nil; };
-
-   LL.Cons = function(head, tail) { return { _head: head, _tail: tail }; };
-
-   LL.snoc = function(xs, x) { return LL.append(xs, singleton(x)); };
-
-   LL.singleton = function(head) { return { _head: head, _tail: Nil }; };
-
-   LL.isList = function(v) {
-    return v == Nil || (v[_head] != undefined && v[_tail] != undefined)
-  };
-
-  LL.forEach = function(list, f) {
-    while(list != Nil) {
-      var cur = list._head;
-      f(cur);
-      list = list._tail;
-    }
-  };
-
-  LL.lsFromArray = function(arr) {
-    var out = Nil;
-    for (let i = arr.length - 1; i >= 0; --i) {
-      out = LL.Cons(arr[i], out);
-    }
-    return out;
-  };
-
-  LL.take = function (n, xs) {
-    var arr = [ ];
-    while (xs !== Nil && n > 0) {
-      arr.push(xs._head);
-      xs = xs._tail;
-      --n;
-    }
-    return LL.lsFromArray(arr);
-  };
-
-  LL.drop = function(n, xs) {
-    while (xs !== Nil && n > 0) {
-      xs = xs._tail;
-      --n;
-    }
-    return xs;
-  };
-
-   LL.length = function (xs) {
-    var out = 0;
-    while (xs !== Nil) {
-      out += 1;
-      xs = xs._tail;
-    }
-    return out;
-  };
-
-  LL.head = function(v) { return v === Nil ? _error('head') : v._head; }; // inline?
-
-  LL.tail = function(v) { return v === Nil ? _error('tail') : v._tail; };
-
-  LL.last = function(xs) {
-    if (xs === Nil) {
-      return _error('last');
-    }
-    var out = xs._head;
-    while (xs !== Nil) {
-      out = xs._head;
-      xs = xs._tail;
-    }
-    return out;
-  };
-
-  LL.revAppend = function(xs, ys) {
-    var out = ys;
-    while (xs !== Nil) {
-      out = LL.Cons(head(xs), out);
-      xs = LL.tail(xs);
-    }
-    return out;
-  };
-
-  LL.append = function(xs, ys) {
-    if (xs === Nil) {
-      return ys;
-    }
-    const rootEl = LL.Cons(xs._head, Nil);
-    let curr = rootEl;
-    xs = xs._tail;
-    while (xs !== Nil) {
-      curr._tail = LL.Cons(xs._head, Nil);
-      xs = xs._tail;
-      curr = curr._tail;
-    }
-    curr._tail = ys;
-    return rootEl;
-  };
-
-  LL.at = function(xs, i) {
-    var out;
-    while (xs !== Nil && i >= 0) {
-      out = xs._head;
-      xs = xs._tail;
-      --i;
-    }
-    // FIXME should check i / index out of bounds here
-    return out;
-  };
-
-  LL.empty = function(xs) {
-    return xs === Nil;
-  };
-
-  LL.zip = function(xs, ys) {
-    var arr = [ ];
-    while (xs !== Nil && ys !== Nil) {
-      arr.push({ "1": xs._head, "2": ys._head }); // { ctor:"_Tuple2", _0:x, _1:y }
-      xs = xs._tail;
-      ys = ys._tail;
-    }
-    return LL.lsFromArray(arr);
-  };
-
-  LL.range =  function(a, b) {
-    var lst = Nil;
-    if (a <= b) {
-      do {
-        lst = Cons(b, lst);
-      } while (b-- > a);
-    }
-    return lst;
-  };
-
-  LL.replicate = function(n, item) {
-    var out = Nil;
-    while (n > 0) {
-      out = Cons(item, out);
-      --n;
-    }
-    return out;
-  };
-
-  // faster than _lsReplicate? not really?
-  LL.repeat = function(n, x) {
-    var arr = [ ];
-    var pattern = [ x ];
-    while (n > 0) {
-      if (n & 1) {
-        arr = arr.concat(pattern);
+  LinkedList.prototype.forEach = function(f) {
+      var list = this;
+      while(list != Nil) {
+        var cur = list._head;
+        f(cur);
+        list = list._tail;
       }
-      n >>= 1;
-      pattern = pattern.concat(pattern);
-    }
-    return LL.lsFromArray(arr);
+    };
+
+  LinkedList.prototype.toArray =  function() {
+      var res = [];
+      var cur = this;
+      while(cur !== Nil) {
+        res.push(cur._head);
+        cur = cur._tail;
+      }
+      return res;
   };
 
-  // FIXME: max and min rely on '<' and '>', which
-// may not do the right thing for non-primitive types
-// (of course, we really want something like type classes
-// in order to be able to handle this kind of situation
-// more robustly)
 
-  LL.min = function(xs) {
-    var currentMin = LL.head(xs);
-    while (xs !== Nil) {
-      if (xs._head < currentMin) currentMin = xs._head;
+
+  var NilConstructor =  function() { };
+  NilConstructor.prototype = new LinkedList();
+
+  
+  var ConsConstructor = function(x,xs) {
+    DEBUG.assert(TYPES.isLinkedList(xs),"Second argument must be list");
+    this._head = x;
+    this._tail = xs;
+  };
+  ConsConstructor.prototype = new LinkedList();
+
+
+  return Object.freeze({
+
+    //Constant representing the Nil Object
+    //the JS constructor goes out of scope after this, so we can construct just one
+    //This allows us to see a difference between undefined/null and the empty list
+    Nil: "nil",//;new NilConstructor(),
+  
+    //Not a JS constructor, but a function calling it 
+    //(i.e., it behaves like one excepts when calling "Cons(x,xs)")
+    Cons: function(x,xs) {return new ConsConstructor(x,xs) },
+
+
+    /**
+     * We could test here if v instanceof LinkedList holds,
+     * but this would return false for objects created for deserialized objects
+     */
+    isLinkedList: function(v) {
+      return v === Nil 
+        && v.hasOwnProperty("_head") && v.hasOwnProperty("_tail");
+        //could test list-property recursively, but seems overly expensive
+        //&& LINKEDLIST.isLinkedList(v._tail) 
+      
+    },
+
+
+    snoc: function(xs, x) { return LINKEDLIST.append(xs, LINKEDLIST.singleton(x)); },
+
+    singleton: function(head) { return LINKEDLIST.Cons(head,Nil); },
+
+    nilF: function() {return Nil},
+
+    lsFromArray: function(arr) {
+      var out = Nil;
+      for (let i = arr.length - 1; i >= 0; --i) {
+        out = LINKEDLIST.Cons(arr[i], out);
+      }
+      return out;
+    },
+
+    take: function (n, xs) {
+      var arr = [ ];
+      while (xs !== Nil && n > 0) {
+        arr.push(xs._head);
+        xs = xs._tail;
+        --n;
+      }
+      return LINKEDLIST.lsFromArray(arr);
+    },
+
+    drop: function(n, xs) {
+      while (xs !== Nil && n > 0) {
+        xs = xs._tail;
+        --n;
+      }
+      return xs;
+    },
+
+    length: function (xs) {
+      var out = 0;
+      while (xs !== Nil) {
+        out += 1;
+        xs = xs._tail;
+      }
+      return out;
+    },
+
+    head: function(v) {
+      DEBUG.assert(TYPES.isLinkedList(v), "Not a linked list"); 
+      return v === Nil ? _error('head') : v._head; 
+      }, 
+
+    tail: function(v) {
+      DEBUG.assert(TYPES.isLinkedList(v), "Not a linked list"); 
+      return v === Nil ? _error('tail') : v._tail; 
+      },
+
+    last: function(xs) {
+      if (xs === Nil) {
+        return _error('last');
+      }
+      var out = xs._head;
+      while (xs !== Nil) {
+        out = xs._head;
+        xs = xs._tail;
+      }
+      return out;
+    },
+
+      revAppend: function(xs, ys) {
+        var out = ys;
+        while (xs !== Nil) {
+          out = LINKEDLIST.Cons(head(xs), out);
+          xs = LINKEDLIST.tail(xs);
+        }
+        return out;
+      },
+
+    append: function(xs, ys) {
+      DEBUG.assert(TYPES.isLinkedList(xs) && TYPES.isLinkedList(ys), "Not a linked list"); 
+      //Using ConsConstructor directly here to get mutable lists to avoid using recursion
+      if (xs === Nil) {
+        return ys;
+      }
+      const origxs = xs;
+      const rootEl = new ConsConstructor(xs._head, Nil);
+      let curr = rootEl;
       xs = xs._tail;
-    }
-    return currentMin;
-  };
+      while (xs !== Nil) {
+        curr._tail = new ConsConstructor(xs._head, Nil);
+        xs = xs._tail;
+        curr = curr._tail;
+      }
+      curr._tail = ys;
+      return rootEl;
+    },
 
-  LL.max = function(xs) {
-    var currentMax = LL.head(xs);
-    while (xs !== Nil) {
-      if (xs._head > currentMax) currentMax = xs._head;
-      xs = xs._tail;
+    at: function(xs, i) {
+      var out;
+      while (xs !== Nil && i >= 0) {
+        out = xs._head;
+        xs = xs._tail;
+        --i;
+      }
+      // FIXME should check i / index out of bounds here
+      return out;
+    },
+
+    empty: function(xs) {
+      return xs === Nil;
+    },
+
+    zip: function(xs, ys) {
+      var arr = [ ];
+      while (xs !== Nil && ys !== Nil) {
+        arr.push({ "1": xs._head, "2": ys._head }); // { ctor:"_Tuple2", _0:x, _1:y }
+        xs = xs._tail;
+        ys = ys._tail;
+      }
+      return LINKEDLIST.lsFromArray(arr);
+    },
+
+    range:  function(a, b) {
+      var lst = Nil;
+      if (a <= b) {
+        do {
+          lst = LINKEDLIST.Cons(b, lst);
+        } while (b-- > a);
+      }
+      return lst;
+    },
+
+    replicate: function(n, item) {
+      var out = Nil;
+      while (n > 0) {
+        out = LINKEDLIST.Cons(item, out);
+        --n;
+      }
+      return out;
+    },
+
+    // faster than _lsReplicate? not really?
+    repeat: function(n, x) {
+      var arr = [ ];
+      var pattern = [ x ];
+      while (n > 0) {
+        if (n & 1) {
+          arr = arr.concat(pattern);
+        }
+        n >>= 1;
+        pattern = pattern.concat(pattern);
+      }
+      return LINKEDLIST.lsFromArray(arr);
+    },
+
+    // FIXME: max and min rely on '<' and '>', which
+  // may not do the right thing for non-primitive types
+  // (of course, we really want something like type classes
+  // in order to be able to handle this kind of situation
+  // more robustly)
+
+    min: function(xs) {
+      var currentMin = LINKEDLIST.head(xs);
+      while (xs !== Nil) {
+        if (xs._head < currentMin) currentMin = xs._head;
+        xs = xs._tail;
+      }
+      return currentMin;
+    },
+
+    max: function(xs) {
+      var currentMax = LINKEDLIST.head(xs);
+      while (xs !== Nil) {
+        if (xs._head > currentMax) currentMax = xs._head;
+        xs = xs._tail;
+      }
+      return currentmax;
     }
-    return currentmax;
-  };
-return Object.freeze(LL);
+  });
 }();
 
 /* Core functions */
@@ -236,6 +289,7 @@ const TYPES = {
     }
   },
   isArray: function (val) { return Array.isArray(val); },
+  isLinkedList: LINKEDLIST.isLinkedList,
   isCharlist: function (val) { return (TYPES.isArray(val) && !val.some(function (c) { return !TYPES.isString(c) })); },
   isEvent: function (val) { return (val instanceof Event); },
   isTextnode: function (val) { return (TYPES.isXmlNode(val) && val.nodeType === document.TEXT_NODE); },
@@ -244,14 +298,15 @@ const TYPES = {
   isFunction: function (val) { return (typeof val === 'function'); },
   getType: function (val) {
     if (TYPES.isNumber (val))    return 'number';
-    else if (TYPES.isString (val))    return 'string';
-    else if (TYPES.isBoolean (val))   return 'boolean';
-    else if (TYPES.isTextnode (val))  return 'textnode';
-    else if (TYPES.isXmlnode (val))   return 'xmlnode';
-    else if (TYPES.isArray (val))     return 'array';
-    else if (TYPES.isEvent (val))     return 'event';
-    else if (TYPES.isUndefined (val)) return 'undefined';
-    else if (TYPES.isNull (val))      return 'null';
+    else if (TYPES.isString (val))      return 'string';
+    else if (TYPES.isBoolean (val))     return 'boolean';
+    else if (TYPES.isTextnode (val))    return 'textnode';
+    else if (TYPES.isXmlnode (val))     return 'xmlnode';
+    else if (TYPES.isArray (val))       return 'array';
+    else if (TYPES.isLinkedList (val))  return 'linkedlist';
+    else if (TYPES.isEvent (val))       return 'event';
+    else if (TYPES.isUndefined (val))   return 'undefined';
+    else if (TYPES.isNull (val))        return 'null';
     else if (typeof(val) == 'object' && 'constructor' in val) return new String(val.constructor); // makes garbage
     else return 'Unknown Type';
   }

--- a/lib/js/jslib.js
+++ b/lib/js/jslib.js
@@ -109,7 +109,7 @@ const LINKEDLIST =  new function(){
       var curL = l;
       var curR = r;
       while(!LINKEDLIST.isNil(curL) && !LINKEDLIST.isNil(curR)) {
-        if(!LINKS.eqal(curL._head,curR._head))
+        if(!LINKS.eq(curL._head,curR._head))
           return false;
         curL = curL._tail;
         curR = curR._tail;
@@ -926,6 +926,8 @@ const LINKS = new (function() {
       _isXmlItem(value)
     ) {
       return { _xml: value };
+    } else if(value === Nil) {
+      return Nil;
     } else if (value.nodeType !== undefined) {
       return storeDomRef(value);
     }

--- a/lib/js/jslib.js
+++ b/lib/js/jslib.js
@@ -1,14 +1,13 @@
 'use strict';
 
 /* LIST MANIPULATING FUNCTIONS */
-const LINKEDLIST =  new function(){
+const LINKEDLIST =  (function(){
   
   return Object.freeze({
 
-    //Using [] here for easier parsing (if we used e.g. a string, JSON parsing would become ambiguous)
+    
     Nil: null,
 
-    //Use this to check if something is Nil (using == or === may fail, since we have e.g. that  [] === [] is false in JavaScript)
     isNil: function(n) {return n === null},
   
     Cons: function(x,xs) {DEBUG.assert(LINKEDLIST.isLinkedList(xs), "Second argument must be linked list"); return {_head: x, _tail: xs}},
@@ -25,15 +24,15 @@ const LINKEDLIST =  new function(){
 
     forEach: function(list, f) {
       while(!LINKEDLIST.isNil(list)) {
-        var cur = list._head;
+        let cur = list._head;
         f(cur);
         list = list._tail;
       }
     },
 
     map: function(list, f) {
-      var cur = LINKEDLIST.singleton(null);
-      var res = cur;
+      let cur = LINKEDLIST.singleton(null);
+      const res = cur;
       while(!LINKEDLIST.isNil(list)) {
         cur._tail = LINKEDLIST.Cons(f(list._head),Nil);
         cur = cur.tail;
@@ -43,9 +42,9 @@ const LINKEDLIST =  new function(){
     },
 
     mapFromArray: function(array, f) {
-      var cur = LINKEDLIST.singleton(null);
-      var res = cur;
-      for(var i = 0; i < array.length; i++) {
+      let cur = LINKEDLIST.singleton(null);
+      const res = cur;
+      for(let i = 0; i < array.length; i++) {
         cur._tail = LINKEDLIST.Cons(f(array[i]),Nil);
         cur = cur.tail;
         list = list._tail;
@@ -54,10 +53,10 @@ const LINKEDLIST =  new function(){
     },
 
     toArray: function(list) {
-      var res = [];
-      var cur = list;
+      const res = [];
+      let cur = list;
       while(!LINKEDLIST.isNil(cur)) {
-        res.push(cur._head);
+        res[res.length] = cur._head;
         cur = cur._tail;
       }
       return res;
@@ -68,36 +67,10 @@ const LINKEDLIST =  new function(){
 
     singleton: function(head) { return LINKEDLIST.Cons(head,Nil); },
 
-    nilF: function() {return Nil},
 
-    lsFromArray: function(arr) {
-      var out = Nil;
-      for (let i = arr.length - 1; i >= 0; --i) {
-        out = LINKEDLIST.Cons(arr[i], out);
-      }
-      return out;
-    },
-
-    take: function (n, xs) {
-      var arr = [ ];
-      while (!LINKEDLIST.isNil(xs) && n > 0) {
-        arr.push(xs._head);
-        xs = xs._tail;
-        --n;
-      }
-      return LINKEDLIST.lsFromArray(arr);
-    },
-
-    drop: function(n, xs) {
-      while (!LINKEDLIST.isNil(xs) && n > 0) {
-        xs = xs._tail;
-        --n;
-      }
-      return xs;
-    },
 
     length: function (xs) {
-      var out = 0;
+      let out = 0;
       while (!LINKEDLIST.isNil(xs)) {
         out += 1;
         xs = xs._tail;
@@ -106,8 +79,8 @@ const LINKEDLIST =  new function(){
     },
 
     equal: function(l,r) {
-      var curL = l;
-      var curR = r;
+      let curL = l;
+      let curR = r;
       while(!LINKEDLIST.isNil(curL) && !LINKEDLIST.isNil(curR)) {
         if(!LINKS.eq(curL._head,curR._head))
           return false;
@@ -140,14 +113,14 @@ const LINKEDLIST =  new function(){
       return out;
     },
 
-      revAppend: function(xs, ys) {
-        var out = ys;
-        while (!LINKEDLIST.isNil(xs)) {
-          out = LINKEDLIST.Cons(head(xs), out);
-          xs = LINKEDLIST.tail(xs);
-        }
-        return out;
-      },
+    revAppend: function(xs, ys) {
+      let out = ys;
+      while (!LINKEDLIST.isNil(xs)) {
+        out = LINKEDLIST.Cons(head(xs), out);
+        xs = LINKEDLIST.tail(xs);
+      }
+      return out;
+    },
 
     append: function(xs, ys) {
       DEBUG.assert(TYPES.isLinkedList(xs) && TYPES.isLinkedList(ys), "Not linked lists"); 
@@ -167,89 +140,7 @@ const LINKEDLIST =  new function(){
       return rootEl;
     },
 
-    at: function(xs, i) {
-      var out;
-      while (!LINKEDLIST.isNil(xs) && i >= 0) {
-        out = xs._head;
-        xs = xs._tail;
-        --i;
-      }
-      // FIXME should check i / index out of bounds here
-      return out;
-    },
-
-    empty: function(xs) {
-      return LINKEDLIST.isNil(xs);
-    },
-
-    zip: function(xs, ys) {
-      var arr = [ ];
-      while (!LINKEDLIST.isNil(xs) && !LINKEDLIST.isNil(ys)) {
-        arr.push({ "1": xs._head, "2": ys._head }); // { ctor:"_Tuple2", _0:x, _1:y }
-        xs = xs._tail;
-        ys = ys._tail;
-      }
-      return LINKEDLIST.lsFromArray(arr);
-    },
-
-    range:  function(a, b) {
-      var lst = Nil;
-      if (a <= b) {
-        do {
-          lst = LINKEDLIST.Cons(b, lst);
-        } while (b-- > a);
-      }
-      return lst;
-    },
-
-    replicate: function(n, item) {
-      var out = Nil;
-      while (n > 0) {
-        out = LINKEDLIST.Cons(item, out);
-        --n;
-      }
-      return out;
-    },
-
-    // faster than _replicate? not really?
-    repeat: function(n, x) {
-      var arr = [ ];
-      var pattern = [ x ];
-      while (n > 0) {
-        if (n & 1) {
-          arr = arr.concat(pattern);
-        }
-        n >>= 1;
-        pattern = pattern.concat(pattern);
-      }
-      return LINKEDLIST.lsFromArray(arr);
-    },
-
-    // FIXME: max and min rely on '<' and '>', which
-  // may not do the right thing for non-primitive types
-  // (of course, we really want something like type classes
-  // in order to be able to handle this kind of situation
-  // more robustly)
-
-    min: function(xs) {
-      var currentMin = LINKEDLIST.head(xs);
-      while (!LINKEDLIST.isNil(xs)) {
-        if (xs._head < currentMin) currentMin = xs._head;
-        xs = xs._tail;
-      }
-      return currentMin;
-    },
-
-    max: function(xs) {
-      var currentMax = LINKEDLIST.head(xs);
-      while (!LINKEDLIST.isNil(xs)) {
-        if (xs._head > currentMax) currentMax = xs._head;
-        xs = xs._tail;
-      }
-      return currentmax;
-    }
-  });
-}();
+}());
 
 /* Core functions */
 
@@ -976,11 +867,6 @@ const LINKS = new (function() {
       }
     },
 
-    /**
-     * @param {any[]} list
-     * @returns {Boolean} whether list is empty
-     */
-    isEmpty: function (list) { return (list.length == 0) },
 
     eq: undefined,
 
@@ -1362,9 +1248,7 @@ const LINKS = new (function() {
     if (TYPES.isLinkedList(l) && l != null &&
         TYPES.isLinkedList(r) && r != null) {
       return LINKEDLIST.equal(l,r)
-
-    return true;
-  }
+    }
     else if(typeof(l) == 'object' && l != undefined && l != null &&
             typeof(r) == 'object' && r != undefined && r != null) {
       if(l.constructor != r.constructor)
@@ -1417,14 +1301,9 @@ var stringToFloat = LINKS.kify(_stringToFloat);
 function _not(x) { return !x; } // should be inlined
 var _Concat = LINKEDLIST.append;
 var _Cons = LINKEDLIST.Cons;
-var _empty = LINKEDLIST.empty;
 var _hd = LINKEDLIST.head;
 var _tl = LINKEDLIST.tail;
 var _length = LINKEDLIST.length;
-var _take = LINKEDLIST.take;
-var _drop = LINKEDLIST.drop;
-var _max = LINKEDLIST.max;
-var _min = LINKEDLIST.min;
 var _singleton = LINKEDLIST.singleton;
 
 
@@ -1433,14 +1312,10 @@ var not    = LINKS.kify(_not);
 var Nil    = LINKEDLIST.Nil;
 var Cons   = LINKS.kify(LINKEDLIST.Cons);
 var Concat = LINKS.kify(LINKEDLIST.Concat);
-var empty  = LINKS.kify(LINKEDLIST.empty);
 var hd     = LINKS.kify(LINKEDLIST.head);
 var tl     = LINKS.kify(LINKEDLIST.tail);
 var length = LINKS.kify(LINKEDLIST.length);
-var take   = LINKS.kify(LINKEDLIST.take);
-var drop   = LINKS.kify(LINKEDLIST.drop);
-var max    = LINKS.kify(LINKEDLIST.max);
-var min    = LINKS.kify(LINKEDLIST.min);
+
 
 
 function _charAt (s, i) {

--- a/lib/js/jslib.js
+++ b/lib/js/jslib.js
@@ -1,187 +1,190 @@
 'use strict';
 
 /* LIST MANIPULATING FUNCTIONS */
+const LINKEDLIST =  new function(){
+  var LL = {};
+  
+   LL.Nil =  "Nil";
 
-var lsNil = null;
+   LL.nilF =  function() { return Nil; };
 
-function _lsNilF () { return null; }
-const lsNilF = _lsNilF;
+   LL.Cons = function(head, tail) { return { _head: head, _tail: tail }; };
 
-function _lsCons (head, tail) { return { _head: head, _tail: tail }; }
-const lsCons = _lsCons;
+   LL.snoc = function(xs, x) { return LL.append(xs, singleton(x)); };
 
-function _lsSnoc (xs, x) { return _lsAppend(xs, _lsSingleton(x)); }
-const lsSnoc = _lsSnoc
+   LL.singleton = function(head) { return { _head: head, _tail: Nil }; };
 
-function _lsSingleton (head) { return { _head: head, _tail: lsNil }; }
+   LL.isList = function(v) {
+    return v == Nil || (v[_head] != undefined && v[_tail] != undefined)
+  };
 
-function _lsFromArray (arr) {
-  var out = lsNil;
-  for (let i = arr.length - 1; i >= 0; --i) {
-	  out = _lsCons(arr[i], out);
-  }
-  return out;
-}
-const lsFromArray = _lsFromArray
-
-function _lsTake (n, xs) {
-  var arr = [ ];
-  while (xs !== null && n > 0) {
-    arr.push(xs._head);
-    xs = xs._tail;
-    --n;
-  }
-  return _lsFromArray(arr);
-}
-const lsTake = _lsTake;
-
-function _lsDrop (n, xs) {
-  while (xs !== null && n > 0) {
-    xs = xs._tail;
-    --n;
-  }
-  return xs;
-}
-const lsDrop = _lsDrop;
-
-function _lsLength (xs) {
-  var out = 0;
-  while (xs !== null) {
-    out += 1;
-    xs = xs._tail;
-  }
-  return out;
-}
-const lsLength = _lsLength;
-
-function _lsHead (v) { return v === null ? _error('head') : v._head; } // inline?
-const lsHead = _lsHead;
-
-function _lsTail (v) { return v === null ? _error('tail') : v._tail; }
-const lsTail = _lsTail;
-
-function _lsLast (xs) {
-  if (xs === null) {
-    return _error('last');
-  }
-  var out = xs._head;
-  while (xs !== null) {
-    out = xs._head;
-    xs = xs._tail;
-  }
-  return out;
-}
-const lsLast = _lsLast;
-
-function _lsRevAppend (xs, ys) {
-  var out = ys;
-  while (xs !== lsNil) {
-    out = _lsCons(_lsHead(xs), out);
-    xs = _lsTail(xs);
-  }
-  return out;
-}
-const lsRevAppend = _lsRevAppend;
-
-function _lsAppend (xs, ys) {
-  if (xs === null) {
-    return ys;
-  }
-  const rootEl = _lsCons(xs._head, lsNil);
-  let curr = rootEl;
-  xs = xs._tail;
-  while (xs !== null) {
-    curr._tail = _lsCons(xs._head, lsNil);
-    xs = xs._tail;
-    curr = curr._tail;
-  }
-  curr._tail = ys;
-  return rootEl;
-}
-const lsAppend = _lsAppend;
-
-function _lsAt (xs, i) {
-  var out;
-  while (xs !== null && i >= 0) {
-    out = xs._head;
-    xs = xs._tail;
-    --i;
-  }
-  // FIXME should check i / index out of bounds here
-  return out;
-}
-const lsAt = _lsAt;
-
-function _lsEmpty (xs) {
-	return xs === null;
-}
-const lsEmpty = _lsEmpty;
-
-function _lsZip (xs, ys) {
-  var arr = [ ];
-  while (xs !== null && ys !== null) {
-    arr.push({ "1": xs._head, "2": ys._head }); // { ctor:"_Tuple2", _0:x, _1:y }
-    xs = xs._tail;
-    ys = ys._tail;
-  }
-  return _lsFromArray(arr);
-}
-const lsZip = _lsZip;
-
-function _lsRange (a, b) {
-  var lst = lsNil;
-  if (a <= b) {
-    do {
-      lst = _lsCons(b, lst);
-    } while (b-- > a);
-  }
-  return lst;
-}
-const lsRange = _lsRange;
-
-function _lsReplicate (n, item) {
-  var out = lsNil;
-  while (n > 0) {
-    out = _lsCons(item, out);
-    --n;
-  }
-  return out;
-}
-const lsReplicate = _lsReplicate;
-
-// faster than _lsReplicate? not really?
-function _lsRepeat (n, x) {
-  var arr = [ ];
-  var pattern = [ x ];
-  while (n > 0) {
-    if (n & 1) {
-      arr = arr.concat(pattern);
+  LL.forEach = function(list, f) {
+    while(list != Nil) {
+      var cur = list._head;
+      f(cur);
+      list = list._tail;
     }
-    n >>= 1;
-    pattern = pattern.concat(pattern);
-  }
-  return _lsFromArray(arr);
-}
-const lsRepeat = _lsRepeat;
+  };
 
-function _ls (arr) {
-	var out = lsNil;
-	for (var i = arr.length - 1; i >= 0; --i) {
-		out = _lsCons(arr[i], out);
-	}
-	return out;
-}
-const ls = _ls;
+  LL.lsFromArray = function(arr) {
+    var out = Nil;
+    for (let i = arr.length - 1; i >= 0; --i) {
+      out = LL.Cons(arr[i], out);
+    }
+    return out;
+  };
 
-function _lsMinimum(xs) {
-  var currentMin = _lsHead(xs);
-  while (xs !== null) {
-    if (xs._head < currentMin) currentMin = xs._head;
+  LL.take = function (n, xs) {
+    var arr = [ ];
+    while (xs !== Nil && n > 0) {
+      arr.push(xs._head);
+      xs = xs._tail;
+      --n;
+    }
+    return LL.lsFromArray(arr);
+  };
+
+  LL.drop = function(n, xs) {
+    while (xs !== Nil && n > 0) {
+      xs = xs._tail;
+      --n;
+    }
+    return xs;
+  };
+
+   LL.length = function (xs) {
+    var out = 0;
+    while (xs !== Nil) {
+      out += 1;
+      xs = xs._tail;
+    }
+    return out;
+  };
+
+  LL.head = function(v) { return v === Nil ? _error('head') : v._head; }; // inline?
+
+  LL.tail = function(v) { return v === Nil ? _error('tail') : v._tail; };
+
+  LL.last = function(xs) {
+    if (xs === Nil) {
+      return _error('last');
+    }
+    var out = xs._head;
+    while (xs !== Nil) {
+      out = xs._head;
+      xs = xs._tail;
+    }
+    return out;
+  };
+
+  LL.revAppend = function(xs, ys) {
+    var out = ys;
+    while (xs !== Nil) {
+      out = LL.Cons(head(xs), out);
+      xs = LL.tail(xs);
+    }
+    return out;
+  };
+
+  LL.append = function(xs, ys) {
+    if (xs === Nil) {
+      return ys;
+    }
+    const rootEl = LL.Cons(xs._head, Nil);
+    let curr = rootEl;
     xs = xs._tail;
-  }
-  return currentMin;
-}
-const lsMinimum = _lsMinimum;
+    while (xs !== Nil) {
+      curr._tail = LL.Cons(xs._head, Nil);
+      xs = xs._tail;
+      curr = curr._tail;
+    }
+    curr._tail = ys;
+    return rootEl;
+  };
+
+  LL.at = function(xs, i) {
+    var out;
+    while (xs !== Nil && i >= 0) {
+      out = xs._head;
+      xs = xs._tail;
+      --i;
+    }
+    // FIXME should check i / index out of bounds here
+    return out;
+  };
+
+  LL.empty = function(xs) {
+    return xs === Nil;
+  };
+
+  LL.zip = function(xs, ys) {
+    var arr = [ ];
+    while (xs !== Nil && ys !== Nil) {
+      arr.push({ "1": xs._head, "2": ys._head }); // { ctor:"_Tuple2", _0:x, _1:y }
+      xs = xs._tail;
+      ys = ys._tail;
+    }
+    return LL.lsFromArray(arr);
+  };
+
+  LL.range =  function(a, b) {
+    var lst = Nil;
+    if (a <= b) {
+      do {
+        lst = Cons(b, lst);
+      } while (b-- > a);
+    }
+    return lst;
+  };
+
+  LL.replicate = function(n, item) {
+    var out = Nil;
+    while (n > 0) {
+      out = Cons(item, out);
+      --n;
+    }
+    return out;
+  };
+
+  // faster than _lsReplicate? not really?
+  LL.repeat = function(n, x) {
+    var arr = [ ];
+    var pattern = [ x ];
+    while (n > 0) {
+      if (n & 1) {
+        arr = arr.concat(pattern);
+      }
+      n >>= 1;
+      pattern = pattern.concat(pattern);
+    }
+    return LL.lsFromArray(arr);
+  };
+
+  // FIXME: max and min rely on '<' and '>', which
+// may not do the right thing for non-primitive types
+// (of course, we really want something like type classes
+// in order to be able to handle this kind of situation
+// more robustly)
+
+  LL.min = function(xs) {
+    var currentMin = LL.head(xs);
+    while (xs !== Nil) {
+      if (xs._head < currentMin) currentMin = xs._head;
+      xs = xs._tail;
+    }
+    return currentMin;
+  };
+
+  LL.max = function(xs) {
+    var currentMax = LL.head(xs);
+    while (xs !== Nil) {
+      if (xs._head > currentMax) currentMax = xs._head;
+      xs = xs._tail;
+    }
+    return currentmax;
+  };
+return Object.freeze(LL);
+}();
 
 /* Core functions */
 
@@ -1318,64 +1321,37 @@ var floatToInt = LINKS.kify(_floatToInt);
 var floatToString = LINKS.kify(_floatToString);
 var stringToFloat = LINKS.kify(_stringToFloat);
 
-function _Concat(xs, ys) { return LINKS.concat(xs, ys); }
-function _Cons(x, xs) { return _Concat([x], xs); }
-
 function _not(x) { return !x; } // should be inlined
-function _empty(list) { return (list.length == 0); }
-function _hd(list) { return list[0]; }
-function _tl(list) { return list.slice(1); } // makes garbage
+var _Concat = LINKEDLIST.append;
+var _Cons = LINKEDLIST.Cons;
 
-function _length(list) { return list.length; }
-function _take(n, list) { return list.slice(0, n); } // makes garbage
-function _drop(n, list) { return list.slice(n); } // makes garbage
 
-// FIXME: _max and _min rely on '<' and '>', which
-// may not do the right thing for non-primitive types
-// (of course, we really want something like type classes
-// in order to be able to handle this kind of situation
-// more robustly)
+var _empty = LINKEDLIST.empty;
+var _hd = LINKEDLIST.head;
+var _tl = LINKEDLIST.tail;
 
-function _max (list) {
-  if (list.length === 0) {
-    return { '_label': 'None' };
-  } else {
-    var x = list[0];
-    for (i = 1; i < list.length; i++) {
-      if (list[i] > x)
-        x = list[i];
-    }
-    return { '_label': 'Some', '_value': x };
-  }
-}
+var _length = LINKEDLIST.length;
+var _take = LINKEDLIST.take;
+var _drop = LINKEDLIST.drop;
+var _max = LINKEDLIST.max;
+var _min = LINKEDLIST.min;
 
-function _min (list) {
-  if (list.length === 0) {
-    return { '_label': 'None' };
-  } else {
-    var x = list[0];
-    for (i = 1; i < list.length; i++) {
-      if (list[i] < x)
-        x = list[i];
-    }
-    return { '_label': 'Some', '_value': x };
-  }
-}
 
-var Nil    = [ ];
-var Cons   = LINKS.kify(_Cons);
-var Concat = LINKS.kify(_Concat);
 
 var not    = LINKS.kify(_not);
-var empty  = LINKS.kify(_empty);
-var hd     = LINKS.kify(_hd);
-var tl     = LINKS.kify(_tl);
 
-var length = LINKS.kify(_length);
-var take   = LINKS.kify(_take);
-var drop   = LINKS.kify(_drop);
-var max    = LINKS.kify(_max);
-var min    = LINKS.kify(_min);
+var Nil    = LINKEDLIST.Nil;
+var Cons   = LINKS.kify(LINKEDLIST.Cons);
+var Concat = LINKS.kify(LINKEDLIST.Concat);
+var empty  = LINKS.kify(LINKEDLIST.empty);
+var hd     = LINKS.kify(LINKEDLIST.head);
+var tl     = LINKS.kify(LINKEDLIST.tail);
+var length = LINKS.kify(LINKEDLIST.length);
+var take   = LINKS.kify(LINKEDLIST.take);
+var drop   = LINKS.kify(LINKEDLIST.drop);
+var max    = LINKS.kify(LINKEDLIST.max);
+var min    = LINKS.kify(LINKEDLIST.min);
+
 
 function _charAt (s, i) {
   return {_c:s.charAt(i)};
@@ -1390,22 +1366,18 @@ function _strsub (s, start, len) {
 }
 
 function _explode (s) {
-  const cs = [ ];
-  for (var i = 0; i < s.length; ++i) {
-    cs.push({ _c: s.charAt(i) });
+  var cs = Nil;
+  for (var i = s.length-1; i >= 0; --i) {
+    cs = LINKEDLIST.Cons({ _c: s.charAt(i) },cs)
   }
   return cs;
 }
 
 function _implode(cs) {
-  DEBUG.assert(
-    TYPES.isArray(cs),
-    "_implode expected an array, got: " + cs
-  );
   var s = "";
-  for (let i in cs) {
-    s += cs[i]._c;
-  }
+  LINKEDLIST.forEach(cs, function(e) {
+    s += e._c;
+  });
   return s;
 }
 

--- a/lib/js/jslib.js
+++ b/lib/js/jslib.js
@@ -166,7 +166,7 @@ const LINKEDLIST =  (function(){
 
     
     at: function(xs, i) {
-      var out;
+      let out = null;
       while (!LINKEDLIST.isNil(xs) && i >= 0) {
         out = xs._head;
         xs = xs._tail;
@@ -181,7 +181,7 @@ const LINKEDLIST =  (function(){
     },
 
     zip: function(xs, ys) {
-      var arr = [ ];
+      let arr = [ ];
       while (!LINKEDLIST.isNil(xs) && !LINKEDLIST.isNil(ys)) {
         arr.push({ "1": xs._head, "2": ys._head }); // { ctor:"_Tuple2", _0:x, _1:y }
         xs = xs._tail;
@@ -191,7 +191,7 @@ const LINKEDLIST =  (function(){
     },
 
     range:  function(a, b) {
-      var lst = Nil;
+      let lst = Nil;
       if (a <= b) {
         do {
           lst = LINKEDLIST.Cons(b, lst);
@@ -201,7 +201,7 @@ const LINKEDLIST =  (function(){
     },
 
     replicate: function(n, item) {
-      var out = Nil;
+      let out = Nil;
       while (n > 0) {
         out = LINKEDLIST.Cons(item, out);
         --n;
@@ -211,8 +211,8 @@ const LINKEDLIST =  (function(){
 
     // faster than _replicate? not really?
     repeat: function(n, x) {
-      var arr = [ ];
-      var pattern = [ x ];
+      let arr = [ ];
+      let pattern = [ x ];
       while (n > 0) {
         if (n & 1) {
           arr = arr.concat(pattern);
@@ -230,7 +230,7 @@ const LINKEDLIST =  (function(){
   // more robustly)
 
     min: function(xs) {
-      var currentMin = LINKEDLIST.head(xs);
+      let currentMin = LINKEDLIST.head(xs);
       while (!LINKEDLIST.isNil(xs)) {
         if (xs._head < currentMin) currentMin = xs._head;
         xs = xs._tail;
@@ -239,7 +239,7 @@ const LINKEDLIST =  (function(){
     },
 
     max: function(xs) {
-      var currentMax = LINKEDLIST.head(xs);
+      let currentMax = LINKEDLIST.head(xs);
       while (!LINKEDLIST.isNil(xs)) {
         if (xs._head > currentMax) currentMax = xs._head;
         xs = xs._tail;

--- a/lib/js/jslib.js
+++ b/lib/js/jslib.js
@@ -6,10 +6,10 @@ const LINKEDLIST =  new function(){
   return Object.freeze({
 
     //Using [] here for easier parsing (if we used e.g. a string, JSON parsing would become ambiguous)
-    Nil: [],
+    Nil: null,
 
     //Use this to check if something is Nil (using == or === may fail, since we have e.g. that  [] === [] is false in JavaScript)
-    isNil: function(n) {return n !== undefined && Array.isArray(n) && n.length === 0},
+    isNil: function(n) {return n === null},
   
     Cons: function(x,xs) {DEBUG.assert(LINKEDLIST.isLinkedList(xs), "Second argument must be linked list"); return {_head: x, _tail: xs}},
 
@@ -728,6 +728,9 @@ const LINKS = new (function() {
         return;
       }
       for (let i in obj) {
+        if(LINKEDLIST.isNil(obj[i]))
+          continue;
+
          resolveServerValue(state, obj[i]);
 
          if (obj[i].func) {

--- a/lib/js/jslib.js
+++ b/lib/js/jslib.js
@@ -14,10 +14,7 @@ const LINKEDLIST =  new function(){
     Cons: function(x,xs) {DEBUG.assert(LINKEDLIST.isLinkedList(xs), "Second argument must be linked list"); return {_head: x, _tail: xs}},
 
 
-    /**
-     * We could test here if v instanceof LinkedList holds,
-     * but this would return false for objects created for deserialized objects
-     */
+
     isLinkedList: function(v) {
       return LINKEDLIST.isNil(v)
         || v.hasOwnProperty("_head") && v.hasOwnProperty("_tail");

--- a/lib/js/jslib.js
+++ b/lib/js/jslib.js
@@ -3,42 +3,6 @@
 /* LIST MANIPULATING FUNCTIONS */
 const LINKEDLIST =  new function(){
   
-  //Common prototype Object for linked lists
-  var LinkedList = function()  {}
-
-  LinkedList.prototype.forEach = function(f) {
-      var list = this;
-      while(list != Nil) {
-        var cur = list._head;
-        f(cur);
-        list = list._tail;
-      }
-    };
-
-  LinkedList.prototype.toArray =  function() {
-      var res = [];
-      var cur = this;
-      while(cur !== Nil) {
-        res.push(cur._head);
-        cur = cur._tail;
-      }
-      return res;
-  };
-
-
-
-  var NilConstructor =  function() { };
-  NilConstructor.prototype = new LinkedList();
-
-  
-  var ConsConstructor = function(x,xs) {
-    DEBUG.assert(TYPES.isLinkedList(xs),"Second argument must be list");
-    this._head = x;
-    this._tail = xs;
-  };
-  ConsConstructor.prototype = new LinkedList();
-
-
   return Object.freeze({
 
     //Constant representing the Nil Object
@@ -48,7 +12,7 @@ const LINKEDLIST =  new function(){
   
     //Not a JS constructor, but a function calling it 
     //(i.e., it behaves like one excepts when calling "Cons(x,xs)")
-    Cons: function(x,xs) {return new ConsConstructor(x,xs) },
+    Cons: function(x,xs) {DEBUG.assert(LINKEDLIST.isLinkedList(xs), "Second argument must be linked list"); return {_head: x, _tail: xs}},
 
 
     /**
@@ -57,10 +21,28 @@ const LINKEDLIST =  new function(){
      */
     isLinkedList: function(v) {
       return v === Nil 
-        && v.hasOwnProperty("_head") && v.hasOwnProperty("_tail");
+        || v.hasOwnProperty("_head") && v.hasOwnProperty("_tail");
         //could test list-property recursively, but seems overly expensive
         //&& LINKEDLIST.isLinkedList(v._tail) 
       
+    },
+
+    forEach: function(list, f) {
+      while(list != Nil) {
+        var cur = list._head;
+        f(cur);
+        list = list._tail;
+      }
+    },
+
+    toArray: function(list) {
+      var res = [];
+      var cur = list;
+      while(cur !== Nil) {
+        res.push(cur._head);
+        cur = cur._tail;
+      }
+      return res;
     },
 
 
@@ -137,17 +119,16 @@ const LINKEDLIST =  new function(){
       },
 
     append: function(xs, ys) {
-      DEBUG.assert(TYPES.isLinkedList(xs) && TYPES.isLinkedList(ys), "Not a linked list"); 
-      //Using ConsConstructor directly here to get mutable lists to avoid using recursion
+      DEBUG.assert(TYPES.isLinkedList(xs) && TYPES.isLinkedList(ys), "Not linked lists"); 
       if (xs === Nil) {
         return ys;
       }
       const origxs = xs;
-      const rootEl = new ConsConstructor(xs._head, Nil);
+      const rootEl = _Cons(xs._head, Nil);
       let curr = rootEl;
       xs = xs._tail;
       while (xs !== Nil) {
-        curr._tail = new ConsConstructor(xs._head, Nil);
+        curr._tail = _Cons(xs._head, Nil);
         xs = xs._tail;
         curr = curr._tail;
       }
@@ -1002,7 +983,7 @@ const LINKS = new (function() {
         xmlForest
       );
       var domNodeArray = [];
-      xmlForest.forEach(function(xmlNode){
+      LINKEDLIST.forEach(xmlForest,function(xmlNode){
         domNodeArray.push(LINKS.singleXmlToDomNodes(xmlNode))
       }); 
       return domNodeArray;
@@ -1016,7 +997,7 @@ const LINKS = new (function() {
      */
     XML : function (tag, attrs, body) {
       var children = Nil;
-      body.forEach(function(e) {
+      LINKEDLIST.forEach(body,function(e) {
         if(TYPES.isLinkedList(e)) {
           children = LINKEDLIST.append(children,e);
         } else {
@@ -1066,12 +1047,12 @@ const LINKS = new (function() {
      * objects and not references.
      *
      * @param {Object} obj
-     * @param {any[]} names
+     * @param linkedlist names
      * @returns {Object}
      */
     erase: function (obj, names) {
       const o = JSON.parse(JSON.stringify(obj));
-      names.forEach(function (n) { delete o[n] });
+      LINKEDLIST.forEach(names,function (n) { delete o[n] });
       return o;
     },
 
@@ -1284,7 +1265,7 @@ const LINKS = new (function() {
       case 'ELEMENT':
         const tagName = xmlObj.tagName;
         const attributes = xmlObj.attrs;
-        const children = xmlObj.children !== undefined ? xmlObj.children.toArray() : [ ];
+        const children = xmlObj.children !== undefined ? LINKEDLIST.toArray(xmlObj.children) : [ ];
         const namespace = xmlObj.namespace;
 
         const node = namespace ?
@@ -1306,7 +1287,7 @@ const LINKS = new (function() {
           }
         });
         if(xmlObj.children) {
-          xmlObj.children.forEach(function(c) {
+          LINKEDLIST.forEach(xmlObj.children,function(c) {
             node.appendChild(LINKS.singleXmlToDomNodes(c));
           });
         }
@@ -1445,7 +1426,7 @@ function _explode (s) {
 
 function _implode(cs) {
   var s = "";
-  cs.forEach(function(e) {
+  LINKEDLIST.forEach(cs,function(e) {
     s += e._c;
   });
   return s;
@@ -1951,13 +1932,16 @@ function _isXmlItem(obj) {
 
   if (obj.type === 'ELEMENT') {
 
-    if(!obj.children) {
+    if(!TYPES.isLinkedList(obj.children)) {
       return false;
     }
-    obj.children.forEach(function(child) {
-      if(!_isXmlItem(child))
-        return false;
+    var childrenOkay = true;
+    LINKEDLIST.forEach(obj.children, function(child) {
+      childrenOkay &= _isXmlItem(child)
     });
+    if(!childrenOkay)
+      return false;
+
 
     return Boolean(
       obj.tagName &&

--- a/lib/js/jslib.js
+++ b/lib/js/jslib.js
@@ -992,36 +992,47 @@ const LINKS = new (function() {
 
     map: function (f, list) { return list.map(f) },
 
+    /*
+      Implictly converts from linked list to JS Array, use with caution!
+    */
     XmlToDomNodes : function (xmlForest) {
       DEBUG.assert(
-        TYPES.isArray(xmlForest),
-        'LINKS.XmlToDomNodes expected an array, but got ',
+        TYPES.isLinkedList(xmlForest),
+        'LINKS.XmlToDomNodes expected a linked list, but got ',
         xmlForest
       );
-      return LINKS.map(LINKS.singleXmlToDomNodes, xmlForest);
+      var domNodeArray = [];
+      xmlForest.forEach(function(xmlNode){
+        domNodeArray.push(LINKS.singleXmlToDomNodes(xmlNode))
+      }); 
+      return domNodeArray;
     },
 
     /**
      * Create a an XML value representation
      * @param {string} tag
      * @param {{ [attr: string]: string }} attr
-     * @param { } body
+     * @param { } body (linked list)
      */
     XML : function (tag, attrs, body) {
-      return [
+      var children = Nil;
+      body.forEach(function(e) {
+        if(TYPES.isLinkedList(e)) {
+          children = LINKEDLIST.append(children,e);
+        } else {
+          children = LINKEDLIST.snoc(children,e);
+        }
+      });
+      return _Cons(
         {
           type: 'ELEMENT',
           tagName: tag,
           attrs: attrs,
-          children: [].concat.apply([],body),
-        }
-      ];
+          children: children
+        },
+         Nil);
     },
 
-    // yucky CPS XML function used by the old JS compiler
-    XMLk : function (tag, attrs, body, kappa) {
-      return _applyCont(kappa, LINKS.XML(tag, attrs, body));
-    },
 
     // Records
 
@@ -1273,7 +1284,7 @@ const LINKS = new (function() {
       case 'ELEMENT':
         const tagName = xmlObj.tagName;
         const attributes = xmlObj.attrs;
-        const children = xmlObj.children || [ ];
+        const children = xmlObj.children !== undefined ? xmlObj.children.toArray() : [ ];
         const namespace = xmlObj.namespace;
 
         const node = namespace ?
@@ -1294,7 +1305,11 @@ const LINKS = new (function() {
             throw new Error('attribute names can contain one or no colon. `' + k + '` found.');
           }
         });
-        children.forEach(function (c) { node.appendChild(LINKS.singleXmlToDomNodes(c)); });
+        if(xmlObj.children) {
+          xmlObj.children.forEach(function(c) {
+            node.appendChild(LINKS.singleXmlToDomNodes(c));
+          });
+        }
 
         return node;
       case 'TEXT':
@@ -1430,7 +1445,7 @@ function _explode (s) {
 
 function _implode(cs) {
   var s = "";
-  LINKEDLIST.forEach(cs, function(e) {
+  cs.forEach(function(e) {
     s += e._c;
   });
   return s;
@@ -1620,7 +1635,9 @@ var isNull = LINKS.kify(_isNull);
  *   text?: string,
  *   tagName?: string,
  *   attrs?: { [attrName: string]: string },
- *   children?: XmlItem[]
+ *   children?: XmlItem[] 
+ *      (in our XML representation, we use our custom linked lists for the children,
+ *       whereas JS node objects use  JS Arrays to represent the children)
  * };
  */
 
@@ -1642,18 +1659,18 @@ var getInputValue = LINKS.kify(_getInputValue);
 //    NOTE: this is recursive.
 function _getValue(nodeRef) {
   if (nodeRef.nodeType == document.TEXT_NODE) {
-    return [
+    return _Cons(
       {
         type: 'TEXT',
         text: _nodeTextContent(nodeRef)
-      }
-    ];
+      },
+      Nil);
   } else if (nodeRef.nodeType == document.ELEMENT_NODE ) {
-    var children = [ ];
+    var children = Nil;
 
     // @TODO
-    for (var i=0; i < nodeRef.childNodes.length; i++) {
-      children = children.concat(_getValue(nodeRef.childNodes[i]));
+    for (var i=nodeRef.childNodes.length -1; i <= 0; i++) {
+      children = LINKEDLIST.Cons(_getValue(nodeRef.childNodes[i]),children);
     }
 
     var attrs = { };
@@ -1667,14 +1684,14 @@ function _getValue(nodeRef) {
       'Invalid children constructed in _getValue'
     );
 
-    return [
+    return _Cons(
       {
         type: 'ELEMENT',
         tagName: nodeRef.tagName,
         attrs: attrs,
         children: children,
-      }
-    ];
+      },Nil
+    );
 
   } else {
     throw new Error("Unknown node type " + nodeRef.nodeType + " in GetXml");
@@ -1934,6 +1951,14 @@ function _isXmlItem(obj) {
 
   if (obj.type === 'ELEMENT') {
 
+    if(!obj.children) {
+      return false;
+    }
+    obj.children.forEach(function(child) {
+      if(!_isXmlItem(child))
+        return false;
+    });
+
     return Boolean(
       obj.tagName &&
       TYPES.isString(obj.tagName) &&
@@ -1941,12 +1966,7 @@ function _isXmlItem(obj) {
       obj.attrs &&
       Object.keys(obj.attrs)
         .map(function (key) { return TYPES.isString(key) && TYPES.isString(obj.attrs[key]); })
-        .reduce(function (a, b) { return a && b; }, true) &&
-
-      obj.children &&
-      obj.children
-        .map(function (child) { return _isXmlItem(child); })
-        .reduce(function (a, b) { return a && b; }, true)
+        .reduce(function (a, b) { return a && b; }, true) 
     );
   }
 
@@ -1967,13 +1987,10 @@ function _isXml(obj) {
 
 function _stringToXml(s) {
 //  DEBUG.assert(TYPES.isArray(s), "_stringToXml Expected an array, got: " + s);
-  return [
-    {
-      type: 'TEXT',
-      text: s
-    }
-  ];
+  var res = _Cons(  { type: 'TEXT',text: s},Nil);
+  return res;
 }
+
 function _intToXml(i) {
   return _stringToXml(_intToString(i));
 }

--- a/lib/js/jslib.js
+++ b/lib/js/jslib.js
@@ -67,7 +67,31 @@ const LINKEDLIST =  (function(){
 
     singleton: function(head) { return LINKEDLIST.Cons(head,Nil); },
 
+    lsFromArray: function(arr) {
+      let out = Nil;
+      for (let i = arr.length - 1; i >= 0; --i) {
+        out = LINKEDLIST.Cons(arr[i], out);
+      }
+      return out;
+    },
 
+    take: function (n, xs) {
+      let arr = [ ];
+      while (!LINKEDLIST.isNil(xs) && n > 0) {
+        arr.push(xs._head);
+        xs = xs._tail;
+        --n;
+      }
+      return LINKEDLIST.lsFromArray(arr);
+    },
+
+    drop: function(n, xs) {
+      while (!LINKEDLIST.isNil(xs) && n > 0) {
+        xs = xs._tail;
+        --n;
+      }
+      return xs;
+    },
 
     length: function (xs) {
       let out = 0;
@@ -140,6 +164,89 @@ const LINKEDLIST =  (function(){
       return rootEl;
     },
 
+    
+    at: function(xs, i) {
+      var out;
+      while (!LINKEDLIST.isNil(xs) && i >= 0) {
+        out = xs._head;
+        xs = xs._tail;
+        --i;
+      }
+      // FIXME should check i / index out of bounds here
+      return out;
+    },
+
+    empty: function(xs) {
+      return LINKEDLIST.isNil(xs);
+    },
+
+    zip: function(xs, ys) {
+      var arr = [ ];
+      while (!LINKEDLIST.isNil(xs) && !LINKEDLIST.isNil(ys)) {
+        arr.push({ "1": xs._head, "2": ys._head }); // { ctor:"_Tuple2", _0:x, _1:y }
+        xs = xs._tail;
+        ys = ys._tail;
+      }
+      return LINKEDLIST.lsFromArray(arr);
+    },
+
+    range:  function(a, b) {
+      var lst = Nil;
+      if (a <= b) {
+        do {
+          lst = LINKEDLIST.Cons(b, lst);
+        } while (b-- > a);
+      }
+      return lst;
+    },
+
+    replicate: function(n, item) {
+      var out = Nil;
+      while (n > 0) {
+        out = LINKEDLIST.Cons(item, out);
+        --n;
+      }
+      return out;
+    },
+
+    // faster than _replicate? not really?
+    repeat: function(n, x) {
+      var arr = [ ];
+      var pattern = [ x ];
+      while (n > 0) {
+        if (n & 1) {
+          arr = arr.concat(pattern);
+        }
+        n >>= 1;
+        pattern = pattern.concat(pattern);
+      }
+      return LINKEDLIST.lsFromArray(arr);
+    },
+
+    // FIXME: max and min rely on '<' and '>', which
+  // may not do the right thing for non-primitive types
+  // (of course, we really want something like type classes
+  // in order to be able to handle this kind of situation
+  // more robustly)
+
+    min: function(xs) {
+      var currentMin = LINKEDLIST.head(xs);
+      while (!LINKEDLIST.isNil(xs)) {
+        if (xs._head < currentMin) currentMin = xs._head;
+        xs = xs._tail;
+      }
+      return currentMin;
+    },
+
+    max: function(xs) {
+      var currentMax = LINKEDLIST.head(xs);
+      while (!LINKEDLIST.isNil(xs)) {
+        if (xs._head > currentMax) currentMax = xs._head;
+        xs = xs._tail;
+      }
+      return currentmax;
+    }
+  });
 }());
 
 /* Core functions */
@@ -1300,10 +1407,15 @@ var stringToFloat = LINKS.kify(_stringToFloat);
 
 function _not(x) { return !x; } // should be inlined
 var _Concat = LINKEDLIST.append;
+var _empty = LINKEDLIST.empty;
 var _Cons = LINKEDLIST.Cons;
 var _hd = LINKEDLIST.head;
 var _tl = LINKEDLIST.tail;
 var _length = LINKEDLIST.length;
+var _take = LINKEDLIST.take;
+var _drop = LINKEDLIST.drop;
+var _max = LINKEDLIST.max;
+var _min = LINKEDLIST.min;
 var _singleton = LINKEDLIST.singleton;
 
 
@@ -1312,9 +1424,14 @@ var not    = LINKS.kify(_not);
 var Nil    = LINKEDLIST.Nil;
 var Cons   = LINKS.kify(LINKEDLIST.Cons);
 var Concat = LINKS.kify(LINKEDLIST.Concat);
+var empty  = LINKS.kify(LINKEDLIST.empty);
 var hd     = LINKS.kify(LINKEDLIST.head);
 var tl     = LINKS.kify(LINKEDLIST.tail);
 var length = LINKS.kify(LINKEDLIST.length);
+var take   = LINKS.kify(LINKEDLIST.take);
+var drop   = LINKS.kify(LINKEDLIST.drop);
+var max    = LINKS.kify(LINKEDLIST.max);
+var min    = LINKS.kify(LINKEDLIST.min);
 
 
 


### PR DESCRIPTION
One thing I'm not terribly happy about is the fact that I currently represent Nil as [] (i.e., the empty Javascript Array). This is mostly due to the fact that it's short and easy to parse. If we used something different, like a dedicated string or the empty object {}, it would be kind of hacky to parse this to the empty list in jsonparse.mly.

In addition, I could have squashed a few commits. In particular, what I did in 
bed80f3 was later mostly reverted. Do we pay a lot of attentition to squashing such useless commits?