### PR TITLE
Returns linked list instead of arrays

### DIFF
--- a/lib/js/jslib.js
+++ b/lib/js/jslib.js
@@ -1795,7 +1795,7 @@ function _domGetStyleAttrFromRef(nodeRef, attr) {
  */
 function _domGetChildrenFromRef (nodeRef) {
   // map(id, xs) transforms from NodeList to Array
-  return Array.prototype.map.call(nodeRef.childNodes, function (a) { return a; });
+  return LINKEDLIST.lsFromArray(Array.prototype.map.call(nodeRef.childNodes, function (a) { return a; }));
 }
 const domGetChildrenFromRef = LINKS.kify(_domGetChildrenFromRef);
 
@@ -2087,12 +2087,12 @@ function _getAttributes(xml) {
     throw new Error("getAttributes() applied to non-element node");
   }
 
-  return Object.keys(first.attrs).map(function (key) {
+  return LINKEDLIST.lsFromArray(Object.keys(first.attrs).map(function (key) {
     return {
       1: key,
       2: first.attrs[key],
     };
-  });
+  }));
 }
 
 function _hasAttribute(xml, attrName) {


### PR DESCRIPTION
Fixes minor issue in `domGetChildrenByRef` and `getAttributes`. Instead of returning arrays, resulting in an undefined object, these return linked lists.