### PR TITLE
Fixing #354: Wrong type signatures or implementations for built-in DOM functions

### DIFF
--- a/core/lib.ml
+++ b/core/lib.ml
@@ -816,7 +816,7 @@ let env : (string * (located_primitive * Types.datatype * pure)) list = [
   IMPURE);
 
   "domSetPropertyFromRef",
-  (`Client, datatype "(DomNode, String, String) ~> String",
+  (`Client, datatype "(DomNode, String, String) ~> ()",
   IMPURE);
 
   "domHasAttribute",
@@ -832,7 +832,7 @@ let env : (string * (located_primitive * Types.datatype * pure)) list = [
   IMPURE);
 
   "domSetAttributeFromRef",
-  (`Client, datatype "(DomNode, String, String) ~> String",
+  (`Client, datatype "(DomNode, String, String) ~> ()",
   IMPURE);
 
   "domGetStyleAttrFromRef",
@@ -844,7 +844,7 @@ let env : (string * (located_primitive * Types.datatype * pure)) list = [
   IMPURE);
 
   "domSetStyleAttrFromRef",
-  (`Client, datatype "(DomNode, String, String) ~> String",
+  (`Client, datatype "(DomNode, String, String) ~> ()",
   IMPURE);
 
   (* Section:  Navigation for DomNodes *)

--- a/lib/js/jslib.js
+++ b/lib/js/jslib.js
@@ -1765,12 +1765,12 @@ function _domGetPropertyFromRef(nodeRef, propertyName) {
 
 function _domSetPropertyFromRef(nodeRef, propertyName, newVal) {
   nodeRef[propertyName] = newVal;
-  return newVal;
+  return CONSTANTS.UNIT;
 }
 
-
 function _domSetAttributeFromRef(nodeRef, attr, value) {
-  return nodeRef.setAttribute(attr, value);
+  nodeRef.setAttribute(attr, value);
+  return CONSTANTS.UNIT;
 }
 
 function _domRemoveAttributeFromRef(nodeRef, attr) {
@@ -1779,7 +1779,8 @@ function _domRemoveAttributeFromRef(nodeRef, attr) {
 }
 
 function _domSetStyleAttrFromRef(nodeRef, attr, value) {
-  return nodeRef.style[attr] = value;
+  nodeRef.style[attr] = value;
+  return CONSTANTS.UNIT;
 }
 
 function _domGetStyleAttrFromRef(nodeRef, attr) {


### PR DESCRIPTION
Changed the return type of `domSetAttributeFromRef`, `domSetPropertyFromRef` and `domSetStyleAttrFromRef` to unit and adapted the type signatures. 
Related to #354 