### PR TITLE
Add opam multi-package rules to makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -23,3 +23,17 @@ clean:
 	jbuilder clean
 	rm -rf *.install
 	rm -rf links linx
+
+REPO=../opam-repository
+PACKAGES=$(REPO)/packages
+
+pkg-%:
+	topkg opam pkg -n $*
+	mkdir -p $(PACKAGES)/$*
+	cp -r _build/$*.* $(PACKAGES)/$*/
+	rm -f $(PACKAGES)/$*/$*.opam
+	cd $(PACKAGES) && git add $*
+
+PKGS=$(basename $(wildcard *.opam))
+opam-pkg:
+	$(MAKE) $(PKGS:%=pkg-%)


### PR DESCRIPTION
Shamelessly nicked from Mirage, these Makefile rules make it possible to release multiple packages at once. I'll update the wiki with details of how to use these.