### PR TITLE
Make shift/reduce conflicts build time errors

### DIFF
--- a/core/dune
+++ b/core/dune
@@ -1,7 +1,14 @@
 (ocamllex
   (modules jsonlex lexer xmlLexer))
 (ocamlyacc
-  (modules parser jsonparse xmlParser))
+  (modules jsonparse xmlParser))
+
+(rule
+  (targets parser.ml parser.mli)
+  (deps parser.mly)
+  (action
+     (chdir %{workspace_root}
+       (run %{bin:ocamlyacc} --strict %{deps}))))
 
 (library
   (name links)


### PR DESCRIPTION
The introduction of shift/reduce conflicts is now regarded as a build error.

Following Jeremy Yallop's suggestion I have added the `--strict' flag
to `ocamlyacc`. We might want to do the same for the other two
parsers.