### PR TITLE
Session Exceptions (again!)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -80,6 +80,7 @@ SOURCES = $(OPC)                                \
           defaultAliases.ml                     \
           requestData.mli requestData.ml        \
           value.mli value.ml                    \
+					channelVarUtils.mli channelVarUtils.ml \
           eventHandlers.mli eventHandlers.ml    \
           xmlParser.mly xmlLexer.mll            \
           parseXml.mli parseXml.ml              \
@@ -97,6 +98,7 @@ SOURCES = $(OPC)                                \
           desugarInners.mli desugarInners.ml             \
 	  desugarCP.mli desugarCP.ml                     \
 	  desugarHandlers.mli desugarHandlers.ml         \
+          desugarSessionExceptions.mli desugarSessionExceptions.ml \
           typeSugar.mli typeSugar.ml                     \
           checkXmlQuasiquotes.ml                \
           experimentalExtensions.ml \

--- a/Makefile
+++ b/Makefile
@@ -44,11 +44,11 @@ SOURCES = $(OPC)                                \
           multipart.ml                          \
           notfound.ml                           \
           utility.ml                            \
-	  processTypes.mli processTypes.ml      \
+					processTypes.mli processTypes.ml      \
           env.mli env.ml                        \
           settings.mli settings.ml              \
           basicsettings.ml                      \
-	  parseSettings.ml \
+					parseSettings.ml \
           debug.mli debug.ml                    \
           performance.mli performance.ml        \
           graph.ml                              \
@@ -71,7 +71,7 @@ SOURCES = $(OPC)                                \
           closures.ml                           \
           parse.mli parse.ml                    \
           sugarTraversals.mli  sugarTraversals.ml       \
-	  moduleUtils.mli moduleUtils.ml \
+					moduleUtils.mli moduleUtils.ml \
           resolvePositions.mli resolvePositions.ml       \
 					chaser.mli chaser.ml \
 					desugarAlienBlocks.mli desugarAlienBlocks.ml \
@@ -96,8 +96,8 @@ SOURCES = $(OPC)                                \
           desugarFuns.mli desugarFuns.ml                 \
           desugarProcesses.mli desugarProcesses.ml       \
           desugarInners.mli desugarInners.ml             \
-	  desugarCP.mli desugarCP.ml                     \
-	  desugarHandlers.mli desugarHandlers.ml         \
+					desugarCP.mli desugarCP.ml                     \
+				  desugarHandlers.mli desugarHandlers.ml         \
           desugarSessionExceptions.mli desugarSessionExceptions.ml \
           typeSugar.mli typeSugar.ml                     \
           checkXmlQuasiquotes.ml                \
@@ -114,7 +114,7 @@ SOURCES = $(OPC)                                \
 					resolveJsonState.mli resolveJsonState.ml \
           database.mli database.ml              \
           linksregex.ml                         \
-	  lib.mli lib.ml                        \
+					lib.mli lib.ml                        \
           sugartoir.mli sugartoir.ml            \
           loader.mli loader.ml                  \
           $(DB_CODE)                            \
@@ -123,10 +123,10 @@ SOURCES = $(OPC)                                \
           queryshredding.ml                     \
           webserver_types.mli webserver_types.ml \
           webserver.mli                         \
-	  evalir.ml                             \
+					evalir.ml                             \
           buildTables.ml                        \
           webif.mli webif.ml                    \
-	  webserver.ml                          \
+					webserver.ml                          \
           links.ml                              \
 
 # TODO: get these working again

--- a/Makefile
+++ b/Makefile
@@ -44,11 +44,11 @@ SOURCES = $(OPC)                                \
           multipart.ml                          \
           notfound.ml                           \
           utility.ml                            \
-					processTypes.mli processTypes.ml      \
+          processTypes.mli processTypes.ml      \
           env.mli env.ml                        \
           settings.mli settings.ml              \
           basicsettings.ml                      \
-					parseSettings.ml \
+          parseSettings.ml \
           debug.mli debug.ml                    \
           performance.mli performance.ml        \
           graph.ml                              \
@@ -71,16 +71,16 @@ SOURCES = $(OPC)                                \
           closures.ml                           \
           parse.mli parse.ml                    \
           sugarTraversals.mli  sugarTraversals.ml       \
-					moduleUtils.mli moduleUtils.ml \
+          moduleUtils.mli moduleUtils.ml \
           resolvePositions.mli resolvePositions.ml       \
-					chaser.mli chaser.ml \
-					desugarAlienBlocks.mli desugarAlienBlocks.ml \
-					desugarModules.mli desugarModules.ml \
+          chaser.mli chaser.ml \
+          desugarAlienBlocks.mli desugarAlienBlocks.ml \
+          desugarModules.mli desugarModules.ml \
           desugarDatatypes.mli desugarDatatypes.ml      \
           defaultAliases.ml                     \
           requestData.mli requestData.ml        \
           value.mli value.ml                    \
-					channelVarUtils.mli channelVarUtils.ml \
+          channelVarUtils.mli channelVarUtils.ml \
           eventHandlers.mli eventHandlers.ml    \
           xmlParser.mly xmlLexer.mll            \
           parseXml.mli parseXml.ml              \
@@ -96,8 +96,8 @@ SOURCES = $(OPC)                                \
           desugarFuns.mli desugarFuns.ml                 \
           desugarProcesses.mli desugarProcesses.ml       \
           desugarInners.mli desugarInners.ml             \
-					desugarCP.mli desugarCP.ml                     \
-				  desugarHandlers.mli desugarHandlers.ml         \
+          desugarCP.mli desugarCP.ml                     \
+          desugarHandlers.mli desugarHandlers.ml         \
           desugarSessionExceptions.mli desugarSessionExceptions.ml \
           typeSugar.mli typeSugar.ml                     \
           checkXmlQuasiquotes.ml                \
@@ -105,16 +105,16 @@ SOURCES = $(OPC)                                \
           frontend.ml                           \
           dumpTypes.ml                          \
           compilePatterns.ml                    \
-					websocketMessages.ml \
+          websocketMessages.ml \
           jsonparse.mly                         \
           jsonlex.mll                           \
           js.ml                                 \
           json.mli json.ml                      \
           proc.mli proc.ml                      \
-					resolveJsonState.mli resolveJsonState.ml \
+          resolveJsonState.mli resolveJsonState.ml \
           database.mli database.ml              \
           linksregex.ml                         \
-					lib.mli lib.ml                        \
+          lib.mli lib.ml                        \
           sugartoir.mli sugartoir.ml            \
           loader.mli loader.ml                  \
           $(DB_CODE)                            \
@@ -123,10 +123,10 @@ SOURCES = $(OPC)                                \
           queryshredding.ml                     \
           webserver_types.mli webserver_types.ml \
           webserver.mli                         \
-					evalir.ml                             \
+          evalir.ml                             \
           buildTables.ml                        \
           webif.mli webif.ml                    \
-					webserver.ml                          \
+          webserver.ml                          \
           links.ml                              \
 
 # TODO: get these working again

--- a/basicsettings.ml
+++ b/basicsettings.ml
@@ -281,3 +281,7 @@ module Readline = struct
   (* Enable native readline? *)
   let native_readline = Settings.add_bool("native_readline", true, `User)
 end
+
+module Sessions = struct
+  let exceptions_enabled = Settings.add_bool ("session_exceptions", false, `User)
+end

