### PR TITLE
Better error message for kind error during type alias application

### DIFF
--- a/instantiate.ml
+++ b/instantiate.ml
@@ -304,7 +304,7 @@ let apply_type : Types.datatype -> Types.type_arg list -> Types.datatype =
         | `ForAll (vars, t) -> t, Types.unbox_quantifiers vars
         | t -> t, [] in
     let tenv, renv, penv =
-      if (List.length vars <> List.length tyargs) then        
+      if (List.length vars <> List.length tyargs) then
         (Debug.print (Printf.sprintf "# Type variables (total %d)" (List.length vars));
          let tyvars = String.concat "\n" @@ List.mapi (fun i t -> (string_of_int @@ i+1) ^ ". " ^ Types.Show_quantifier.show t) vars in
          Debug.print tyvars;
@@ -393,7 +393,9 @@ let alias name tyargs env =
         let tenv, renv, penv =
           List.fold_right2
             (fun q arg (tenv, renv, penv) ->
-              assert (primary_kind_of_quantifier q = primary_kind_of_type_arg arg);
+              if not (primary_kind_of_quantifier q = primary_kind_of_type_arg arg)
+              then failwith (Printf.sprintf
+"Argument '%s' to type alias '%s' has the wrong kind ('%s' instead of '%s')" (Types.string_of_type_arg arg) name (Types.string_of_primary_kind (primary_kind_of_type_arg arg)) (Types.string_of_primary_kind (primary_kind_of_quantifier q)));
               let x = var_of_quantifier q in
                 match arg with
                 | `Type t ->

--- a/types.ml
+++ b/types.ml
@@ -1575,11 +1575,12 @@ struct
       | (`Any, `Session) -> restriction `Session
       | (l, r) -> full (l, r)
 
+  let primary_kind : primary_kind -> string = function
+    | `Type -> "Type"
+    | `Row -> "Row"
+    | `Presence -> "Presence"
+
   let kind : (policy * names) -> kind -> string =
-    let primary_kind = function
-      | `Type -> "Type"
-      | `Row -> "Row"
-      | `Presence -> "Presence" in
     let restriction = function
       | `Any -> "Any"
       | `Base -> "Base"
@@ -2040,6 +2041,9 @@ let string_of_tycon_spec ?(policy=Print.default_policy) ?(refresh_tyvar_names=tr
   if refresh_tyvar_names then
     build_tyvar_names (fun x -> free_bound_tycon_type_vars x) [tycon];
   Print.tycon_spec TypeVarSet.empty (policy (), Vars.tyvar_name_map) tycon
+
+let string_of_primary_kind primary_kind =
+  Print.primary_kind primary_kind
 
 module Show_datatype =
   Deriving_Show.Defaults

--- a/types.mli
+++ b/types.mli
@@ -352,6 +352,7 @@ val string_of_row_var    : ?policy:(unit -> Print.policy)
                         -> ?refresh_tyvar_names:bool -> row_var    -> string
 val string_of_tycon_spec : ?policy:(unit -> Print.policy)
                         -> ?refresh_tyvar_names:bool -> tycon_spec -> string
+val string_of_primary_kind : primary_kind -> string
 val string_of_environment        : environment -> string
 val string_of_typing_environment : typing_environment -> string
 
@@ -363,6 +364,6 @@ val add_tyvar_names : ('a -> Vars.vars_list)
                    -> ('a list)
                    -> unit
 (* Function type constructors *)
-val make_pure_function_type : datatype -> datatype -> datatype		   
+val make_pure_function_type : datatype -> datatype -> datatype
 val make_function_type      : datatype -> row -> datatype -> datatype
-val make_thunk_type : row -> datatype -> datatype  
+val make_thunk_type : row -> datatype -> datatype


### PR DESCRIPTION
Pick a low-hanging error message "fruit". We could always do better,
but this should be enough to finally close #19 which was reported
almost 3 years ago.