### PR TITLE
Resolves issue #341 "No way to disable OCaml stack traces when Links fails"

### DIFF
--- a/core/errors.ml
+++ b/core/errors.ml
@@ -113,7 +113,8 @@ let display ?(default=(fun e -> raise e)) ?(stream=stderr) (e) =
   try
     Lazy.force e
   with exc ->
-    Printexc.print_backtrace stderr;
+    (if Printexc.print_backtraces
+     then Printexc.print_backtrace stderr);
     output_string stream (format_exception exc ^ "\n");
     flush stream;
     default exc

--- a/core/utility.ml
+++ b/core/utility.ml
@@ -964,6 +964,7 @@ module StringLabels = Notfound.StringLabels
 module Sys = Notfound.Sys
 module Unix = Notfound.Unix
 module UnixLabels = Notfound.UnixLabels
+module Printexc = Notfound.Printexc
 
 exception NotFound = Notfound.NotFound
 


### PR DESCRIPTION
This PR resolves #341.

TL;DR The problem was a combination of two things

1. On line 116 in `errors.ml` we always ran `Printexc.print_backtrace stderr`
2. Some recent version of OCaml has changed the behaviour of `Printexc.print_backtrace` such that it prints the stack trace if available regardless of `OCAMLRUNPARAM` or `CAMLRUNPARAM` being unset.