### PR TITLE
Removes safepass

### DIFF
--- a/core/jbuild
+++ b/core/jbuild
@@ -10,5 +10,5 @@
   (wrapped false)
   (modes (native))
   (flags (:standard -safe-string -dtypes -w Ae-44-45-60 -g -cclib -lunix -thread))
-  (libraries (str yojson ppx_deriving_yojson.runtime unix safepass base64 ANSITerminal linenoise cohttp lwt websocket websocket-lwt.cohttp findlib))
+  (libraries (str yojson ppx_deriving_yojson.runtime unix base64 ANSITerminal linenoise cohttp lwt websocket websocket-lwt.cohttp findlib))
   (preprocess (pps (ppx_deriving.std ppx_deriving_yojson)))))

--- a/core/lib.ml
+++ b/core/lib.ml
@@ -1603,18 +1603,6 @@ let env : (string * (located_primitive * Types.datatype * pure)) list = [
     (`PFun (fun _ -> assert false),
     datatype "() ~> ()",
     IMPURE);
-
-    (* Crypt API *)
-
-    "crypt",
-    (`Server (p1 (Value.box_string -<- Bcrypt.string_of_hash -<-  (Bcrypt.hash ?count:None ?seed:None) -<- Value.unbox_string)),
-    datatype "(String) ~> String",
-    PURE);
-
-    "verify",
-    (`Server (p2 (fun str -> Value.box_bool -<- (Bcrypt.verify (Value.unbox_string str)) -<- Bcrypt.hash_of_string -<- Value.unbox_string)),
-    datatype "(String, String) ~> Bool",
-    PURE)
 ]
 
 (* HACK

--- a/links.opam
+++ b/links.opam
@@ -63,6 +63,5 @@ depends: [
   "lwt" {>= "3.1.0"}
   "cohttp"
   "websocket-lwt"
-  "safepass"
   "ocamlfind"
 ]

--- a/tests/crypt.tests
+++ b/tests/crypt.tests
@@ -1,8 +1,0 @@
-Crypt accepts correct passwords
-verify("correcthorsebatterystaple", crypt("correcthorsebatterystaple"))
-stdout : true : Bool
-
-Crypt rejects incorrect passwords
-verify("password", crypt("correcthorsebatterystaple"))
-stdout : false : Bool
-


### PR DESCRIPTION
A recent update to safepass (verison 3.0.0) has added a new optional argument to the API for `hash`, which causes a new warning during compilation of Links
```
      ocamlc core/.links.objs/lib.{cmo,cmt}
File "core/lib.ml", line 1610, characters 66-102:
Warning 48: implicit elimination of optional argument ?variant
    ocamlopt core/.links.objs/lib.{cmx,o}
File "core/lib.ml", line 1610, characters 66-102:
Warning 48: implicit elimination of optional argument ?variant
```
Setting a default value for `variant` would require everybody to upgrade their `safepass` package, however, as there appear to be no uses of the built-in `crypt` and `verify` I thought we might as well remove the dependency altogether.

Arguably, functionality a la `safepass` should be provided via a foreign function interface rather than being built-in.