--- a/channelVarUtils.ml
+++ b/channelVarUtils.ml
@@ -1,0 +1,151 @@
+open Value
+open Utility
+open Pervasives (* PIPES *)
+
+(* TODO: Maybe it would be nice to have some kind of visitors for the IR?
+ * Or is it just me that's crazy enough to have to traverse it? *)
+let variables_in_computation comp =
+  Debug.print ("Getting variables in computation: " ^ (Ir.Show_computation.show comp));
+  let open Ir in
+  let variable_set = ref IntSet.empty in
+  let add_variable var =
+    variable_set := (IntSet.add var !variable_set) in
+  let rec traverse_stringmap : 'a . ('a -> unit) -> 'a stringmap -> unit =
+    fun proj_fn smap -> (* (proj_fn: 'a . 'a -> 'b) (smap: 'a stringmap) : unit = *)
+      StringMap.fold (fun _ v _ -> proj_fn v) smap ()
+  and traverse_value = function
+    | `Variable v -> add_variable v
+    | `Closure (_, value)
+    | `Project (_, value)
+    | `Inject (_, value, _)
+    | `TAbs (_, value)
+    | `TApp (value, _)
+    | `Coerce (value, _)
+    | `Erase (_, value) -> traverse_value value
+    | `XmlNode (_, v_map, vs) ->
+        traverse_stringmap (traverse_value) v_map;
+        List.iter traverse_value vs
+    | `ApplyPure (v, vs) ->
+        traverse_value v;
+        List.iter traverse_value vs
+    | `Extend (v_map, v_opt) ->
+        traverse_stringmap (traverse_value) v_map;
+        begin match v_opt with | Some v -> traverse_value v | None -> () end
+    | `Constant _ -> ()
+  and traverse_tail_computation = function
+    | `Return value -> traverse_value value
+    | `Apply (value, values) ->
+        traverse_value value; List.iter traverse_value values
+    | `Special s -> traverse_special s
+    | `If (v, c1, c2) ->
+        traverse_value v; List.iter traverse_computation [c1 ; c2]
+    | `Case (scrutinee, cases, case_opt) ->
+        traverse_value scrutinee;
+        traverse_stringmap (fun (_, c) -> traverse_computation c) cases;
+        OptionUtils.opt_iter (fun (_, c) -> traverse_computation c) case_opt
+  and traverse_fundef (bnd, (_, _, _), _, _) =
+    let fun_var = Var.var_of_binder bnd in
+    match Tables.(lookup fun_defs fun_var) with
+      | Some (_, _, (Some fvs_var), _) ->
+          Debug.print ("fvs_var: " ^ (string_of_int fvs_var));
+          add_variable fvs_var
+      | Some _fd -> Debug.print ("fundef without fvs var attached")
+      | _ -> ()
+    (* traverse_computation c *)
+  and traverse_binding = function
+    | `Let (_, (_, tc)) -> traverse_tail_computation tc
+    | `Fun fd ->
+        Debug.print "traversing fundef";
+        traverse_fundef fd
+    | `Rec fds -> List.iter traverse_fundef fds
+    | `Module (_, (Some bs)) -> List.iter traverse_binding bs
+    | `Module _
+    | `Alien _ -> ()
+  and traverse_special = function
+    | `Database value
+    | `CallCC value
+    | `Select (_, value) -> traverse_value value
+    | `Wrong _ -> ()
+    | `Table (v1, v2, v3, _) -> List.iter (traverse_value) [v1; v2; v3]
+    | `Query (vs_opt, comp, _) ->
+        OptionUtils.opt_iter
+          (fun (v1, v2) -> List.iter (traverse_value) [v1; v2]) vs_opt;
+        traverse_computation comp
+    | `Update ((_, v), c_opt, c) ->
+        traverse_value v;
+        OptionUtils.opt_iter (traverse_computation) c_opt;
+        traverse_computation c
+    | `Delete ((_, v), c_opt) ->
+        traverse_value v;
+        OptionUtils.opt_iter (traverse_computation) c_opt
+    | `Handle h -> traverse_handler h
+    | `DoOperation (_, vs, _) -> List.iter (traverse_value) vs
+    | `Choice (v, clauses) ->
+        traverse_value v;
+        traverse_stringmap (fun (_, c) ->
+          traverse_computation c) clauses
+  and traverse_computation (bnds, tc) =
+    List.iter traverse_binding bnds; traverse_tail_computation tc
+  and traverse_clause (_, _, c) = traverse_computation c
+  and traverse_handler (h: Ir.handler) =
+    traverse_computation (h.ih_comp);
+    traverse_stringmap (traverse_clause) h.ih_clauses in
+  traverse_computation comp;
+  IntSet.elements (!variable_set)
+
+(* Key point: IR variables are unique (HURRAH!) -- so no need to
+ * worry about shadowing. All we need to do is:
+   * 1) traverse each frame's computation to gather the referenced variables
+   * 2) for each variable, check whether it's in the environment upon handler
+   *    installation. If so, and it's a channel, add to the variable set
+   * 3) fold over variable set in order to resolve to channels *)
+
+
+let sessions_in_value v =
+  let values = ref [] in
+  let add_value v = values := (v :: (!values)) in
+
+  let rec go = function
+    | `List vs -> List.iter (go) vs
+    | `Record r -> List.iter (fun (_, v) -> go v) r
+    | `Variant (_, v) -> go v
+    | `FunctionPtr (_, (Some fvs)) -> go fvs
+    | (`SessionChannel _) as c ->
+        Debug.print ("affected value: " ^ (Value.string_of_value c));
+        add_value c
+    | v ->
+        Debug.print ("not-affected value: " ^ (Value.string_of_value v)) in
+  go v; (!values)
+
+
+let affected_in_context (raise_env: Value.env) comp =
+  let open Pervasives in
+  let show_values xs =
+    String.concat "," (List.map (string_of_value) xs) in
+  let affected_values =
+    List.fold_left (fun acc v ->
+      match Value.Env.lookup v raise_env with
+        | Some v -> v :: acc
+        | None -> acc
+    ) [] (variables_in_computation comp) in
+  let res = List.map (sessions_in_value) affected_values |> List.concat in
+  Debug.print ("Final affected values: " ^ (show_values res));
+  res
+
+(*
+let show_frames =
+  List.iter (fun (sc, v, env, comp) ->
+    Printf.printf "FRAME: \n scope: %s \n var: %s \n env: %s \n comp: %s \n \n"
+      (Ir.Show_scope.show sc)
+      (string_of_int v)
+      (Value.Show_env.show env)
+      (Ir.Show_computation.show comp))
+*)
+
+let affected_channels raise_env frames =
+  let affected_context_chans =
+    List.fold_left (
+      fun acc c ->
+        (affected_in_context raise_env c) @ acc) [] frames in
+  unduplicate (fun v1 v2 -> v1 = v2) (affected_context_chans)
+

--- a/channelVarUtils.ml
+++ b/channelVarUtils.ml
@@ -2,8 +2,10 @@ open Value
 open Utility
 open Pervasives (* PIPES *)
 
-(* TODO: Maybe it would be nice to have some kind of visitors for the IR?
- * Or is it just me that's crazy enough to have to traverse it? *)
+(* We can't use the visitor in ir.ml, since we don't have access to the
+ * typing environment at this point. It would be good to replace this with
+ * a visitor (or better, an implementation using the built tables) but that
+ * will have to come later. *)
 let variables_in_computation comp =
   Debug.print ("Getting variables in computation: " ^ (Ir.Show_computation.show comp));
   let open Ir in

--- a/channelVarUtils.mli
+++ b/channelVarUtils.mli
@@ -1,0 +1,9 @@
+val affected_channels :
+  Value.env -> (* Environment upon raising of exception *)
+  Ir.computation list -> (* Pure frames in remainder of try-block *)
+  Value.t list
+
+val variables_in_computation :
+  Ir.computation ->
+  Var.var list (* List of values in the computation *)
+

--- a/desugarSessionExceptions.ml
+++ b/desugarSessionExceptions.ml
@@ -1,0 +1,119 @@
+open Sugartypes
+
+(*
+ try { M } as (pat) in { N } otherwise { N' }
+
+  --->
+
+ handle M with {
+   Return pat -> N
+   _SessionFail _ _ -> N'
+ }
+
+*)
+
+
+module TyEnv = Env.String
+
+let failure_op_name = Value.session_exception_operation
+
+let dp = Sugartypes.dummy_position
+let mk_var_pat name : pattern = (`Variable (name, Some `Not_typed, dp), dp)
+let dummy_pat () = mk_var_pat @@ Utility.gensym ~prefix:"dsh" ()
+
+class insert_toplevel_handlers env =
+object (o: 'self_type)
+  inherit (TransformSugar.transform env) as super
+
+  method! phrasenode = function
+    | (`Spawn (`Wait, _, _, _)) as sw ->
+        super#phrasenode sw
+    | `Spawn (k, spawn_loc, (body, body_loc), Some inner_effects) ->
+        let as_var = Utility.gensym ~prefix:"spawn_aspat" () in
+        let as_pat = mk_var_pat as_var in
+        let unit_phr = (`RecordLit ([], None), dp) in
+
+        let (o, spawn_loc) = o#given_spawn_location spawn_loc in
+        let envs = o#backup_envs in
+        let (o, inner_effects) = o#row inner_effects in
+        let process_type = `Application (Types.process, [`Row inner_effects]) in
+        let o = o#with_effects inner_effects in
+        let (o, body, _) = o#phrasenode body in
+        let body =
+          `TryInOtherwise ((body, body_loc), as_pat, (`Var as_var, dp), unit_phr, (Some (Types.unit_type))) in
+        let o = o#restore_envs envs in
+        (o, (`Spawn (k, spawn_loc, (body, body_loc), Some inner_effects)), process_type)
+    | e -> super#phrasenode e
+end
+
+
+class desugar_session_exceptions env =
+object (o : 'self_type)
+  inherit (TransformSugar.transform env) as super
+
+  method! phrasenode = function
+    | `Raise ->
+        (o, `DoOperation (failure_op_name, [], Some `Not_typed), `Not_typed)
+    | `TryInOtherwise (_, _, _, _, None) -> assert false
+    | `TryInOtherwise (try_phr, pat, as_phr, otherwise_phr, (Some dt)) ->
+        let open Pervasives in (* Let me have those sweet, sweet pipes *)
+        let (o, try_phr, try_dt) = o#phrase try_phr in
+        let envs = o#backup_envs in
+        let (o, pat) = o#pattern pat in
+        let (o, as_phr, _as_dt) = o#phrase as_phr in
+        let o = o#restore_envs envs in
+        let (o, otherwise_phr, otherwise_dt) = o#phrase otherwise_phr in
+        (* Now, to create a handler... *)
+
+        let return_pat = (`Variant ("Return", Some (pat)), dp) in
+        let return_clause = (return_pat, as_phr) in
+        (* Otherwise clause: Distinguished 'session failure' name. Since
+         * we'll never use the continuation (and this is invoked after pattern
+         * deanonymisation in desugarHandlers), generate a fresh name for the
+         * continuation argument. *)
+        let cont_pat = dummy_pat () in
+
+        let otherwise_pat : Sugartypes.pattern =
+          ((`Variant (failure_op_name, Some (cont_pat))), dp) in
+
+        let otherwise_clause = (otherwise_pat, otherwise_phr) in
+
+        let clauses = [return_clause ; otherwise_clause] in
+
+        (* Manually construct a row with the two hardwired handler cases. *)
+        let raw_row =
+          Types.make_empty_closed_row ()
+            |> Types.row_with ("Return", (`Present try_dt))
+            |> Types.row_with (failure_op_name, (`Present (otherwise_dt))) in
+
+        (* Dummy types *)
+        let types =
+          (Types.make_empty_closed_row (), try_dt,
+          Types.make_empty_closed_row (), otherwise_dt) in
+
+        let hndl_desc = {
+          shd_depth = `Shallow; (* Doesn't matter either way, since we don't invoke the resumption. *)
+          shd_types = types;
+          shd_raw_row = raw_row
+        } in
+
+        let hndlr = {
+          sh_expr = try_phr;
+          sh_clauses = clauses;
+          sh_descr = hndl_desc
+        } in (o, `Handle hndlr, dt)
+    | e -> super#phrasenode e
+end
+
+let insert_toplevel_handlers env =
+  ((new insert_toplevel_handlers env) :
+    insert_toplevel_handlers :> TransformSugar.transform)
+
+let desugar_session_exceptions env =
+  ((new desugar_session_exceptions env) :
+    desugar_session_exceptions :> TransformSugar.transform)
+
+let show prog =
+  Printf.printf "%s\n\n" (Sugartypes.Show_program.show prog);
+  prog
+

--- a/desugarSessionExceptions.mli
+++ b/desugarSessionExceptions.mli
@@ -1,0 +1,3 @@
+val insert_toplevel_handlers : Types.typing_environment -> TransformSugar.transform
+val desugar_session_exceptions : Types.typing_environment -> TransformSugar.transform
+val show : Sugartypes.program -> Sugartypes.program

--- a/desugarSessionExceptions.mli
+++ b/desugarSessionExceptions.mli
@@ -1,3 +1,4 @@
 val insert_toplevel_handlers : Types.typing_environment -> TransformSugar.transform
 val desugar_session_exceptions : Types.typing_environment -> TransformSugar.transform
 val show : Sugartypes.program -> Sugartypes.program
+val settings_check : Sugartypes.program -> unit

--- a/evalir.ml
+++ b/evalir.ml
@@ -593,13 +593,12 @@ struct
            already been applied here *)
         match value env db, value env name, value env keys, (TypeUtils.concrete_type readtype) with
           | `Database (db, params), name, keys, `Record row ->
-        let unboxed_keys =
-    List.map
-      (fun key ->
-        List.map Value.unbox_string (Value.unbox_list key))
-      (Value.unbox_list keys)
-        in
-              apply_cont cont env (`Table ((db, params), Value.unbox_string name, unboxed_keys, row))
+            let unboxed_keys =
+              List.map
+                (fun key ->
+                  List.map Value.unbox_string (Value.unbox_list key))
+                (Value.unbox_list keys)
+            in apply_cont cont env (`Table ((db, params), Value.unbox_string name, unboxed_keys, row))
           | _ -> eval_error "Error evaluating table handle"
       end
     | `Query (range, e, _t) ->
@@ -613,25 +612,25 @@ struct
            match Queryshredding.compile_shredded env (range, e) with
            | None -> computation env cont e
            | Some (db, p) ->
-               begin
-     if db#driver_name() <> "postgresql"
-     then raise (Errors.Runtime_error "Only PostgreSQL database driver supports shredding");
-     let get_fields t =
-                   match t with
-                   | `Record fields ->
-                       StringMap.to_list (fun name p -> (name, `Primitive p)) fields
-                   | _ -> assert false
-     in
-                 let execute_shredded_raw (q, t) =
-       Database.execute_select_result (get_fields t) q db, t in
-     let raw_results =
-       Queryshredding.Shred.pmap execute_shredded_raw p in
-     let mapped_results =
-       Queryshredding.Shred.pmap Queryshredding.Stitch.build_stitch_map raw_results in
+             begin
+               if db#driver_name() <> "postgresql"
+                 then raise (Errors.Runtime_error "Only PostgreSQL database driver supports shredding");
+               let get_fields t =
+                             match t with
+                             | `Record fields ->
+                                 StringMap.to_list (fun name p -> (name, `Primitive p)) fields
+                             | _ -> assert false
+               in
+               let execute_shredded_raw (q, t) =
+                 Database.execute_select_result (get_fields t) q db, t in
+               let raw_results =
+                 Queryshredding.Shred.pmap execute_shredded_raw p in
+               let mapped_results =
+                 Queryshredding.Shred.pmap Queryshredding.Stitch.build_stitch_map raw_results in
                  apply_cont cont env
-       (Queryshredding.Stitch.stitch_mapped_query mapped_results)
-               end
-   end
+                 (Queryshredding.Stitch.stitch_mapped_query mapped_results)
+             end
+         end
        else (* shredding disabled *)
          begin
            match Query.compile env (range, e) with
@@ -650,7 +649,7 @@ struct
                    []
                in
                apply_cont cont env (Database.execute_select fields q db)
-   end
+         end
     | `Update ((xb, source), where, body) ->
       let db, table, field_types =
         match value env source with

--- a/examples/distribution/chatserver/chatServer.links
+++ b/examples/distribution/chatserver/chatServer.links
@@ -6,16 +6,21 @@ open ChatClient
 # Alas, we can't make this an inner function at the moment since we need a type
 # annotation, and type annotations are broken for inner functions at the moment
 fun clientHandlerLoop(nick, clientToServerChan, loopPid) {
-
-  offer(clientToServerChan) {
-    case ChatMessage(clientToServerChan) ->
-      var (msg, clientToServerChan) = receive(clientToServerChan);
-      loopPid ! BroadcastMessage(nick, msg);
-      clientHandlerLoop(nick, clientToServerChan, loopPid)
-    case ChangeTopic(clientToServerChan) ->
-      var (newTopic, clientToServerChan) = receive(clientToServerChan);
-      loopPid ! BroadcastChangeTopic(newTopic);
-      clientHandlerLoop(nick, clientToServerChan, loopPid)
+  try {
+    offer(clientToServerChan) {
+      case ChatMessage(clientToServerChan) ->
+        var (msg, clientToServerChan) = receive(clientToServerChan);
+        loopPid ! BroadcastMessage(nick, msg);
+        (nick, clientToServerChan, loopPid)
+      case ChangeTopic(clientToServerChan) ->
+        var (newTopic, clientToServerChan) = receive(clientToServerChan);
+        loopPid ! BroadcastChangeTopic(newTopic);
+        (nick, clientToServerChan, loopPid)
+    }
+  } as (nick, chan, pid) in {
+    clientHandlerLoop(nick, chan, pid)
+  } otherwise {
+    loopPid ! BroadcastUserLeft(nick)
   }
 }
 
@@ -74,6 +79,9 @@ fun serverLoop(topic, nicks, pids) {
     case BroadcastChangeTopic(newTopic) ->
       broadcastMessage(DeliverNewTopic(newTopic), pids);
       serverLoop(newTopic, nicks, pids)
+    case BroadcastUserLeft(nick) ->
+      broadcastMessage(DeliverUserLeft(nick), pids);
+      serverLoop(topic, filter(fun(x) { not(x == nick) }, nicks), pids)
     case NewClient(nick, pid) ->
       broadcastMessage(DeliverNewUser(nick), pids);
       serverLoop(topic, nick :: nicks, pid :: pids)

--- a/examples/distribution/clientToClientViaServerAP.links
+++ b/examples/distribution/clientToClientViaServerAP.links
@@ -62,10 +62,10 @@ module Pinger {
     }
   }
 
-  fun setup(clLoc, srvAP) {
+  fun setup(srvAP) {
     # Spawn a thread on the client to request a channel from
     # srvAP, and handle communication.
-    var clPid = spawnAt(clLoc, { commThread(srvAP) } );
+    var clPid = spawnClient { commThread(srvAP) };
     makePage(clPid, true)
   }
 
@@ -96,10 +96,10 @@ module Ponger {
     }
   }
 
-  fun setup(clLoc, srvAP) {
+  fun setup(srvAP) {
     # Spawn a thread on the client to request a channel from
     # srvAP, and handle communication.
-    var clPid = spawnAt(clLoc, { commThread(srvAP) } );
+    var clPid = spawnClient { commThread(srvAP) };
     makePage(clPid, false)
   }
 }
@@ -107,8 +107,8 @@ module Ponger {
 
 fun main() {
   var srvAP = new();
-  addRoute("/pinger", fun(_, clientLoc) { Pinger.setup(clientLoc, srvAP) });
-  addRoute("/ponger", fun(_, clientLoc) { Ponger.setup(clientLoc, srvAP) });
+  addRoute("/pinger", fun(_) { Pinger.setup(srvAP) });
+  addRoute("/ponger", fun(_) { Ponger.setup(srvAP) });
   serveWebsockets();
   servePages();
 }

--- a/frontend.ml
+++ b/frontend.ml
@@ -54,6 +54,8 @@ struct
         (*->- after_typing ((FixTypeAbstractions.fix_type_abstractions tyenv)#program ->- snd3)*)
        ->- after_typing ((DesugarCP.desugar_cp tyenv)#program ->- snd3)
        ->- after_typing ((DesugarInners.desugar_inners tyenv)#program ->- snd3)
+       ->- after_typing ((DesugarSessionExceptions.insert_toplevel_handlers tyenv)#program ->- snd3)
+       ->- after_typing ((DesugarSessionExceptions.desugar_session_exceptions tyenv)#program ->- snd3)
        ->- after_typing ((DesugarProcesses.desugar_processes tyenv)#program ->- snd3)
        ->- after_typing ((DesugarDbs.desugar_dbs tyenv)#program ->- snd3)
        ->- after_typing ((DesugarFors.desugar_fors tyenv)#program ->- snd3)

--- a/frontend.ml
+++ b/frontend.ml
@@ -45,6 +45,7 @@ struct
               "modules flag to true, or run with -m.")
       else (program, ModuleUtils.get_ffi_files program) in
       let _program = CheckXmlQuasiquotes.checker#program program in
+      let () = DesugarSessionExceptions.settings_check program in
       ((( ExperimentalExtensions.check#program
        ->- DesugarHandlers.desugar_handlers_early#program
        ->- DesugarLAttributes.desugar_lattributes#program

--- a/ir.ml
+++ b/ir.ml
@@ -499,7 +499,7 @@ struct
 	   let (vs, _, o) = o#list (fun o -> o#value) vs in
 	   (`DoOperation (name, vs, t), t, o)
 
-    method bindings : binding list -> (binding list * 'self_type) =
+   method bindings : binding list -> (binding list * 'self_type) =
       fun bs ->
         let bs, o =
           List.fold_left

--- a/ir.mli
+++ b/ir.mli
@@ -84,7 +84,8 @@ and special =
   | `Select of (name * value)
   | `Choice of (value * (binder * computation) name_map)
   | `Handle of handler
-  | `DoOperation of (name * value list * Types.datatype) ]
+  | `DoOperation of (name * value list * Types.datatype)
+  ]
 and computation = binding list * tail_computation
 and clause = [`ResumptionBinder of binder | `NoResumption] * binder * computation
 and handler = {

--- a/ir.mli
+++ b/ir.mli
@@ -84,8 +84,7 @@ and special =
   | `Select of (name * value)
   | `Choice of (value * (binder * computation) name_map)
   | `Handle of handler
-  | `DoOperation of (name * value list * Types.datatype)
-  ]
+  | `DoOperation of (name * value list * Types.datatype) ]
 and computation = binding list * tail_computation
 and clause = [`ResumptionBinder of binder | `NoResumption] * binder * computation
 and handler = {

--- a/irtojs.ml
+++ b/irtojs.ml
@@ -54,6 +54,65 @@ module VEnv = Env.Int
 (** Type of environments mapping IR variables to source variables *)
 type venv = string VEnv.t
 
+module VariableInspection = struct
+  let inspect_code_variables code =
+    let open Pervasives in
+    let vars = ref (StringSet.empty) in
+    let add_var s = vars := (StringSet.add s (!vars)) in
+
+    let binders = ref (StringSet.empty) in
+    let add_binder s = binders := (StringSet.add s (!binders)) in
+    let add_binders = List.iter (add_binder) in
+
+    let get_vars () =
+      let res = StringSet.diff (!vars) (!binders) |> StringSet.elements in
+      Debug.print "affected client vars: \n";
+      List.iter (Debug.print) res;
+      res in
+
+    let rec go cmd =
+      match cmd with
+        | Var s -> add_var s
+        | Fn (bnds, cmd) ->
+            add_binders bnds;
+            go cmd
+        | LetFun ((bnd1, bnds, cmd1, _), cmd2) ->
+            add_binder bnd1; add_binders bnds;
+            go cmd1; go cmd2
+        | LetRec (xs, cmd) ->
+            List.iter (fun (bnd1, bnds, cmd, _) ->
+              add_binder bnd1; add_binders bnds; go cmd) xs;
+            go cmd
+        | Call (c, cs) -> go c; List.iter (go) cs
+        | Unop (_, c) -> go c
+        | Binop (c1, _, c2) -> go c1; go c2
+        | If (i, t, e) -> List.iter (go) [i;t;e]
+        | Dict xs -> List.iter (go -<- snd) xs
+        | Arr xs -> List.iter (go) xs
+        | Bind (bnd, c1, c2) -> add_binder bnd; go c1; go c2
+        | Return c -> go c
+        | Case (bnd, sm, sc_opt) ->
+            add_var bnd;
+            StringMap.iter (fun _ (s, code) -> add_binder s; go code) sm;
+            OptionUtils.opt_iter (fun (bnd, c) -> add_binder bnd; go c) sc_opt
+        | Lit _ | Die _ | Nothing -> () in
+    go code;
+    get_vars ()
+
+(*
+  let filter_resolvable env vars =
+    let open Pervasives in
+    List.map (fun var ->
+      if (VEnv.has env var) then [var] else []) vars
+    |> List.concat
+*)
+
+  let get_affected_variables code =
+    let open Pervasives in
+    inspect_code_variables code
+    (* |> filter_resolvable env *)
+    |> List.map (fun v -> Var(v))
+end
 
 
 (** Continuation parameter name (convention) *)
@@ -367,7 +426,7 @@ end
 (** [cps_prims]: a list of primitive functions that need to see the
     current continuation. Calls to these are translated in CPS rather than
     direct-style.  A bit hackish, this list. *)
-let cps_prims = ["recv"; "sleep"; "spawnWait"; "receive"; "request"; "accept"]
+let cps_prims = ["recv"; "sleep"; "spawnWait"; "receive"; "request"; "accept"; "send"]
 
 (** Generate a JavaScript name from a binder, wordifying symbolic names *)
 let name_binder (x, info) =
@@ -415,6 +474,9 @@ module type CONTINUATION = sig
 
   (* Generates appropriate bindings for primitives *)
   val primitive_bindings : string
+
+  (* Generates a string dump of the continuation, for debugging purposes. *)
+  val to_string : t -> string
 end
 
 (* (\* The standard Links continuation (no extensions) *\) *)
@@ -468,18 +530,24 @@ module Default_Continuation : CONTINUATION = struct
     "function _makeCont(k) { return k; }\n" ^
       "var _idy = function(x) { return; };\n" ^
       "var _applyCont = _applyCont_Default; var _yieldCont = _yieldCont_Default;\n" ^
-        "var _cont_kind = \"Default_Continuation\";\n" ^
-          "function is_continuation(value) {return value != undefined && (typeof value == 'function' || value instanceof Object && value.constructor == Function); }"
+      "var _cont_kind = \"Default_Continuation\";\n" ^
+        "function is_continuation(value) {return value != undefined && (typeof value == 'function' || value instanceof Object && value.constructor == Function); }\n" ^
+      "const exceptions_enabled = false;\n"
+
 
   let contify_with_env fn =
     match fn Identity with
     | env, (Fn _ as k) -> env, reflect k
-    | _ -> failwith "error: contify: none function argument."
+    | _ -> failwith "error: contify: non-function argument."
 
   (* Pop returns the code in "the singleton list" as the second
      component, and returns a fresh singleton list containing the
      identity element in the third component. *)
   let pop k = (fun code -> code), k, Identity
+
+  let to_string = function
+    | Identity -> "IDENTITY"
+    | Code code -> "CODE: " ^ (Show_code.show code)
 end
 
 (* The higher-order continuation structure for effect handlers
@@ -521,12 +589,14 @@ module Higher_Order_Continuation : CONTINUATION = struct
        append a b
 
   let bind kappas body =
+    (* Binds a continuation *)
     let rec bind bs ks =
       fun kappas ->
         match kappas with
         | Identity ->
+           (* Generate a new continuation name *)
            let k = gensym ~prefix:"_kappa" () in
-          (fun code -> bs (Bind (k, reify Identity, code))), ks, Var k
+             (fun code -> bs (Bind (k, reify Identity, code))), ks, Var k
         | Reflect ((Var _) as v) ->
            bs, ks, v
         | Reflect v ->
@@ -554,10 +624,11 @@ module Higher_Order_Continuation : CONTINUATION = struct
       "}\n" ^
       "var _idy = _makeCont(function(x, ks) { return; }); var _idk = function(x,ks) { };\n" ^
       "var _applyCont = _applyCont_HO; var _yieldCont = _yieldCont_HO;\n" ^
-        "var _cont_kind = \"Higher_Order_Continuation\";\n" ^
-          "function is_continuation(kappa) {\n" ^
-            "return kappa !== null && typeof kappa === 'object' && _hd(kappa) !== undefined && _tl(kappa) !== undefined;\n" ^
-              "}"
+      "var _cont_kind = \"Higher_Order_Continuation\";\n" ^
+      "function is_continuation(kappa) {\n" ^
+        "return kappa !== null && typeof kappa === 'object' && _hd(kappa) !== undefined && _tl(kappa) !== undefined;\n" ^
+      "}\n" ^
+      "const exceptions_enabled = " ^ (string_of_bool @@ Settings.get_value (Basicsettings.Sessions.exceptions_enabled)) ^ ";\n"
 
   let contify_with_env fn =
     let name = __kappa in
@@ -576,6 +647,13 @@ module Higher_Order_Continuation : CONTINUATION = struct
                Bind (__ks, tail ks, code))),
        (reflect (Var __k)), reflect (Var __ks)
     | Identity -> pop toplevel
+
+  let rec to_string = function
+    | Identity -> "IDENTITY"
+    | Reflect code -> "REFLECT: " ^ (Show_code.show code)
+    | Cons (code, k) ->
+        "CONS: " ^ (Show_code.show code) ^ ", \n" ^ (to_string k)
+
 end
 
 (** Compiler interface *)
@@ -853,7 +931,11 @@ end = functor (K : CONTINUATION) -> struct
                      let arg = Call (Var ("_" ^ f_name), List.map gv vs) in
                      K.apply ~strategy:`Direct kappa arg
                    else
-                     apply_yielding (gv (`Variable f)) (List.map gv vs) kappa
+                     if (f_name = "send" || f_name = "receive") then
+                       let code_vs = List.map gv vs in
+                       generate_cancel_stub env f_name code_vs kappa
+                     else
+                       apply_yielding (gv (`Variable f)) (List.map gv vs) kappa
               end
            | _ ->
               apply_yielding (gv f) (List.map gv vs) kappa
@@ -907,8 +989,10 @@ end = functor (K : CONTINUATION) -> struct
          K.bind kappa
            (fun kappa -> apply_yielding (gv v) [K.reify kappa] kappa)
       | `Select (l, c) ->
-         let arg = Call (Var "_send", [Dict ["_label", strlit l; "_value", Dict []]; gv c]) in
-         K.apply ~strategy:`Direct kappa arg
+  (* and generate_cancel_stub env (f: Ir.var) (args: Ir.value list) (kappa: K.t) = *)
+         let args =
+          [Dict ["_label", strlit l; "_value", Dict []]; gv c] in
+         generate_cancel_stub env "send" args kappa
       | `Choice (c, bs) ->
          let result = gensym () in
          let received = gensym () in
@@ -920,11 +1004,22 @@ end = functor (K : CONTINUATION) -> struct
                let (c, cname) = name_binder cb in
                cname, Bind (cname, channel, snd (generate_computation (VEnv.bind env (c, cname)) b kappa)) in
              let branches = StringMap.map generate_branch bs in
+             let compiled_doOp =
+                   generate_special env (`DoOperation (
+                     Value.session_exception_operation,
+                     [], `Not_typed)) kappa in
+             let cancellation_thunk_name =
+                  gensym ~prefix:"cancellation_thunk" () in
              let recv_cont_name = "__recv_cont" in
-             Bind (recv_cont_name,
-              Call (Var "_makeCont", [Fn ([result], (Bind (received, scrutinee, (Case (received, branches, None)))))]),
-              Call (Var "receive", [gv c; Var recv_cont_name])))
+
+             let cancellation_thunk = Fn ([], compiled_doOp) in
+                (* Thunk will be passed as final non-continuation arg *)
+                Bind (recv_cont_name,
+                  Call (Var "_makeCont", [Fn ([result], (Bind (received, scrutinee, (Case (received, branches, None)))))]),
+                  Bind (cancellation_thunk_name, cancellation_thunk,
+                    (Call (Var "receive", [gv c; Var cancellation_thunk_name; Var recv_cont_name])))))
       | `DoOperation (name, args, _) ->
+         let open Pervasives in
          let box vs =
            Dict (List.mapi (fun i v -> (string_of_int @@ i + 1, gv v)) vs)
          in
@@ -934,20 +1029,32 @@ end = functor (K : CONTINUATION) -> struct
          let nil = Var "Nil" in
          K.bind kappa
            (fun kappas ->
+             (* kappa -- pure continuation *)
              let bind_skappa, skappa, kappas = K.pop kappas in
+             (* eta -- effect continuation *)
              let bind_seta, seta, kappas   = K.pop kappas in
              let resumption = K.(cons (reify seta) (cons (reify skappa) nil)) in
-             let op    =
+             (* Session exceptions need to be compiled specially *)
+             let op =
+             if (name = Value.session_exception_operation) then
+               let affected_variables =
+                 VariableInspection.get_affected_variables (K.reify kappa) in
+               let affected_arr = Dict ([("1", Arr affected_variables)]) in
+                 Dict [ ("_label", strlit name)
+                   ; ("_value", Dict [("p", affected_arr); ("s", resumption)])]
+             else
                Dict [ ("_label", strlit name)
                     ; ("_value", Dict [("p", box args); ("s", resumption)]) ]
              in
              bind_skappa (bind_seta (apply_yielding (K.reify seta) [op] kappas)))
       | `Handle { Ir.ih_comp = comp; Ir.ih_clauses = clauses; _ } ->
+         let open Pervasives in
          (** Generate body *)
          let gb env binder body kappas =
            let env' = VEnv.bind env (name_binder binder) in
            snd (generate_computation env' body kappas)
          in
+
          let (return_clause, operation_clauses) = StringMap.pop "Return" clauses in
          let return =
            let (_, xb, body) = return_clause in
@@ -957,10 +1064,21 @@ end = functor (K : CONTINUATION) -> struct
                  let bind, _, kappa = K.pop kappa in
                  bind @@ gb env xb body kappa))
          in
+
          let operations =
            (** Generate clause *)
-           let gc env (ct, xb, body) kappas =
+           let gc clause_name env (ct, xb, body) kappas =
+             (* env: environment
+              * ct: Resumption / NoResumption indicator
+              * xb: Binder for the operation
+              * body: Body of the clause
+              * kappas: Continuation stack
+              *)
+
+             (* Calculate JS name of the binder *)
              let x_name = snd @@ name_binder xb in
+
+             (* Bind the resumption *)
              let env', r_name =
                match ct with
                | `ResumptionBinder rb ->
@@ -971,20 +1089,36 @@ end = functor (K : CONTINUATION) -> struct
                   let dummy = name_binder dummy_binder in
                   VEnv.bind env dummy, snd dummy
              in
+
+             (* Project the arguments and continuation from the record compiled in DoOperation *)
              let p = Call (Var "LINKS.project", [Var x_name; strlit "p"]) in
              let s = Call (Var "LINKS.project", [Var x_name; strlit "s"]) in
              let r = Call (Var "_makeFun", [s]) in
+
+             (* Bind the names, and generate the body of the clause *)
+             (* The difference in compiling a "regular" operation and a session exception
+              * handler comes in the compilation of the clause body.
+              * For a "regular" clause body, we just bind the names and generate the
+              * clause body. For an exception handler body, we need to insert a call into
+              * _handleSessionException before invoking the clause body. *)
              let clause_body =
-               Bind (r_name, r,
-                     Bind (x_name, p, gb env' xb body kappas))
+               if (clause_name = Value.session_exception_operation) then
+                 let dummy_var_name = gensym () in
+                 Bind (r_name, r,
+                   Bind (x_name, Call(Var "LINKS.project", [p; strlit "1"]),
+                     Bind (dummy_var_name, Call (Var "_handleSessionException", [Var x_name]),
+                      gb env' xb body kappas)))
+               else
+                 Bind (r_name, r,
+                   Bind (x_name, p, gb env' xb body kappas))
              in
              x_name, clause_body
            in
            let clauses kappas =
-             StringMap.map
-               (fun clause ->
-                 gc env clause kappas)
-               operation_clauses
+             StringMap.fold
+               (fun clause_name clause ->
+                 StringMap.add clause_name (gc clause_name env clause kappas))
+               operation_clauses (StringMap.empty)
            in
            let forward ks =
              let z_name = "_z" in
@@ -1073,12 +1207,33 @@ end = functor (K : CONTINUATION) -> struct
        xs_names @ [__kappa],
        body,
        location)
+  and generate_cancel_stub env (f_name: string) (args: code list) (kappa: K.t) =
+    (* Compile a thunk to be invoked if the operation fails *)
+    let cancellation_thunk_name =
+      gensym ~prefix:"cancellation_thunk" () in
+
+    let raiseOp =
+      generate_special env (`DoOperation (
+        Value.session_exception_operation,
+        [], `Not_typed)) in
+
+    let fresh_kappa = gensym ~prefix:"kappa" () in
+    let cancellation_thunk = Fn ([fresh_kappa], raiseOp (K.reflect (Var fresh_kappa))) in
+
+    Bind (cancellation_thunk_name, cancellation_thunk,
+      (apply_yielding (Var f_name) (args @ [Var cancellation_thunk_name]) kappa))
 
   and generate_program env : Ir.program -> (venv * code) = fun ((bs, _) as comp) ->
     let (venv, code) = generate_computation env comp (K.reflect (Var "_start")) in
     (venv, GenStubs.bindings bs code)
 
-  let generate_toplevel_binding : Value.env -> Json.json_state -> venv -> Ir.binding -> Json.json_state * venv * string option * (code -> code) =
+  let generate_toplevel_binding :
+    Value.env ->
+    Json.json_state ->
+    venv ->
+    Ir.binding ->
+    Json.json_state * venv * string option * (code -> code) =
+
     fun valenv state varenv ->
       function
       | `Let (b, _) ->

--- a/irtojs.ml
+++ b/irtojs.ml
@@ -99,18 +99,9 @@ module VariableInspection = struct
     go code;
     get_vars ()
 
-(*
-  let filter_resolvable env vars =
-    let open Pervasives in
-    List.map (fun var ->
-      if (VEnv.has env var) then [var] else []) vars
-    |> List.concat
-*)
-
   let get_affected_variables code =
     let open Pervasives in
     inspect_code_variables code
-    (* |> filter_resolvable env *)
     |> List.map (fun v -> Var(v))
 end
 
@@ -174,7 +165,7 @@ struct
         StringMap.fold (fun l c s ->
                           s ^ show_case v l c)
           cases "" in
-    
+
     let show_default v = opt_app
       (fun (x, e) ->
          "default:{var " ^ x ^ "=" ^ v ^ ";" ^ show e ^ ";" ^ "break;}") "" in
@@ -199,10 +190,10 @@ struct
         | Case (v, cases, default) ->
             "switch (" ^ v ^ "._label) {" ^ show_cases v cases ^ show_default v default ^ "}"
         | Dict (elems) -> "{" ^ String.concat ", " (List.map (fun (name, value) -> "'" ^  name ^ "':" ^ show value) elems) ^ "}"
-        | Arr elems -> 
-          let rec show_list = function 
+        | Arr elems ->
+          let rec show_list = function
             | [] ->  Json.nil_literal
-            | x :: xs -> "{\"_head\":" ^ (show x) ^ ",\"_tail\":" ^ (show_list xs) ^ "}" in 
+            | x :: xs -> "{\"_head\":" ^ (show x) ^ ",\"_tail\":" ^ (show_list xs) ^ "}" in
           show_list elems
         | Bind (name, value, body) ->  name ^" = "^ show value ^"; "^ show body
         | Return expr -> "return " ^ (show expr) ^ ";"
@@ -265,9 +256,9 @@ struct
         | Fn _ as f -> show_func "" f
         | Call (Var "LINKS.project", [record; label]) ->
             maybe_parenise record ^^ (brackets (show label))
-        | Call (Var "hd", [list;kappa]) -> 
+        | Call (Var "hd", [list;kappa]) ->
             (maybe_parenise kappa) ^^ PP.text "hd" ^^ (parens (  maybe_parenise list))
-        | Call (Var "tl", [list;kappa]) -> 
+        | Call (Var "tl", [list;kappa]) ->
             (maybe_parenise kappa) ^^ PP.text "tl" ^^ (parens (  maybe_parenise list))
         | Call (Var "_yield", (fn :: args)) ->
             PP.text "_yield" ^^ (parens (PP.text "function () { " ^^ maybe_parenise fn ^^
@@ -292,10 +283,10 @@ struct
                                        group (PP.text "'" ^^ PP.text name ^^
                                                 PP.text "':" ^^ show value))
                                   elems)))
-        | Arr elems -> 
-            let rec show_list = function 
+        | Arr elems ->
+            let rec show_list = function
               | [] -> PP.text Json.nil_literal
-              | x :: xs -> PP.braces (PP.text "\"_head\":" ^+^ (show x) ^^ (PP.text ",") ^|  PP.nest 1 (PP.text "\"_tail\":" ^+^  (show_list xs))) in 
+              | x :: xs -> PP.braces (PP.text "\"_head\":" ^+^ (show x) ^^ (PP.text ",") ^|  PP.nest 1 (PP.text "\"_tail\":" ^+^  (show_list xs))) in
             show_list elems
         | Bind (name, value, body) ->
             PP.text "var" ^+^ PP.text name ^+^ PP.text "=" ^+^ show value ^^ PP.text ";" ^^

--- a/irtojs.ml
+++ b/irtojs.ml
@@ -426,7 +426,7 @@ end
 (** [cps_prims]: a list of primitive functions that need to see the
     current continuation. Calls to these are translated in CPS rather than
     direct-style.  A bit hackish, this list. *)
-let cps_prims = ["recv"; "sleep"; "spawnWait"; "receive"; "request"; "accept"; "send"]
+let cps_prims = ["recv"; "sleep"; "spawnWait"; "receive"; "request"; "accept"]
 
 (** Generate a JavaScript name from a binder, wordifying symbolic names *)
 let name_binder (x, info) =
@@ -931,7 +931,7 @@ end = functor (K : CONTINUATION) -> struct
                      let arg = Call (Var ("_" ^ f_name), List.map gv vs) in
                      K.apply ~strategy:`Direct kappa arg
                    else
-                     if (f_name = "send" || f_name = "receive") then
+                     if (f_name = "receive") then
                        let code_vs = List.map gv vs in
                        generate_cancel_stub env f_name code_vs kappa
                      else
@@ -989,10 +989,8 @@ end = functor (K : CONTINUATION) -> struct
          K.bind kappa
            (fun kappa -> apply_yielding (gv v) [K.reify kappa] kappa)
       | `Select (l, c) ->
-  (* and generate_cancel_stub env (f: Ir.var) (args: Ir.value list) (kappa: K.t) = *)
-         let args =
-          [Dict ["_label", strlit l; "_value", Dict []]; gv c] in
-         generate_cancel_stub env "send" args kappa
+         let arg = Call (Var "_send", [Dict ["_label", strlit l; "_value", Dict []]; gv c]) in
+         K.apply ~strategy:`Direct kappa arg
       | `Choice (c, bs) ->
          let result = gensym () in
          let received = gensym () in

--- a/jsonparse.mly
+++ b/jsonparse.mly
@@ -74,6 +74,10 @@ let websocket_req assoc_list =
 
         let msg_table = List.map parse_lost_message_entry unboxed_msgs in
         LostMessageResponse (carrier_chan, msg_table)
+    | "CHANNEL_CANCELLATION" ->
+        let notify_ep = get_and_unbox_str "notify_ep" |> ChannelID.of_string in
+        let cancelled_ep = get_and_unbox_str "cancelled_ep" |> ChannelID.of_string in
+        ChannelCancellation ( { notify_ep = notify_ep; cancelled_ep = cancelled_ep } )
     | _ -> failwith "Invalid opcode in websocket message"
 %}
 

--- a/lexer.mll
+++ b/lexer.mll
@@ -191,10 +191,11 @@ let keywords = [
  "orderby"  , ORDERBY;
  "op"       , OP;
  "open"     , OPEN;
+ "otherwise", OTHERWISE;
  "page"     , PAGE;
  "query"    , QUERY;
+ "raise"    , RAISE;
  "readonly" , READONLY;
-
  "receive"  , RECEIVE;
  "returning", RETURNING;
  "select"   , SELECT;
@@ -213,6 +214,7 @@ let keywords = [
  "table"    , TABLE;
  "TableHandle", TABLEHANDLE;
  "true"     , TRUE;
+ "try"     , TRY;
  "typename" , TYPENAME;
  "update"   , UPDATE;
  "values"   , VALUES;

--- a/lib.ml
+++ b/lib.ml
@@ -453,6 +453,11 @@ let env : (string * (located_primitive * Types.datatype * pure)) list = [
    datatype "forall s::Type(Any, Session).(AP(s)) ~> ~s",
    IMPURE);
 
+  "cancel",
+  (`PFun (fun _ -> assert false),
+   datatype "forall s::Type(Any, Session).(s) ~> ()",
+   IMPURE);
+
   (* Lists and collections *)
   "Nil",
   (`List [],

--- a/lib/js/jslib.js
+++ b/lib/js/jslib.js
@@ -424,7 +424,7 @@ const WEBSOCKET = {
   },
 
   onMessage : function(evt) {
-    var js_parsed = JSON.parse(evt.data);
+    const js_parsed = JSON.parse(evt.data);
     DEBUG.debug("Received message ", js_parsed || evt.data);
     if (TYPES.isObject(js_parsed)) {
       if ("opcode" in js_parsed) {
@@ -444,11 +444,11 @@ const WEBSOCKET = {
             break;
           case "SESSION_MESSAGE_DELIVERY":
             var ep_id = js_parsed.ep_id;
-            var msg = js_parsed.msg;
+            var message = js_parsed.msg;
             var delegated_chans = js_parsed.deleg_chans;
             var requires_lost_messages = js_parsed.requires_lost_messages;
             migrateDelegatedSessions(delegated_chans, requires_lost_messages);
-            deliverSessionMessage(ep_id, msg);
+            deliverSessionMessage(ep_id, message);
             break;
           case "GET_LOST_MESSAGES":
             var remote_ep = js_parsed.carrier_ep;
@@ -459,6 +459,11 @@ const WEBSOCKET = {
             var ep_id = js_parsed.ep_id;
             var lost_message_table = js_parsed.lost_messages;
             handleLostMessages(ep_id, lost_message_table);
+            break;
+          case "CHANNEL_CANCELLATION":
+            var notify_ep = js_parsed.notify_ep;
+            var cancelled_ep = js_parsed.cancelled_ep;
+            handleChannelCancellation(notify_ep, cancelled_ep);
             break;
           default:
             DEBUG.debug("Unhandled message: ", evt.data);
@@ -579,7 +584,15 @@ const WEBSOCKET = {
       msgs: lost_message_table,
     };
     WEBSOCKET.try_send(to_send_json);
-    return;
+  },
+
+  sendRemoteCancellation : function(notify_ep, cancelled_ep) {
+    DEBUG.debug("Sending remote cancellation. Notify ep ", notify_ep,
+                ", cancelled ep ", cancelled_ep);
+    const to_send_json =
+      { opcode: "CHANNEL_CANCELLATION", notify_ep: notify_ep,
+        cancelled_ep: cancelled_ep };
+    WEBSOCKET.try_send(to_send_json);
   }
 };
 
@@ -1532,10 +1545,14 @@ var error = LINKS.kify(_error);
 
 // partialApply : ((a0, a1, ..., an) -> b, a0) -> (a1, ..., an) -> b
 // the partialApply function is used to construct closures
+// Note that we annotate the closure with its environment, so that it
+// can be inspected
 function partialApply(f, x) {
-  return function () {
-    return f.apply(this, [x].concat(Array.prototype.slice.call(arguments)));
+  const res = function () {
+      f.apply(this, [x].concat(Array.prototype.slice.call(arguments)));
   }
+  res.__closureEnv = x;
+  return res;
 }
 
 // DOM interaction
@@ -2364,6 +2381,86 @@ var javascript = true;
 
 function _efferr(z, ks) { return _error("Unhandled operation `" + z._label + "'.") }
 
+function _isChannel(v) {
+   return (("_sessEP1" in v) && ("_sessEP2" in v));
+}
+
+// We want to inspect each variable to get the contained channels, even
+// if these things are, for example, tuples, lists, or closures.
+// Luckily we've already done this -- in the inspection for delegated sessions!
+function resolveSet(set) {
+  const ret = new Set();
+  for (let obj of set) {
+    const chans = getContainedSessions(obj);
+    for (let c of chans) {
+      ret.add(c);
+    }
+  }
+  return ret;
+}
+
+function _handleSessionException(cont_variables) {
+  const cont_set = new Set(cont_variables);
+  const resolved_cont_set = resolveSet(cont_set);
+  const affected_channels = Array.from(resolved_cont_set);
+  _debug("In handle session exception. Affected channels:");
+
+  affected_channels.forEach(v => {
+    _debug("cancelling channel: " + JSON.stringify(v));
+    _cancel(v);
+  });
+}
+
+function _cancel(c) {
+  if (isEndpointCancelled(c)) {
+    return; // Re-cancelling sessions is a no-op
+  }
+
+  DEBUG.assert(c.hasOwnProperty("_sessEP1"), "Cancelling non-channel");
+
+  const peer_ep = c._sessEP1;
+  const local_ep = c._sessEP2;
+
+  function cancelContainedValues() {
+    const buf_set = new Set(_buffers[local_ep]);
+    const chans = Array.from(resolveSet(buf_set));
+    for (let contained_chan of chans) {
+      _cancel(contained_chan);
+    }
+  }
+
+  function notifyPeer() {
+    if (peer_ep in _buffers) {
+      _wakeup(_chan_blocked[peer_ep]);
+      delete _chan_blocked[peer_ep];
+    } else {
+      if (!isEndpointCancelled(peer_ep)) {
+        WEBSOCKET.sendRemoteCancellation(peer_ep, local_ep);
+      }
+    }
+  }
+
+  if (!(local_ep in _buffers)) {
+    _debug("Trying to cancel non-local buffer. Probably shouldn't happen!");
+    return;
+  }
+
+  cancelContainedValues();
+  addCancelledEndpoint(local_ep);
+  notifyPeer();
+}
+
+
+function handleChannelCancellation(notify_ep, cancelled_ep) {
+  // Need to add cancelled_ep to cancelled EP set, and wake up
+  // any processes blocked on notify_ep
+  addCancelledEndpoint(cancelled_ep);
+  if (notify_ep in _chan_blocked) {
+    _wakeup(_chan_blocked[notify_ep]);
+    delete _chan_blocked[notify_ep];
+  }
+}
+
 
 function _makeFun (s) {
   return function (x, ks) {
@@ -2627,7 +2724,7 @@ function _Send(pid, msg) {
 }
 
 function Send(pid, msg, kappa) {
-  return _applyCont(kappa,_send(pid, msg));
+  return _applyCont(kappa, _Send(pid, msg));
 }
 
 function _SendWrapper(env) {  // necessary wrapper for server->client calls
@@ -2687,35 +2784,48 @@ function _recvWrapper(env) {  // necessary wrapper for server->client calls
 
 // SESSIONS
 
-var _nextAP = 0
-var _nextChannel = 0
+let _nextAP = 0
+let _nextChannel = 0
 
 /* Channel state */
 // Moving this to the model used on the server.
 //
 // The buffers table maps channel IDs to lists of messages.
-var _buffers = {}; // port |-> message list
+const _buffers = {}; // port |-> message list
 
 // The _chan_blocked table is a partial mapping from channel IDs to
 // processes, which are blocked waiting on a result.
-var _chan_blocked = {}; // port |-> process ID
+const _chan_blocked = {}; // port |-> process ID
 
 // Receive endpoints which have been received, but for which we do not yet have
 // a lost message response.
 // port |-> message list (buffer which was sent with the EP)
-var _pending_endpoints = {};
+const _pending_endpoints = {};
 
 // Messages which have been received after sending a delegation request,
 // but before a request to get lost messages.
 // port |-> message list
-var _lost_messages = {};
+const _lost_messages = {};
 
 // Messages which have been received without an associated buffer, and are
 // not in _lost_messages.
 // This happens when delegation has started, but we have not yet received
 // the channel endpoint / lost messages.
 // port |-> message list
-var _orphan_messages = {};
+const _orphan_messages = {};
+
+
+// Channels which have been cancelled
+const _cancelled_endpoints = new Set();
+
+function isEndpointCancelled(chan) {
+  return _cancelled_endpoints.has(chan);
+}
+
+function addCancelledEndpoint(chan) {
+  _cancelled_endpoints.add(chan);
+}
+
 
 function addMessageToDict(dict, port, msg) {
   buf = [];
@@ -2820,7 +2930,7 @@ function blockUntilAPResponse(kappa) {
         "resuming process after remote accept, but no channel available!");
       var chan = _returned_channels[_current_pid];
       delete _returned_channels[_current_pid];
-      return _applyCont(kappa,chan);
+      return _applyCont(kappa, chan);
     }
   );
 }
@@ -2982,7 +3092,7 @@ function request(ap, kappa) {
 
 function canReceiveMessage(v) {
   // Check whether all contained sessions are in _buffers (i.e. are committed)
-  var contained_sessions = getDelegatedSessions(v);
+  var contained_sessions = getContainedSessions(v);
   for (var i = 0; i < contained_sessions.length; i++) {
     if (!(contained_sessions[i]._sessEP2 in _buffers)) {
       return false;
@@ -3082,11 +3192,13 @@ function handleLostMessages(blocked_ep, lost_message_table) {
 
 
 // Retrieves all sessions within the value.
-function getDelegatedSessions(v) {
+// TODO: Extend this to include closures!
+function getContainedSessions(v) {
+  if (v == null || v == undefined) { return []; }
   if (TYPES.isArray(v)) {
     var res = [];
     for (var i = 0; i < v.length; i++) {
-      res = res.concat(getDelegatedSessions(v[i]));
+      res = res.concat(getContainedSessions(v[i]));
     }
     return res;
   } else if(TYPES.isObject(v)) {
@@ -3097,9 +3209,11 @@ function getDelegatedSessions(v) {
     var vals = Object.values(v);
     var res = [];
     for (var i = 0; i < vals.length; i++) {
-      res = res.concat(getDelegatedSessions(vals[i]));
+      res = res.concat(getContainedSessions(vals[i]));
     }
     return res;
+  } else if(v.hasOwnProperty("__closureEnv")) {
+    return getContainedSessions(v.__closureEnv); // tee hee, dynamic typing is nice sometimes
   } else {
     return [];
   }
@@ -3131,46 +3245,65 @@ function prepareDelegatedChannels(chans) {
 }
 
 function _remoteSessionSend(v, c) {
-  var delegated_sessions = getDelegatedSessions(v);
+  var delegated_sessions = getContainedSessions(v);
   var prepared_delegated_sessions = prepareDelegatedChannels(delegated_sessions);
   DEBUG.debug("Prepared delegated sessions:");
   DEBUG.debug(prepared_delegated_sessions);
   return WEBSOCKET.sendRemoteSessionMessage(c, prepared_delegated_sessions, v);
 }
 
-function _send(v, c) {
-  var sendEP = c._sessEP1;
-  if (sendEP in _buffers) {
+function send(v, c, cancellation_thunk, kappa) {
+  const peer_ep = c._sessEP1;
+  const local_ep = c._sessEP2;
+
+  /* New semantics: don't raise exn on send
+  if (isEndpointCancelled(peer_ep)) {
+    _debug("Trying to send to cancelled peer EP -- raising exception");
+    cancellation_thunk();
+    _cancel(c);
+    return;
+  }
+ */
+
+  if (peer_ep in _buffers) {
     // If the send is in the local buffers table, we have hold of the
     // endpoint and can send locally.
-    _buffers[sendEP].unshift(v);
-    _wakeup(_chan_blocked[sendEP]);
-    delete _chan_blocked[sendEP];
-    return c;
+    _buffers[peer_ep].unshift(v);
+    _wakeup(_chan_blocked[peer_ep]);
+    delete _chan_blocked[peer_ep];
+    _applyCont(kappa, c);
   } else {
     _remoteSessionSend(v, c);
-    return c;
+    _applyCont(kappa, c);
   }
 }
 
-function receive(c, kappa) {
-  var recvEP = c._sessEP2;
-  DEBUG.assert(recvEP in _buffers, "Trying to receive from nonexistent buffer!");
-  var buf_len = _buffers[recvEP].length;
-  if (buf_len > 0 && canReceiveMessage(_buffers[recvEP][buf_len - 1])) {
-    var msg = _buffers[recvEP].pop();
+function receive(c, cancellation_thunk, kappa) {
+  var peer_ep = c._sessEP1;
+  var local_ep = c._sessEP2;
+  DEBUG.assert(local_ep in _buffers, "Trying to receive from nonexistent buffer!");
+  var buf_len = _buffers[local_ep].length;
+  if (buf_len > 0 && canReceiveMessage(_buffers[local_ep][buf_len - 1])) {
+    var msg = _buffers[local_ep].pop();
     // DEBUG.debug("Grabbed " + JSON.stringify(msg));
     return _applyCont(kappa, {1:msg, 2:c});
   } else {
-    var current_pid = _current_pid;
-    _chan_blocked[recvEP] = current_pid;
-    return _block_proc(
-      current_pid,
-      function () {
-        _current_pid = current_pid;
-        return receive(c, kappa);
-      }
-    );
+    // If other endpoint is cancelled, raise an exception. Otherwise, block.
+    if (isEndpointCancelled(peer_ep) && exceptions_enabled) {
+      _debug("Trying to receive from empty buffer where remote endpoint is cancelled. Clearing out continuation...");
+      // Cancel the channel & carried channels
+      _cancel(c);
+      // Force cancellation thunk to cancel FVs in the continuation.
+      return cancellation_thunk(kappa);
+    } else {
+      var current_pid = _current_pid;
+      _chan_blocked[local_ep] = current_pid;
+      _block_proc(current_pid,
+        function () {
+          _current_pid = current_pid;
+          receive(c, cancellation_thunk, kappa);
+        });
+    }
   }
 }
 
@@ -3178,6 +3311,7 @@ function receive(c, kappa) {
 function link(c, d, kappa) {
   throw "link not implemented on the client yet"
 }
+
 
 // SCHEDULER
 

--- a/lib/js/jslib.js
+++ b/lib/js/jslib.js
@@ -3197,7 +3197,6 @@ function handleLostMessages(blocked_ep, lost_message_table) {
 
 
 // Retrieves all sessions within the value.
-// TODO: Extend this to include closures!
 function getContainedSessions(v) {
   if (v == null || v == undefined) { return []; }
   if (TYPES.isArray(v)) {

--- a/lib/js/jslib.js
+++ b/lib/js/jslib.js
@@ -2400,7 +2400,12 @@ function resolveSet(set) {
 }
 
 function _handleSessionException(cont_variables) {
-  const cont_set = new Set(cont_variables);
+  let lst = cont_variables;
+  const cont_set = new Set();
+  while (lst != null && lst != undefined) {
+    cont_set.add(_hd(lst));
+    lst = _tl(lst);
+  }
   const resolved_cont_set = resolveSet(cont_set);
   const affected_channels = Array.from(resolved_cont_set);
   _debug("In handle session exception. Affected channels:");
@@ -3252,18 +3257,9 @@ function _remoteSessionSend(v, c) {
   return WEBSOCKET.sendRemoteSessionMessage(c, prepared_delegated_sessions, v);
 }
 
-function send(v, c, cancellation_thunk, kappa) {
+function _send(v, c) {
   const peer_ep = c._sessEP1;
   const local_ep = c._sessEP2;
-
-  /* New semantics: don't raise exn on send
-  if (isEndpointCancelled(peer_ep)) {
-    _debug("Trying to send to cancelled peer EP -- raising exception");
-    cancellation_thunk();
-    _cancel(c);
-    return;
-  }
- */
 
   if (peer_ep in _buffers) {
     // If the send is in the local buffers table, we have hold of the
@@ -3271,10 +3267,10 @@ function send(v, c, cancellation_thunk, kappa) {
     _buffers[peer_ep].unshift(v);
     _wakeup(_chan_blocked[peer_ep]);
     delete _chan_blocked[peer_ep];
-    _applyCont(kappa, c);
+    return c;
   } else {
     _remoteSessionSend(v, c);
-    _applyCont(kappa, c);
+    return c;
   }
 }
 

--- a/lib/js/jslib.js
+++ b/lib/js/jslib.js
@@ -3273,7 +3273,29 @@ function _send(v, c) {
   }
 }
 
-function receive(c, cancellation_thunk, kappa) {
+/* Basic receive: Does not take into account exceptions */
+function _default_receive(c, kappa) {
+  var peer_ep = c._sessEP1;
+  var local_ep = c._sessEP2;
+  DEBUG.assert(local_ep in _buffers, "Trying to receive from nonexistent buffer!");
+  var buf_len = _buffers[local_ep].length;
+  if (buf_len > 0 && canReceiveMessage(_buffers[local_ep][buf_len - 1])) {
+    var msg = _buffers[local_ep].pop();
+    return _applyCont(kappa, {1:msg, 2:c});
+  } else {
+    var current_pid = _current_pid;
+    _chan_blocked[local_ep] = current_pid;
+    _block_proc(current_pid,
+      function () {
+        _current_pid = current_pid;
+        receive(c, kappa);
+      });
+  }
+}
+
+/* Exception receive: takes an extra argument which is a continuation
+ * to invoke if the exception cannot be raised. */
+function _exn_receive(c, cancellation_thunk, kappa) {
   var peer_ep = c._sessEP1;
   var local_ep = c._sessEP2;
   DEBUG.assert(local_ep in _buffers, "Trying to receive from nonexistent buffer!");
@@ -3284,7 +3306,7 @@ function receive(c, cancellation_thunk, kappa) {
     return _applyCont(kappa, {1:msg, 2:c});
   } else {
     // If other endpoint is cancelled, raise an exception. Otherwise, block.
-    if (isEndpointCancelled(peer_ep) && exceptions_enabled) {
+    if (isEndpointCancelled(peer_ep)) {
       _debug("Trying to receive from empty buffer where remote endpoint is cancelled. Clearing out continuation...");
       // Cancel the channel & carried channels
       _cancel(c);

--- a/parseSettings.ml
+++ b/parseSettings.ml
@@ -39,7 +39,8 @@ let options : opt list =
     (noshort, "path",                None,                             Some (fun str -> Settings.set_value BS.links_file_paths str));
     (noshort, "config",              None,                             Some (fun name -> config_file := Some name));
     (noshort, "enable-handlers",     set BS.Handlers.enabled true,     None);
-    ('r',     "rlwrap",              set BS.Readline.native_readline false,     None);
+    ('r',     "rlwrap",              set BS.Readline.native_readline false, None);
+    (noshort, "session-exceptions",  set BS.Sessions.exceptions_enabled true, None);
     ]
 
 

--- a/parser.mly
+++ b/parser.mly
@@ -213,6 +213,7 @@ let cp_unit p = `Unquote ([], (`TupleLit [], p)), p
 %token <[`Left|`Right|`None|`Pre|`Post] -> int -> string -> unit> INFIX INFIXL INFIXR PREFIX POSTFIX
 %token TYPENAME
 %token TYPE ROW PRESENCE
+%token TRY OTHERWISE RAISE
 %token <string> PREFIXOP POSTFIXOP
 %token <string> INFIX0 INFIXL0 INFIXR0
 %token <string> INFIX1 INFIXL1 INFIXR1
@@ -786,6 +787,8 @@ case_expression:
 | RECEIVE LBRACE perhaps_cases RBRACE                          { `Receive ($3, None), pos() }
 | handle_depth LPAREN exp RPAREN LBRACE cases RBRACE           { let hndlr = Sugartypes.make_untyped_handler $3 $6 $1 in
                                                                  `Handle hndlr, pos() }
+| RAISE                                                        { `Raise, pos () }
+| TRY exp AS pattern IN exp OTHERWISE exp                      { `TryInOtherwise ($2, $4, $6, $8, None), pos () }
 
 handle_depth:
 | HANDLE                                                       { `Deep }

--- a/proc.ml
+++ b/proc.ml
@@ -907,7 +907,8 @@ and Session : SESSION = struct
               end in
 
       (* Cancelling a channel twice is a no-op *)
-      if is_endpoint_cancelled local_ep then Lwt.return () else
+      if ((is_endpoint_cancelled local_ep) ||
+         (not @@ Settings.get_value Basicsettings.Sessions.exceptions_enabled)) then Lwt.return () else
       begin
       cancel_endpoint local_ep;
       match lookup_endpoint local_ep with

--- a/sugarTraversals.ml
+++ b/sugarTraversals.ml
@@ -250,9 +250,9 @@ class map =
           let _x_i1 = o#option (fun o -> o#phrase) _x_i1
           in `ConstructorLit ((_x, _x_i1, _x_i2))
       | `DoOperation (name, ps, t) ->
-	 let ps  = o#list (fun o -> o#phrase) ps in
-	 let t   = o#option (fun o -> o#unknown) t in
-	 `DoOperation (name, ps, t)
+          let ps  = o#list (fun o -> o#phrase) ps in
+          let t   = o#option (fun o -> o#unknown) t in
+          `DoOperation (name, ps, t)
       | `Handle { sh_expr; sh_clauses; sh_descr } ->
           let m = o#phrase sh_expr in
           let cases =
@@ -371,6 +371,14 @@ class map =
       | `FormBinding ((_x, _x_i1)) ->
           let _x = o#phrase _x in
           let _x_i1 = o#pattern _x_i1 in `FormBinding ((_x, _x_i1))
+      | `TryInOtherwise (_p1, _pat, _p2, _p3, _ty) ->
+          let _p1 = o#phrase _p1 in
+          let _pat = o#pattern _pat in
+          let _p2 = o#phrase _p2 in
+          let _p3 = o#phrase _p3 in
+          `TryInOtherwise (_p1, _pat, _p2, _p3, _ty)
+      | `Raise -> `Raise
+
 
     method phrase : phrase -> phrase =
       fun (_x, _x_i1) ->
@@ -975,6 +983,13 @@ class fold =
       | `PagePlacement _x -> let o = o#phrase _x in o
       | `FormBinding ((_x, _x_i1)) ->
           let o = o#phrase _x in let o = o#pattern _x_i1 in o
+      | `TryInOtherwise (_p1, _pat, _p2, _p3, _ty) ->
+          let o = o#phrase _p1 in
+          let o = o#pattern _pat in
+          let o = o#phrase _p2 in
+          let o = o#phrase _p3 in
+          o
+      | `Raise -> o
 
     method phrase : phrase -> 'self_type =
       fun (_x, _x_i1) ->
@@ -1627,6 +1642,13 @@ class fold_map =
           let (o, _x) = o#phrase _x in
           let (o, _x_i1) = o#pattern _x_i1
           in (o, (`FormBinding ((_x, _x_i1))))
+      | `TryInOtherwise (_p1, _pat, _p2, _p3, _ty) ->
+          let (o, _p1) = o#phrase _p1 in
+          let (o, _pat) = o#pattern _pat in
+          let (o, _p2) = o#phrase _p2 in
+          let (o, _p3) = o#phrase _p3 in
+          (o, (`TryInOtherwise (_p1, _pat, _p2, _p3, _ty)))
+      | `Raise -> (o, `Raise)
 
     method phrase : phrase -> ('self_type * phrase) =
       fun (_x, _x_i1) ->

--- a/sugartoir.ml
+++ b/sugartoir.ml
@@ -809,9 +809,9 @@ struct
               cofv (I.inject (name, I.record ([], None), t))
           | `ConstructorLit (name, Some e, Some t) ->
               cofv (I.inject (name, ev e, t))
-	  | `DoOperation (name, ps, Some t) ->
-	     let vs = evs ps in
-	     I.do_operation (name, vs, t)
+          | `DoOperation (name, ps, Some t) ->
+             let vs = evs ps in
+             I.do_operation (name, vs, t)
           | `Handle { Sugartypes.sh_expr; Sugartypes.sh_clauses; Sugartypes.sh_descr } ->
               let cases =
                 List.map
@@ -944,6 +944,8 @@ struct
           | `QualifiedVar _
           | `HandlerLit _
           | `DoOperation _
+          | `TryInOtherwise _
+          | `Raise
           | `CP _ ->
               Debug.print ("oops: " ^ Sugartypes.Show_phrasenode.show e);
               assert false

--- a/sugartypes.ml
+++ b/sugartypes.ml
@@ -266,6 +266,8 @@ and phrasenode = [
 | `Offer            of phrase * (pattern * phrase) list * Types.datatype option
 (* | `Fork             of binder * phrase *)
 | `CP               of cp_phrase
+| `TryInOtherwise   of (phrase * pattern * phrase * phrase * Types.datatype option)
+| `Raise (* TEMPORARY, FOR TESTING ONLY *)
 ]
 and phrase = phrasenode * position
 and bindingnode = [
@@ -462,6 +464,8 @@ struct
                      diff (union_map (snd ->- phrase) fields) pat_bound]
     | `DoOperation (_, ps, _) -> union_map phrase ps
     | `QualifiedVar _ -> empty
+    | `TryInOtherwise (p1, pat, p2, p3, _ty) -> union (union_map phrase [p1; p2; p3]) (pattern pat)
+    | `Raise -> empty
   and binding (binding, _: binding) : StringSet.t (* vars bound in the pattern *)
                                     * StringSet.t (* free vars in the rhs *) =
     match binding with

--- a/sugartypes.ml
+++ b/sugartypes.ml
@@ -267,7 +267,7 @@ and phrasenode = [
 (* | `Fork             of binder * phrase *)
 | `CP               of cp_phrase
 | `TryInOtherwise   of (phrase * pattern * phrase * phrase * Types.datatype option)
-| `Raise (* TEMPORARY, FOR TESTING ONLY *)
+| `Raise
 ]
 and phrase = phrasenode * position
 and bindingnode = [

--- a/tests/distribution/11/client.js
+++ b/tests/distribution/11/client.js
@@ -13,13 +13,6 @@ let sum = 0;
 
 let initialised_channel_count = 0;
 
-// - Client A and B connect via a server access point to get channel c,
-//   with channels {c1,c2} and {c2,c1}. A gets {c1, c2}. B gets {c2, c1}.
-// - Client B and C connect via a server access point to get channel d.
-// (- Client A sends 1, 2 along c.)
-// - Client B then wants to delegate {c2,c1} along d so, sends {c2, c1} to C
-//   along {d1, d2}.
-
 function assert(b, str) {
   if (!b) {
     throw("Assertion failed: " + str);

--- a/tests/session-exceptions.tests
+++ b/tests/session-exceptions.tests
@@ -1,0 +1,60 @@
+Receiving from cancelled peer endpoint
+./tests/session-exceptions/cancel1.links
+filemode : args
+args : --session-exceptions --enable-handlers
+stdout : "exception" : String
+
+Sending to cancelled peer endpoint
+./tests/session-exceptions/cancel2.links
+filemode : args
+args : --session-exceptions --enable-handlers
+stdout : "send successful" : String
+
+Receiving from cancelled carried endpoint
+./tests/session-exceptions/cancel3.links
+filemode : args
+args : --session-exceptions --enable-handlers
+stdout : "exception" : String
+
+Nested exceptions
+./tests/session-exceptions/cancel4.links
+filemode : args
+args : --session-exceptions --enable-handlers
+stdout : "-1" : String
+
+Operation guarded by failing operation
+./tests/session-exceptions/cancel5.links
+filemode : args
+args : --session-exceptions --enable-handlers
+stdout : "exception" : String
+
+Cancellation in closure (1)
+./tests/session-exceptions/cancel6.links
+filemode : args
+args : --session-exceptions --enable-handlers
+stdout : "exception" : String
+
+Cancellation in closure (2)
+./tests/session-exceptions/cancel7.links
+filemode : args
+args : --session-exceptions --enable-handlers
+stdout : "exception" : String
+
+Cancellation in closure (3)
+./tests/session-exceptions/cancel8.links
+filemode : args
+args : --session-exceptions --enable-handlers
+stdout : "exception" : String
+
+Cancellation in closure (4)
+./tests/session-exceptions/cancel9.links
+filemode : args
+args : --session-exceptions --enable-handlers
+stdout : "exception" : String
+
+Non-empty continuation environments
+./tests/session-exceptions/cancel10.links
+filemode : args
+args : --session-exceptions --enable-handlers
+stderr : @.*
+exit : 1

--- a/tests/session-exceptions.tests
+++ b/tests/session-exceptions.tests
@@ -58,3 +58,9 @@ filemode : args
 args : --session-exceptions --enable-handlers
 stderr : @.*
 exit : 1
+
+Offering where peer endpoint is cancelled
+./tests/session-exceptions/cancel11.links
+filemode : args
+args : --session-exceptions --enable-handlers
+stdout : "exception" : String

--- a/tests/session-exceptions/cancel1.links
+++ b/tests/session-exceptions/cancel1.links
@@ -1,0 +1,27 @@
+fun goAlright() {
+  try {
+    var s = fork (fun (s) { ignore(send(5, s)) });
+    var (res, _) = receive(s);
+    res
+  } as (x) in {
+    "result: " ^^ intToString(x)
+  } otherwise {
+    "exception"
+  }
+}
+
+fun go() {
+  try {
+    var s = fork (fun (s) { cancel(s) });
+    var (res, _) = receive(s);
+    res
+  } as (x) in {
+    "result: " ^^ intToString(x)
+  } otherwise {
+    "exception"
+  }
+}
+
+go()
+#goBadly()
+#goAlright()

--- a/tests/session-exceptions/cancel10.links
+++ b/tests/session-exceptions/cancel10.links
@@ -1,0 +1,16 @@
+fun go() {
+  var s = fork(fun(s) { ignore(send(5, s)) });
+  try {
+    raise; 10
+  } as (x) in {
+    var (res, _) = receive(s);
+    print("x: " ^^ intToString(x));
+    print("Res: " ^^ intToString(res))
+  } otherwise {
+    var (res, _) = receive(s);
+    print("Received from s: " ^^ intToString(res))
+  }
+}
+
+
+go()

--- a/tests/session-exceptions/cancel11.links
+++ b/tests/session-exceptions/cancel11.links
@@ -1,0 +1,16 @@
+fun go() {
+  try {
+    var s = fork (fun (s) { cancel(s) });
+    offer(s) {
+      case Foo(s) -> 100
+    }
+  } as (x) in {
+    "result: " ^^ intToString(x)
+  } otherwise {
+    "exception"
+  }
+}
+
+go()
+#goBadly()
+#goAlright()

--- a/tests/session-exceptions/cancel2.links
+++ b/tests/session-exceptions/cancel2.links
@@ -1,0 +1,39 @@
+# Failure of sending
+
+fun goAlright() {
+  var ap = new(); # Yay synchronisation!
+  try {
+    var s = fork (fun (s) {
+  #    cancel(s);
+      ignore(request(ap));
+      ignore(receive(s));
+    });
+    ignore(accept(ap));
+    ignore(send(5, s))
+  } as (_) in {
+    "send successful"
+  } otherwise {
+    "exception"
+  }
+}
+
+
+fun go() {
+  var ap = new(); # Yay synchronisation!
+  try {
+    var s = fork (fun (s) {
+      cancel(s);
+      ignore(request(ap))
+    });
+    ignore(accept(ap));
+    ignore(send(5, s))
+  } as (_) in {
+    "send successful"
+  } otherwise {
+    "exception"
+  }
+}
+
+go()
+#goBadly()
+#goAlright()

--- a/tests/session-exceptions/cancel3.links
+++ b/tests/session-exceptions/cancel3.links
@@ -1,0 +1,23 @@
+fun go() {
+  var ap = new();
+  var syncAP = new();
+  try {
+    var t = fork(fun(t) {
+      var carried = request(ap);
+      # Ensure the send takes place before cancellation
+      var _ = send(carried, t);
+      ignore(request(syncAP))
+      });
+    var carried = accept(ap);
+    ignore(accept(syncAP));
+    cancel(t);
+    var (res, _) = receive(carried);
+    res
+  } as (x) in {
+    "received from carried: " ^^ intToString(x)
+  } otherwise {
+    "exception"
+  }
+}
+
+go()

--- a/tests/session-exceptions/cancel4.links
+++ b/tests/session-exceptions/cancel4.links
@@ -1,0 +1,24 @@
+
+fun go() {
+  var ap = new();
+  var s = fork(fun(s) { cancel(s); ignore(request(ap)) });
+  try {
+    var x =
+      try {
+        var _ = accept(ap);
+        var (res, _) = receive(s);
+        res
+      } as (x) in {
+        x
+      } otherwise {
+        (-1)
+      };
+    x
+  } as (x) in {
+    intToString(x)
+  } otherwise {
+    "exception"
+  }
+}
+
+go()

--- a/tests/session-exceptions/cancel5.links
+++ b/tests/session-exceptions/cancel5.links
@@ -1,0 +1,20 @@
+fun go() {
+  var ap = new();
+  try {
+    var s = fork(fun(s) {
+      var t = request(ap);
+      ignore(receive(s));
+      ignore(send(5, t))
+    });
+    cancel(s);
+    var t = accept(ap);
+    var (x, _) = receive(t);
+    x
+  } as (x) in {
+    intToString(x)
+  } otherwise {
+   "exception"
+  }
+}
+
+go()

--- a/tests/session-exceptions/cancel6.links
+++ b/tests/session-exceptions/cancel6.links
@@ -1,0 +1,21 @@
+fun go() {
+  var ap = new();
+
+  try {
+    var s = fork (fun(s) {
+      var t = accept(ap);
+      raise;
+      ignore(send(linfun() { send(5, t) }, s))
+    });
+    var t = request(ap);
+    var (res, _) = receive(t);
+    cancel(s);
+    res
+  } as (x) in {
+    "success: " ^^ intToString(x)
+  } otherwise {
+    "exception"
+  }
+}
+
+go()

--- a/tests/session-exceptions/cancel7.links
+++ b/tests/session-exceptions/cancel7.links
@@ -1,0 +1,23 @@
+fun go() {
+  var ap = new();
+
+  try {
+    var s = fork (fun(s) {
+      var t = accept(ap);
+      var clos = linfun() { send(5, t) };
+      raise;
+      ignore(send(clos, s))
+    });
+    var t = request(ap);
+    var (res, _) = receive(t);
+    #cancel(t);
+    cancel(s);
+    1
+  } as (x) in {
+    "success: " ^^ intToString(x)
+  } otherwise {
+    "exception"
+  }
+}
+
+go()

--- a/tests/session-exceptions/cancel8.links
+++ b/tests/session-exceptions/cancel8.links
@@ -1,0 +1,24 @@
+fun go() {
+  var ap = new();
+  var syncAP = new();
+
+  try {
+    var s = fork (fun(s) {
+      var t = accept(ap);
+      var clos = linfun() { send(5, t) };
+      ignore(send(clos, s));
+      ignore(request(syncAP))
+    });
+    var t = request(ap);
+    ignore(accept(syncAP));
+    cancel(s);
+    var (res, _) = receive(t);
+    res
+  } as (x) in {
+    "success: " ^^ intToString(x)
+  } otherwise {
+    "exception"
+  }
+}
+
+go()

--- a/tests/session-exceptions/cancel9.links
+++ b/tests/session-exceptions/cancel9.links
@@ -1,0 +1,22 @@
+fun go() {
+  var ap = new();
+
+  try {
+    var s = fork (fun(s) {
+      var t = accept(ap);
+      raise;
+      var clos = linfun() { send(5, t) };
+      ignore(send(clos, s))
+    });
+    var t = request(ap);
+    var (res, _) = receive(t);
+    cancel(s);
+    res
+  } as (x) in {
+    "success: " ^^ intToString(x)
+  } otherwise {
+    "exception"
+  }
+}
+
+go()

--- a/tests/session-exceptions/clientCancel1.links
+++ b/tests/session-exceptions/clientCancel1.links
@@ -1,0 +1,3 @@
+open Cancel1
+fun main() { addRoute("/", fun (_) { ignore(spawnClient {print(Cancel1.go()) }); page <#><h1>Yup</h1></#>} ); serveWebsockets(); servePages() }
+main()

--- a/tests/session-exceptions/clientCancel10.links
+++ b/tests/session-exceptions/clientCancel10.links
@@ -1,0 +1,3 @@
+open Cancel10
+fun main() { addRoute("/", fun (_) { ignore(spawnClient {print(Cancel10.go()) }); page <#><h1>Yup</h1></#>} ); serveWebsockets(); servePages() }
+main()

--- a/tests/session-exceptions/clientCancel11.links
+++ b/tests/session-exceptions/clientCancel11.links
@@ -1,0 +1,3 @@
+open Cancel11
+fun main() { addRoute("/", fun (_) { ignore(spawnClient {print(Cancel11.go()) }); page <#><h1>Yup</h1></#>} ); serveWebsockets(); servePages() }
+main()

--- a/tests/session-exceptions/clientCancel2.links
+++ b/tests/session-exceptions/clientCancel2.links
@@ -1,0 +1,3 @@
+open Cancel2
+fun main() { addRoute("/", fun (_) { ignore(spawnClient {print(Cancel2.go()) }); page <#><h1>Yup</h1></#>} ); serveWebsockets(); servePages() }
+main()

--- a/tests/session-exceptions/clientCancel3.links
+++ b/tests/session-exceptions/clientCancel3.links
@@ -1,0 +1,3 @@
+open Cancel3
+fun main() { addRoute("/", fun (_) { ignore(spawnClient {print(Cancel3.go()) }); page <#><h1>Yup</h1></#>} ); serveWebsockets(); servePages() }
+main()

--- a/tests/session-exceptions/clientCancel4.links
+++ b/tests/session-exceptions/clientCancel4.links
@@ -1,0 +1,3 @@
+open Cancel4
+fun main() { addRoute("/", fun (_) { ignore(spawnClient {print(Cancel4.go()) }); page <#><h1>Yup</h1></#>} ); serveWebsockets(); servePages() }
+main()

--- a/tests/session-exceptions/clientCancel5.links
+++ b/tests/session-exceptions/clientCancel5.links
@@ -1,0 +1,3 @@
+open Cancel5
+fun main() { addRoute("/", fun (_) { ignore(spawnClient {print(Cancel5.go()) }); page <#><h1>Yup</h1></#>} ); serveWebsockets(); servePages() }
+main()

--- a/tests/session-exceptions/clientCancel6.links
+++ b/tests/session-exceptions/clientCancel6.links
@@ -1,0 +1,3 @@
+open Cancel6
+fun main() { addRoute("/", fun (_) { ignore(spawnClient {print(Cancel6.go()) }); page <#><h1>Yup</h1></#>} ); serveWebsockets(); servePages() }
+main()

--- a/tests/session-exceptions/clientCancel7.links
+++ b/tests/session-exceptions/clientCancel7.links
@@ -1,0 +1,3 @@
+open Cancel7
+fun main() { addRoute("/", fun (_) { ignore(spawnClient {print(Cancel7.go()) }); page <#><h1>Yup</h1></#>} ); serveWebsockets(); servePages() }
+main()

--- a/tests/session-exceptions/clientCancel8.links
+++ b/tests/session-exceptions/clientCancel8.links
@@ -1,0 +1,3 @@
+open Cancel8
+fun main() { addRoute("/", fun (_) { ignore(spawnClient {print(Cancel8.go()) }); page <#><h1>Yup</h1></#>} ); serveWebsockets(); servePages() }
+main()

--- a/tests/session-exceptions/clientCancel9.links
+++ b/tests/session-exceptions/clientCancel9.links
@@ -1,0 +1,3 @@
+open Cancel9
+fun main() { addRoute("/", fun (_) { ignore(spawnClient {print(Cancel9.go()) }); page <#><h1>Yup</h1></#>} ); serveWebsockets(); servePages() }
+main()

--- a/tests/session-exceptions/clientClosure.links
+++ b/tests/session-exceptions/clientClosure.links
@@ -1,0 +1,31 @@
+#open Cancel2
+
+fun makePage() {
+    fun foo() {
+        try {
+          var s = fork(fun(s) { ignore(send(5, s)) });
+          linfun clos() { var (res, _) = receive(s); print("Closure received: " ^^ intToString(res)) }
+          var t = linFork(linfun(t) { ignore(send(clos, t)) });
+          raise;
+          var (clos, _) = receive(t);
+          clos()
+        } as (_) in {
+          print("success!")
+        } otherwise {
+          print("exception!")
+        }
+      }
+    var _ = spawnClient {
+      foo()
+    };
+
+    page
+        <#><h1>Yup</h1></#>
+}
+
+fun main() {
+    addRoute("/", fun (_) { makePage() });
+    servePages()
+}
+
+main()

--- a/tests/session-exceptions/clientClosure2.links
+++ b/tests/session-exceptions/clientClosure2.links
@@ -1,0 +1,29 @@
+#open Cancel2
+
+fun makePage() {
+    fun foo() {
+        try {
+          var f = fork(fun(s) { ignore(send(5, s)) });
+          linfun clos() { var (res, _) = receive(f); print("Closure received: " ^^ intToString(res)) }
+          raise;
+          clos()
+        } as (_) in {
+          print("success!")
+        } otherwise {
+          print("exception!")
+        }
+      }
+    var _ = spawnClient {
+      foo()
+    };
+
+    page
+        <#><h1>Yup</h1></#>
+}
+
+fun main() {
+    addRoute("/", fun (_) { makePage() });
+    servePages()
+}
+
+main()

--- a/transformSugar.ml
+++ b/transformSugar.ml
@@ -429,8 +429,8 @@ class transform (env : Types.typing_environment) =
           let (o, t) = o#datatype t in
           (o, `ConstructorLit (name, e, Some t), t)
       | `DoOperation (name, ps, Some t) ->
-	 let (o, ps, _) = list o (fun o -> o#phrase) ps in
-	 (o, `DoOperation (name, ps, Some t), t)
+         let (o, ps, _) = list o (fun o -> o#phrase) ps in
+         (o, `DoOperation (name, ps, Some t), t)
       | `Handle { sh_expr; sh_clauses; sh_descr } ->
          let (input_row, input_t, output_row, output_t) = sh_descr.shd_types in
          let (o, expr, _) = o#phrase sh_expr in
@@ -445,7 +445,7 @@ class transform (env : Types.typing_environment) =
          let (o, input_t) = o#datatype input_t in
          let (o, output_row) = o#row output_row in
          let (o, output_t) = o#datatype output_t in
-	 let (o, raw_row) = o#row sh_descr.shd_raw_row in
+         let (o, raw_row) = o#row sh_descr.shd_raw_row in
          let descr = {
                        shd_depth = sh_descr.shd_depth;
                        shd_types = (input_row, input_t, output_row, output_t);
@@ -453,6 +453,14 @@ class transform (env : Types.typing_environment) =
                      }
          in
          (o, `Handle { sh_expr = expr; sh_clauses = cases; sh_descr = descr }, output_t)
+      | `TryInOtherwise (try_phr, as_pat, as_phr, otherwise_phr, (Some dt)) ->
+          let (o, try_phr, _) = o#phrase try_phr in
+          let (o, as_pat) = o#pattern as_pat in
+          let (o, as_phr, _) = o#phrase as_phr in
+          let (o, otherwise_phr, _) = o#phrase otherwise_phr in
+          let (o, dt) = o#datatype dt in
+          (o, `TryInOtherwise (try_phr, as_pat, as_phr, otherwise_phr, (Some dt)), dt)
+      | `Raise -> (o, `Raise, `Not_typed) (* TEMP *)
       | `Switch (v, cases, Some t) ->
           let (o, v, _) = o#phrase v in
           let (o, cases) =

--- a/value.ml
+++ b/value.ml
@@ -685,8 +685,10 @@ module Eff_Handler_Continuation = struct
           | (identity, pk) :: k -> handle ((identity, pk) :: k') k
           | [] ->
               begin
+              (* If this is a session exception operation, we need to gather all
+               * of the computations in the pure continuation stack, so we can inspect
+               * their free variables. *)
               if opname = session_exception_operation then
-                (* TODO: Is this correct??? *)
                 let comps =
                   begin
                   match (List.rev k') with

--- a/websocketMessages.ml
+++ b/websocketMessages.ml
@@ -1,5 +1,10 @@
 open ProcessTypes
 
+type channel_cancellation = {
+  notify_ep: channel_id;
+  cancelled_ep: channel_id
+}
+
 type incoming_websocket_message =
   (* Mailbox message from client to other client *)
   | ClientToClient of (client_id * process_id * Value.t)
@@ -13,3 +18,6 @@ type incoming_websocket_message =
   | ChanSend of (channel_id * (Value.delegated_chan list) * Value.t)
   (* Lost message response, containing lost messages for a set of channels *)
   | LostMessageResponse of (channel_id * ((channel_id * (Value.t list)) list))
+  (* Channel cancellation notification: a channel has been cancelled on a client,
+   * where the other EP is either on the server or another client *)
+  | ChannelCancellation of channel_cancellation


### PR DESCRIPTION
This PR adds session exception handling, as described in the draft paper, "Session Types without Tiers" (http://simonjf.com/drafts/chomp-draft-nov17.pdf)

The key idea is to add three new constructs:

  * `raise` raises an exception
  * `try L as x in M otherwise N` evaluates L, binding the result to x in M if successful, and evaluating N if not
  * `cancel M` allows consumption of a linear session channel endpoint

The system works by a notion of "channel cancellation" -- that is, channels that are either discarded explicitly through a use of cancel or implicitly through being in the aborted continuation when an exception is raised, are marked as cancelled. When their peer endpoint attempts to perform an action that wouldn't succeed (for example, receiving from an empty buffer, where the peer endpoint is offline), then an exception is raised.

As an example, consider:

```
fun go() {
  try {
    var t = fork (fun (s) { cancel(s) });
    var (res, _) = receive(t);
    res
  } as (x) in {
    "result: " ^^ intToString(x)
  } otherwise {
    "exception"
  }
}

go()
```

The send endpoint s is cancelled. Thus, receiving from its peer would block forever. However, with this extension, an exception would be raised and "exception" would be printed.

The extension is implemented both on the client and on the server.

The extension is off by default, but can be enabled by using the --session-exceptions flag, or setting session_exceptions=true in the config file.