### PR TITLE
Fixes draggable list (database version) example

### DIFF
--- a/examples/draggableDb.links
+++ b/examples/draggableDb.links
@@ -58,7 +58,7 @@ fun load() server {
   var t = itemsTable();
   var items =
     query { for (item <-- t)
-             orderby (item.i)
+             orderby (-item.i)
               [(name=item.name)]};
   map ((.name), items)
 }


### PR DESCRIPTION
Previously, the draggable list (database version) example should fetch items in descending order from database which would cause load after save to be effectful, i.e. seemingly reorder all the items in the display. Now the items are fetched in ascending order such that load after save appears is idempotent.

Coincidentally #295 appears to be have fixed. I am unable to reproduce the issue with the current master. 

Resolves #295 