### PR TITLE
Allow pure/tame toplevel expressions and bindings

### DIFF
--- a/core/typeSugar.ml
+++ b/core/typeSugar.ml
@@ -1722,7 +1722,6 @@ let check_toplevel_effects_expr tyenv expr =
   check_toplevel_effects tyenv pos griper
 
 
-
 (** check for duplicate names in a list of pattern *)
 let check_for_duplicate_names : Sugartypes.position -> pattern list -> string list = fun pos ps ->
   let add name binder binderss =
@@ -2101,8 +2100,6 @@ let usage_compat =
 
 let usages_cases bs =
   usage_compat (List.map (fun (_, (_, _, m)) -> m) bs)
-
-
 
 let rec type_check : context -> phrase -> phrase * Types.datatype * usagemap =
   fun context (expr, pos) ->
@@ -4002,9 +3999,6 @@ let binding_purity_check bindings =
                if not (Utils.is_pure_binding b) then
                  Gripers.toplevel_purity_restriction pos b)
     bindings
-
-
-
 
 module Check =
 struct

--- a/core/types.ml
+++ b/core/types.ml
@@ -2282,6 +2282,10 @@ let string_of_environment = show_environment
 let string_of_typing_environment { var_env = env; _ }
   = string_of_environment env
 
+let make_effect_row_flexible : typing_environment -> typing_environment = fun env ->
+  let flexible_effect_row = make_empty_open_row (`Any, `Any) in
+   { env with effect_row = flexible_effect_row; }
+
 let make_fresh_envs : datatype -> datatype IntMap.t * row IntMap.t * field_spec IntMap.t =
   let module S = IntSet in
   let module M = IntMap in

--- a/core/types.mli
+++ b/core/types.mli
@@ -175,6 +175,7 @@ val concrete_field_spec : field_spec -> field_spec
 val normalise_datatype : datatype -> datatype
 val normalise_row : row -> row
 val normalise_typing_environment : typing_environment -> typing_environment
+val make_effect_row_flexible : typing_environment -> typing_environment
 
 val hoist_quantifiers : datatype -> unit
 


### PR DESCRIPTION
This fixes #364.

The idea is to change the row denoting the expected effects to an empty row with a flexible row variable each time before type-checking a toplevel expression or binding. In the process, that row will be unified to whatever effects the toplevel expression or binding actually has.

After that, we try to unify the effect row with either an empty, closed row or a closed row containing only the wild effect. At the point of that check, we do not know the particular shape of e.g. the offending expression, which means it didn't make sense to re-use any of the existing gripers. Instead, I created two new ones. The resulting error message looks like this:

../my_examples/toplevel_impure.links:28: Type error: This toplevel binding has unhandled effects.
In expression: var z = f3().

