### PR TITLE
Resolves links-lang/links#360

### DIFF
--- a/core/typeSugar.ml
+++ b/core/typeSugar.ml
@@ -1441,7 +1441,7 @@ let type_binary_op ctxt =
 let close_pattern_type : pattern list -> Types.datatype -> Types.datatype = fun pats t ->
   (* We use a table to keep track of encountered recursive variables
      in order to avert non-termination. *)
-  let rec_vars_seen = Hashtbl.create 32 in
+  let rec_vars_seen = Hashtbl.create 8 in
   let rec cpt : pattern list -> Types.datatype -> Types.datatype = fun pats t ->
     match t with
       | `Alias (alias, t) -> `Alias (alias, cpt pats t)
@@ -1641,7 +1641,7 @@ let close_pattern_type : pattern list -> Types.datatype -> Types.datatype = fun 
               | `Recursive (i, t') when not (Hashtbl.mem rec_vars_seen i) ->
                  Hashtbl.add rec_vars_seen i ();
                  cpt pats t'
-              | `Recursive (_,_) -> t
+              | `Recursive _ -> t
           end
       | `Not_typed
       | `Primitive _

--- a/tests/annotations.tests
+++ b/tests/annotations.tests
@@ -32,3 +32,7 @@ Kind mismatch [2]
 fun (x : a :: Any) {x : a :: Base}
 stderr : @.+
 exit : 1
+
+Close recursive patterns (issue #360)
+switch (Var(0)) { case (_ : (mu a . [|Lam:(Int, a)|Var:Int|])) -> 42 }
+stdout : 42 : Int


### PR DESCRIPTION
Fixes issue #360. 

I picture two potential fixes, either return `t` as in the case for `Var` or unroll the recursive type once, and keep track of the recursive variables already encountered to prevent non-termination. I opted for the latter approach, which may prove be a somewhat conservative option as I have been unable to produce an example that requires unrolling.