### PR TITLE
Ensure channels created on server are correctly sent to client (Fix #323)

### DIFF
--- a/core/evalir.ml
+++ b/core/evalir.ml
@@ -99,10 +99,11 @@ struct
          Some (Settings.get_value Basicsettings.websocket_url) else
          None in
      let st = List.fold_left
-       (fun st_acc arg -> ResolveJsonState.add_val_event_handlers arg st_acc)
+       (fun st_acc arg -> ResolveJsonState.add_value_information arg st_acc)
        (JsonState.empty client_id conn_url) args in
      let st = ResolveJsonState.add_ap_information client_id st in
      let st = ResolveJsonState.add_process_information client_id st in
+     let st = ResolveJsonState.add_channel_information client_id st in
      Json.jsonize_call st continuation name args
 
    let client_call :

--- a/core/irtojs.ml
+++ b/core/irtojs.ml
@@ -1248,7 +1248,7 @@ end = functor (K : CONTINUATION) -> struct
          let varenv = VEnv.bind varenv (x, x_name) in
          let value = Value.Env.find x valenv in
          let jsonized_val = Json.jsonize_value value in
-         let state = ResolveJsonState.add_val_event_handlers value state in
+         let state = ResolveJsonState.add_value_information value state in
          (state,
           varenv,
           Some x_name,
@@ -1384,7 +1384,7 @@ end = functor (K : CONTINUATION) -> struct
     let json_state = JsonState.empty client_id ws_conn_url in
 
     (* Add the event handlers for the final value to be sent *)
-    let json_state = ResolveJsonState.add_val_event_handlers v json_state in
+    let json_state = ResolveJsonState.add_value_information v json_state in
     (* Json.jsonize_state req_data v in *)
 
     (* divide HTML into head and body secitions (as we need to augment the head) *)
@@ -1399,6 +1399,9 @@ end = functor (K : CONTINUATION) -> struct
 
     (* Add process information to the JSON state; mark all processes as active *)
     let json_state = ResolveJsonState.add_process_information client_id json_state in
+
+    (* Add channel information to the JSON state; mark all as residing on client *)
+    let json_state = ResolveJsonState.add_channel_information client_id json_state in
 
     let state_string = JsonState.to_string json_state in
 

--- a/core/json.mli
+++ b/core/json.mli
@@ -22,6 +22,13 @@ module JsonState : sig
   (** Adds an access point ID to the state *)
   val add_ap_id : apid -> t -> t
 
+  val add_carried_channel : Value.chan -> t -> t
+
+  val get_carried_channels : t -> Value.chan list
+
+  (** Adds a buffer to the state *)
+  val add_buffer : channel_id -> Value.t list -> t -> t
+
   (** Serialises the state as a JSON string *)
   val to_string : t -> json_string
 end

--- a/core/proc.ml
+++ b/core/proc.ml
@@ -420,6 +420,7 @@ sig
   val register_client_channel : client_id -> chan -> unit
   val register_server_channel : chan -> unit
 
+  val get_buffer : channel_id -> (Value.t list) option
 end
 
 module rec Websockets : WEBSOCKETS =
@@ -835,6 +836,11 @@ and Session : SESSION = struct
   let sequence act =
     List.fold_left (fun acc c -> acc >>= fun _ -> (act c)) (Lwt.return ())
 
+
+  let get_buffer ch_id =
+    match Hashtbl.lookup buffers ch_id with
+      | Some queue -> Some (Queue.to_list queue)
+      | None -> None
 
   let register_channel location ch =
     begin

--- a/core/proc.mli
+++ b/core/proc.mli
@@ -161,6 +161,8 @@ sig
   val register_client_channel : client_id -> chan -> unit
   val register_server_channel : chan -> unit
 
+  val get_buffer : channel_id -> (Value.t list) option
+
 end
 
 module rec Websockets : WEBSOCKETS

--- a/core/resolveJsonState.ml
+++ b/core/resolveJsonState.ml
@@ -3,10 +3,10 @@ open Json
 open Utility
 
 type handler_id_set = IntSet.t
-let empty_state = IntSet.empty
+let empty_state = (IntSet.empty, [])
 
 (* Given a value, extracts the event handlers that need to be sent to the client *)
-let rec event_handlers_from_value : Value.t -> handler_id_set =
+let rec extract_json_values : Value.t -> (handler_id_set * (Value.chan list)) =
   function
   (* Can't-dos *)
   | `PrimitiveFunction _ | `Socket _
@@ -16,27 +16,30 @@ let rec event_handlers_from_value : Value.t -> handler_id_set =
   (* Empties *)
   | `List [] | `SpawnLocation _ | `Pid _
   | `AccessPointID _ | `ClientDomRef _
-  | `ClientFunction _ | `SessionChannel _ -> empty_state
+  | `ClientFunction _ -> empty_state
+
+  (* Session channels *)
+  | `SessionChannel c -> (IntSet.empty, [c])
 
   (* Homomorphisms *)
   | `FunctionPtr (_f, fvs) ->
     begin
       match fvs with
         | None     -> empty_state
-        | Some fvs -> event_handlers_from_value fvs
+        | Some fvs -> extract_json_values fvs
     end
-  | #Value.primitive_value as p -> event_handlers_from_primitive p
-  | `Variant (_label, value) -> event_handlers_from_value value
+  | #Value.primitive_value as p -> (extract_from_primitive p, [])
+  | `Variant (_label, value) -> extract_json_values value
   | `Record fields ->
     let _ls, vs = List.split fields in
-    event_handlers_from_values vs
-  | `List (elems) -> event_handlers_from_values elems
-  and event_handlers_from_primitive : Value.primitive_value -> handler_id_set = function
+    extract_from_values vs
+  | `List (elems) -> extract_from_values elems
+  and extract_from_primitive : Value.primitive_value -> handler_id_set = function
   (* Everything is empty except XML items *)
-  | `XML xmlitem -> event_handlers_from_xml xmlitem
-  | _ -> empty_state
-and event_handlers_from_xml = function
-  | Value.Text _ -> empty_state
+  | `XML xmlitem -> extract_from_xml xmlitem
+  | _ -> IntSet.empty
+and extract_from_xml = function
+  | Value.Text _ -> IntSet.empty
   | Value.Node (_tag, xml) ->
       (* Any attribute with the "key" label is an event handler; add to state. *)
       List.fold_right (fun xmlitem state ->
@@ -47,25 +50,31 @@ and event_handlers_from_xml = function
                 IntSet.add key state
             else state
           | _ ->
-            let state' = event_handlers_from_xml xmlitem in
-            IntSet.union state state') xml empty_state
+            let state' = extract_from_xml xmlitem in
+            IntSet.union state state') xml IntSet.empty
   | Value.Attr _ -> assert false
   | Value.NsAttr _ -> assert false
   (* Namespace of a tag is not relevant for event handlers, so we can just drop that here *)
-  | Value.NsNode (_, name, children) -> event_handlers_from_xml (Value.Node (name, children))
+  | Value.NsNode (_, name, children) -> extract_from_xml (Value.Node (name, children))
 
-and event_handlers_from_values (vs : Value.t list) : handler_id_set =
+and extract_from_values (vs : Value.t list) : (handler_id_set * Value.chan list) =
     List.fold_left
-        (fun set_acc v ->
-           let v_handlers = event_handlers_from_value v in
-           IntSet.union set_acc v_handlers) IntSet.empty vs
+        (fun (set_acc, chan_acc) v ->
+           let (v_handlers, v_chans) = extract_json_values v in
+           (IntSet.union set_acc v_handlers, v_chans @ chan_acc)) empty_state vs
+
 
 (* External interface *)
-let add_val_event_handlers v json_state =
-  let handler_id_list = IntSet.elements @@ event_handlers_from_value v in
-  List.fold_left (fun state_acc h_id ->
-    JsonState.add_event_handler h_id (EventHandlers.find h_id) state_acc
-  ) json_state handler_id_list
+let add_value_information v json_state =
+  let (handler_ids, chans) = extract_json_values v in
+  let handler_id_list = IntSet.elements handler_ids in
+  let json_state =
+    List.fold_left (fun state_acc h_id ->
+      JsonState.add_event_handler h_id (EventHandlers.find h_id) state_acc
+    ) json_state handler_id_list in
+  List.fold_left (fun state_acc chan ->
+    JsonState.add_carried_channel chan state_acc) json_state chans
+
 
 
 let add_ap_information cid json_state =
@@ -79,5 +88,21 @@ let add_process_information cid json_state =
   List.fold_left (fun state_acc (pid, proc) ->
     (* Pop all messages *)
     let msgs = Mailbox.pop_all_messages_for cid pid in
+    (* Add any channels from each process / any mailbox messages into the state *)
+    let state_acc =
+      List.fold_left
+      (fun state_acc v -> add_value_information v state_acc) state_acc msgs in
+    let state_acc = add_value_information proc state_acc in
     JsonState.add_process pid proc msgs state_acc
   ) json_state pending_processes
+
+
+let add_channel_information client_id json_state =
+  List.fold_left (fun state_acc chan ->
+    let (_, local) = chan in
+    Session.register_client_channel client_id chan;
+    match Session.get_buffer local with
+      | Some (buf) -> JsonState.add_buffer local buf state_acc
+      | None -> JsonState.add_buffer local [] state_acc
+  ) json_state (JsonState.get_carried_channels json_state)
+

--- a/core/resolveJsonState.mli
+++ b/core/resolveJsonState.mli
@@ -3,7 +3,7 @@ open ProcessTypes
 open Json
 
 (* Adds the event handlers found in the given Value.t. Pure. *)
-val add_val_event_handlers : Value.t -> json_state -> json_state
+val add_value_information : Value.t -> json_state -> json_state
 
 (* Adds access point IDs found in the given Value.t.
  * SIDE-EFFECTING! Marks all pending APs as being delivered. *)
@@ -14,3 +14,5 @@ val add_ap_information : client_id -> json_state -> json_state
  * handlers which have been created, but not yet activated on the client.
  * SIDE-EFFECTING! Pops from the client mailbox. *)
 val add_process_information : client_id -> json_state -> json_state
+
+val add_channel_information : client_id -> json_state -> json_state

--- a/core/webif.ml
+++ b/core/webif.ml
@@ -150,10 +150,11 @@ struct
     let client_id = RequestData.get_client_id req_data in
     let json_state = Json.JsonState.empty client_id (get_websocket_url ()) in
     (* Add event handlers *)
-    let json_state = ResolveJsonState.add_val_event_handlers v json_state in
+    let json_state = ResolveJsonState.add_value_information v json_state in
     (* Add AP and process information *)
     let json_state = ResolveJsonState.add_ap_information client_id json_state in
-    ResolveJsonState.add_process_information client_id json_state
+    let json_state = ResolveJsonState.add_process_information client_id json_state in
+    ResolveJsonState.add_channel_information client_id json_state
 
   let perform_request valenv run render_cont render_servercont_cont req =
     let req_data = Value.Env.request_data valenv in

--- a/lib/js/jslib.js
+++ b/lib/js/jslib.js
@@ -689,7 +689,7 @@ const LINKS = new (function() {
    * @param {any} handlers
    * @param {any} aps
    */
-  function _activateJsonState(state, clientId, processes, handlers, aps) {
+  function _activateJsonState(state, clientId, processes, handlers, aps, buffers) {
     // set client ID
     DEBUG.debug("Setting client ID to ", clientId);
     _client_id = clientId;
@@ -714,6 +714,16 @@ const LINKS = new (function() {
       var p = processes[i];
       resolveServerValue(state, p);
       _spawnWithMessages(p.pid, p.process, p.messages);
+    }
+
+    for (let i in buffers) {
+      let entry = buffers[i];
+      let id = entry.buf_id;
+      let buf = entry.values;
+      for (let val in buf) {
+        resolveServerValue(state, val);
+      }
+      _buffers[id] = buf;
     }
     return;
   }
@@ -953,7 +963,7 @@ const LINKS = new (function() {
     },
 
     activateJsonState : function (state, s) {
-      return _activateJsonState(state, s.client_id, s.processes, s.handlers, s.access_points);
+      return _activateJsonState(state, s.client_id, s.processes, s.handlers, s.access_points, s.buffers);
     },
 
     resolveValue : function (state, v) {


### PR DESCRIPTION
This patch inspects all channels sent to the client, includes the buffers in the initial JSON dump, and updates the client locations.

This should fix #323.