### PR TITLE
Fixed closure conversion to generalize functions over their free type variables when hoisting

### DIFF
--- a/core/channelVarUtils.ml
+++ b/core/channelVarUtils.ml
@@ -17,7 +17,7 @@ let variables_in_computation comp =
       StringMap.fold (fun _ v _ -> proj_fn v) smap ()
   and traverse_value = function
     | `Variable v -> add_variable v
-    | `Closure (_, value)
+    | `Closure (_, _, value)
     | `Project (_, value)
     | `Inject (_, value, _)
     | `TAbs (_, value)

--- a/core/closures.ml
+++ b/core/closures.ml
@@ -43,11 +43,19 @@ struct
       method close_term x =
         if IntSet.mem x bound_term_vars then
           if IntMap.mem x fenv then
-            let zs = (IntMap.find x fenv).termvars in
-            List.fold_left
+            let freevars = IntMap.find x fenv in
+            let zs = freevars.termvars in
+            let typevars = freevars.typevars in
+            let o = List.fold_left
               (fun o (z, _) -> o#close_term z)
               o
-              zs
+              zs in
+            List.fold_left
+              (fun o (tv,_) ->
+                o#register_type_var tv
+              )
+              o
+              typevars
           else
             o
         else

--- a/core/closures.ml
+++ b/core/closures.ml
@@ -472,7 +472,6 @@ struct
         | [] -> [], o
         | b :: bs when Ir.binding_scope b = `Global ->
           let b, o = o#binding b in
-          (*o#print_bindings [b];*)
           let bs', o = o#pop_hoisted_bindings in
           let bs, o = o#bindings bs in
           bs' @ (b :: bs), o
@@ -656,7 +655,6 @@ struct
               ) xs [] in
             (*Debug.print ("function currently being hoisted, before instantiation:\n" ^ Ir.string_of_binding (`Fun (f, (tyvars, xs, body), z, location)));*)
             let body = IrTraversals.InstantiateTypes.computation (o#get_type_environment) inner_maps body in
-            (*o#print_bindings [(`Fun (f, (tyvars, xs, body), z, location))];*)
             (f, (tyvars, xs, body), z, location)
           end
 

--- a/core/closures.ml
+++ b/core/closures.ml
@@ -426,7 +426,7 @@ struct
               | [], [] -> `Variable x, x_type
               | _ ->
                 let tyargs = List.map Types.type_arg_of_quantifier tyvars in
-                let (remaining_type, instantiation_maps) = Instantiate.type_arguments_to_instantiation_maps false x_type tyargs in
+                let (remaining_type, instantiation_maps) = Instantiate.instantiation_maps_of_type_arguments false x_type tyargs in
                 let overall_type = Instantiate.datatype instantiation_maps remaining_type in
                 if List.mem_assoc x parents then
                   `Closure (x, tyargs,`Variable parent_env), overall_type

--- a/core/closures.ml
+++ b/core/closures.ml
@@ -568,7 +568,7 @@ struct
       (** Given a list of free variables, return a tuple containing the following:
         - a list of fresh quantifiers, each corresponding to one free variable
         - Three maps mapping the old free variables to fresh ones (to be used with Instantiate)  **)
-      method create_substitutions_replacing_free_variables_with_fresh_ones (free_type_vars : Types.quantifier list)  =
+      method create_substitutions_replacing_free_variables (free_type_vars : Types.quantifier list)  =
         List.fold_right (fun oldq (qs, (type_map, row_map, presence_map) ) ->
           let typevar = Types.var_of_quantifier oldq in
           let primary_kind = Types.primary_kind_of_quantifier oldq in
@@ -602,7 +602,7 @@ struct
           f_binder
         else
           begin
-            let outer_quantifiers, outer_maps = o#create_substitutions_replacing_free_variables_with_fresh_ones free_type_vars in
+            let outer_quantifiers, outer_maps = o#create_substitutions_replacing_free_variables free_type_vars in
             let f_type_generalized =
               let f_type = Var.type_of_binder f_binder in
               match TypeUtils.split_quantified_type f_type with
@@ -627,7 +627,7 @@ struct
           fundef
         else
           begin
-            let inner_quantifiers, inner_maps = o#create_substitutions_replacing_free_variables_with_fresh_ones free_type_vars in
+            let inner_quantifiers, inner_maps = o#create_substitutions_replacing_free_variables free_type_vars in
             let tyvars = inner_quantifiers @ tyvars in
             let (z, o) = match z with
               | Some zbinder ->

--- a/core/evalir.ml
+++ b/core/evalir.ml
@@ -215,7 +215,7 @@ struct
           Value.box_list [Value.box_xml (Value.Node (tag, children))]
     | `ApplyPure (f, args) ->
       Proc.atomically (fun () -> apply K.empty env (value env f, List.map (value env) args))
-    | `Closure (f, v) ->
+    | `Closure (f, _, v) ->
       (* begin *)
 
       (* TODO: consider getting rid of `ClientFunction *)

--- a/core/instantiate.ml
+++ b/core/instantiate.ml
@@ -298,7 +298,8 @@ let datatype = instantiate_datatype
 
 module SEnv = Env.String
 
-let type_arguments_to_instantiation_maps : bool -> Types.datatype -> Types.type_arg list -> (datatype * (datatype IntMap.t * row IntMap.t * field_spec IntMap.t)) =
+let type_arguments_to_instantiation_maps :
+      bool -> Types.datatype -> Types.type_arg list -> (datatype * (datatype IntMap.t * row IntMap.t * field_spec IntMap.t)) =
   fun must_instantiate_all_quantifiers pt tyargs ->
     (* Debug.print ("t: " ^ Types.string_of_datatype t); *)
     let vars, t = TypeUtils.split_quantified_type pt in
@@ -317,9 +318,11 @@ let type_arguments_to_instantiation_maps : bool -> Types.datatype -> Types.type_
          Debug.print tyargs';
          raise ArityMismatch);
 
-    let vars, remaining_quantifiers = if tyargs_length = vars_length
-      then vars, []
-      else (take tyargs_length vars, drop tyargs_length vars) in
+    let vars, remaining_quantifiers =
+      if tyargs_length = vars_length then
+        vars, []
+      else
+        (take tyargs_length vars, drop tyargs_length vars) in
     let tenv, renv, penv =
       List.fold_right2
         (fun var tyarg (tenv, renv, penv) ->

--- a/core/instantiate.ml
+++ b/core/instantiate.ml
@@ -301,10 +301,7 @@ module SEnv = Env.String
 let type_arguments_to_instantiation_maps : bool -> Types.datatype -> Types.type_arg list -> (datatype * (datatype IntMap.t * row IntMap.t * field_spec IntMap.t)) =
   fun must_instantiate_all_quantifiers pt tyargs ->
     (* Debug.print ("t: " ^ Types.string_of_datatype t); *)
-    let t, vars =
-      match concrete_type pt with
-        | `ForAll (vars, t) -> t, Types.unbox_quantifiers vars
-        | t -> t, [] in
+    let vars, t = TypeUtils.split_quantified_type pt in
     let tyargs_length = List.length tyargs in
     let vars_length = List.length vars in
     let arities_okay = if must_instantiate_all_quantifiers
@@ -342,7 +339,7 @@ let type_arguments_to_instantiation_maps : bool -> Types.datatype -> Types.type_
     if remaining_quantifiers = [] then
       t, (tenv, renv, penv)
     else
-      `ForAll (ref remaining_quantifiers, t),  (tenv, renv, penv)
+      `ForAll (Types.box_quantifiers remaining_quantifiers, t),  (tenv, renv, penv)
 
 
 let apply_type : Types.datatype -> Types.type_arg list -> Types.datatype = fun pt tyargs ->

--- a/core/instantiate.mli
+++ b/core/instantiate.mli
@@ -1,5 +1,7 @@
 open Utility
 
+type instantiation_maps = (Types.datatype IntMap.t * Types.row IntMap.t * Types.field_spec IntMap.t)
+
 exception ArityMismatch
 
 val show_recursion : bool Settings.setting
@@ -15,7 +17,7 @@ val datatype :
 val alias : string -> Types.type_arg list -> Types.tycon_environment -> Types.datatype
 
 (* Given a quantified type and a list of type arguments, create the corresponding instantiation maps *)
-val type_arguments_to_instantiation_maps : bool -> Types.datatype -> Types.type_arg list -> (Types.datatype * (Types.datatype IntMap.t * Types.row IntMap.t * Types.field_spec IntMap.t))
+val instantiation_maps_of_type_arguments : bool -> Types.datatype -> Types.type_arg list -> (Types.datatype * instantiation_maps)
 
 val apply_type : Types.datatype -> Types.type_arg list -> Types.datatype
 val freshen_quantifiers : Types.datatype -> Types.datatype

--- a/core/instantiate.mli
+++ b/core/instantiate.mli
@@ -1,3 +1,5 @@
+open Utility
+
 exception ArityMismatch
 
 val show_recursion : bool Settings.setting

--- a/core/instantiate.mli
+++ b/core/instantiate.mli
@@ -12,6 +12,9 @@ val datatype :
   Types.datatype -> Types.datatype
 val alias : string -> Types.type_arg list -> Types.tycon_environment -> Types.datatype
 
+(* Given a quantified type and a list of type arguments, create the corresponding instantiation maps *)
+val type_arguments_to_instantiation_maps : bool -> Types.datatype -> Types.type_arg list -> (Types.datatype * (Types.datatype IntMap.t * Types.row IntMap.t * Types.field_spec IntMap.t))
+
 val apply_type : Types.datatype -> Types.type_arg list -> Types.datatype
 val freshen_quantifiers : Types.datatype -> Types.datatype
 val replace_quantifiers : Types.datatype -> Types.quantifier list -> Types.datatype

--- a/core/ir.ml
+++ b/core/ir.ml
@@ -52,7 +52,7 @@ type value =
   | `XmlNode of (name * value name_map * value list)
   | `ApplyPure of (value * value list)
 
-  | `Closure of var * value
+  | `Closure of var * tyarg list * value
 
   | `Coerce of (value * Types.datatype)
   ]

--- a/core/ir.mli
+++ b/core/ir.mli
@@ -54,7 +54,7 @@ type value =
                                       (* XML node construction: <tag attributes>body</tag> *)
   | `ApplyPure of value * value list  (* non-side-effecting application: v ws *)
 
-  | `Closure of var * value           (* closure creation: f env *)
+  | `Closure of var * tyarg list * value           (* closure creation: f env *)
 
   | `Coerce of value * Types.datatype (* type coercion: v:A *)
   ]

--- a/core/irTraversals.ml
+++ b/core/irTraversals.ml
@@ -875,3 +875,23 @@ module ElimTypeAliases =
       p
 
   end
+
+
+(* Call Instantiate.datatype on all types occuring in a program *)
+module InstantiateTypes =
+  struct
+
+    let instantiate instantiation_maps =
+      object (o)
+        inherit Types.Transform.visitor
+
+        method! typ t =
+          (Instantiate.datatype instantiation_maps t, o)
+
+      end
+
+    let computation tyenv instantiation_maps c  =
+      let p, _, _ = (ir_type_mod_visitor tyenv (instantiate instantiation_maps))#computation c in
+      p
+
+end

--- a/core/irTraversals.ml
+++ b/core/irTraversals.ml
@@ -233,7 +233,7 @@ struct
               match tyargs with
                 | [] -> t
                 | _ ->
-                  let (remaining_type, instantiation_maps) = Instantiate.type_arguments_to_instantiation_maps false t tyargs in
+                  let (remaining_type, instantiation_maps) = Instantiate.instantiation_maps_of_type_arguments false t tyargs in
                   Instantiate.datatype instantiation_maps remaining_type in
             let (z, _, o) = o#value z in
               (* TODO: check that closure environment types match expectations for f *)

--- a/core/irTraversals.ml
+++ b/core/irTraversals.ml
@@ -899,7 +899,10 @@ module InstantiateTypes =
         inherit Types.Transform.visitor
 
         method! typ t =
-          (Instantiate.datatype instantiation_maps t, o)
+          match t with
+            | `Not_typed -> (t, o) (* instantiate.ml dies on `Not_typed *)
+            | _ -> (Instantiate.datatype instantiation_maps t, o)
+
 
       end
 

--- a/core/irTraversals.ml
+++ b/core/irTraversals.ml
@@ -228,16 +228,13 @@ struct
               `ApplyPure (f, args), deconstruct return_type ft, o
 
         | `Closure (f, tyargs, z) ->
-
             let (f, t, o) = o#var f in
-            let t = if tyargs = []
-              then
-                t
-              else
-                begin
+            let t =
+              match tyargs with
+                | [] -> t
+                | _ ->
                   let (remaining_type, instantiation_maps) = Instantiate.type_arguments_to_instantiation_maps false t tyargs in
-                  Instantiate.datatype instantiation_maps remaining_type
-                end in
+                  Instantiate.datatype instantiation_maps remaining_type in
             let (z, _, o) = o#value z in
               (* TODO: check that closure environment types match expectations for f *)
               `Closure (f, tyargs, z), t, o

--- a/core/irTraversals.mli
+++ b/core/irTraversals.mli
@@ -3,7 +3,7 @@ open Utility
 
 module type TRANSFORM =
 sig
-  type environment = Types.datatype Env.Int.t [@@deriving show]
+  type environment = Types.datatype Env.Int.t
 
   class visitor : environment ->
   object ('self_type)

--- a/core/irTraversals.mli
+++ b/core/irTraversals.mli
@@ -1,8 +1,9 @@
 open Ir
+open Utility
 
 module type TRANSFORM =
 sig
-  type environment = Types.datatype Env.Int.t
+  type environment = Types.datatype Env.Int.t [@@deriving show]
 
   class visitor : environment ->
   object ('self_type)
@@ -61,3 +62,7 @@ module ElimDeadDefs : PROGTRANSFORM
 
 module CheckForCycles : PROGTRANSFORM
 module ElimTypeAliases : PROGTRANSFORM
+module InstantiateTypes :
+sig
+  val computation : Types.datatype Env.Int.t -> (Types.datatype IntMap.t * Types.row IntMap.t * Types.field_spec IntMap.t) -> computation -> computation
+end

--- a/core/irtojs.ml
+++ b/core/irtojs.ml
@@ -699,7 +699,7 @@ end = functor (K : CONTINUATION) -> struct
          | _ ->
             Call (gv f, List.map gv vs)
        end
-    | `Closure (f, v) ->
+    | `Closure (f, _, v) ->
        if session_exceptions_enabled
        then Call (Var "partialApplySE", [gv (`Variable f); gv v])
        else Call (Var "partialApply", [gv (`Variable f); gv v])

--- a/core/query.ml
+++ b/core/query.ml
@@ -489,7 +489,7 @@ struct
 
     | `ApplyPure (f, ps) ->
         apply env (value env f, List.map (value env) ps)
-    | `Closure (f, v) ->
+    | `Closure (f, _, v) ->
       let (_finfo, (xs, body), z_opt, _location) = Tables.find Tables.fun_defs f in
       let z = OptionUtils.val_of z_opt in
       (* Debug.print ("Converting evalir closure: " ^ Var.show_binder (f, _finfo) ^ " to query closure"); *)

--- a/core/queryshredding.ml
+++ b/core/queryshredding.ml
@@ -659,7 +659,7 @@ struct
 
     | `ApplyPure (f, ps) ->
         apply env (value env f, List.map (value env) ps)
-    | `Closure (f, v) ->
+    | `Closure (f, _, v) ->
       let (_finfo, (xs, body), z_opt, _location) = Tables.find Tables.fun_defs f in
       let z = OptionUtils.val_of z_opt in
       (* Debug.print ("Converting evalir closure: " ^ Var.show_binder (f, _finfo) ^ " to query closure"); *)

--- a/core/typeUtils.ml
+++ b/core/typeUtils.ml
@@ -219,9 +219,12 @@ let quantifiers t = match concrete_type t with
   | `ForAll (qs, _) -> Types.unbox_quantifiers qs
   | _ -> []
 
-let type_without_quantifiers qt = match concrete_type qt with
-  | `ForAll (_, t) -> t
-  | t -> t
+
+(* Given a type, return its list of toplevel quantifiers and the remaining non-quantified type.
+   This merges adjacent ForAlls *)
+let split_quantified_type qt = match concrete_type qt with
+  | `ForAll (qtref, t) -> (Types.unbox_quantifiers qtref, t)
+  | t -> ([], t)
 
 let record_without t names =
   match concrete_type t with

--- a/core/typeUtils.ml
+++ b/core/typeUtils.ml
@@ -219,6 +219,10 @@ let quantifiers t = match concrete_type t with
   | `ForAll (qs, _) -> Types.unbox_quantifiers qs
   | _ -> []
 
+let type_without_quantifiers qt = match concrete_type qt with
+  | `ForAll (_, t) -> t
+  | t -> t
+
 let record_without t names =
   match concrete_type t with
     | `Record ((fields, row_var, dual) as row) ->

--- a/core/typeUtils.mli
+++ b/core/typeUtils.mli
@@ -27,6 +27,7 @@ val split_variant_type : string -> Types.datatype -> (Types.datatype * Types.dat
 val variant_at : string -> Types.datatype -> Types.datatype
 
 val quantifiers : Types.datatype -> Types.quantifier list
+val type_without_quantifiers : Types.datatype -> Types.datatype
 
 val record_without : Types.datatype -> Utility.StringSet.t -> Types.datatype
 

--- a/core/typeUtils.mli
+++ b/core/typeUtils.mli
@@ -27,7 +27,7 @@ val split_variant_type : string -> Types.datatype -> (Types.datatype * Types.dat
 val variant_at : string -> Types.datatype -> Types.datatype
 
 val quantifiers : Types.datatype -> Types.quantifier list
-val type_without_quantifiers : Types.datatype -> Types.datatype
+val split_quantified_type : Types.datatype -> (Types.quantifier list * Types.datatype)
 
 val record_without : Types.datatype -> Utility.StringSet.t -> Types.datatype
 

--- a/core/types.ml
+++ b/core/types.ml
@@ -1033,7 +1033,7 @@ let rec concrete_field_spec f =
         end
     | _ -> f
 
-let free_type_vars, free_row_type_vars =
+let free_type_vars, free_row_type_vars, free_tyarg_vars =
   let module S = TypeVarSet in
   let rec free_type_vars' : S.t -> datatype -> S.t = fun rec_vars ->
     function
@@ -1111,8 +1111,9 @@ let free_type_vars, free_row_type_vars =
         | `Row row -> free_row_type_vars' rec_vars row
         | `Presence f -> free_field_spec_type_vars' rec_vars f
   in
-    ((fun t -> free_type_vars' S.empty t),
-     (fun t -> free_row_type_vars' S.empty t))
+    ((free_type_vars' S.empty),
+     (free_row_type_vars' S.empty),
+     (free_tyarg_vars' S.empty))
 
 type inference_type_map =
     ((datatype Unionfind.point) IntMap.t ref *

--- a/core/types.mli
+++ b/core/types.mli
@@ -6,6 +6,7 @@ type 'a field_env = 'a stringmap [@@deriving show]
 
 (* type var sets *)
 module TypeVarSet : Utility.INTSET
+module TypeVarMap : Utility.INTMAP
 
 (* points *)
 type 'a point = 'a Unionfind.point
@@ -395,7 +396,6 @@ val make_pure_function_type : datatype list -> datatype -> datatype
 val make_function_type      : datatype list -> row -> datatype -> datatype
 val make_thunk_type : row -> datatype -> datatype
 
-val typevarset_to_intset : TypeVarSet.t -> Utility.IntSet.t
 
 module type TRANSFORM =
 sig

--- a/core/types.mli
+++ b/core/types.mli
@@ -227,6 +227,7 @@ val xml_type : datatype
 (** get type variables *)
 val free_type_vars : datatype -> TypeVarSet.t
 val free_row_type_vars : row -> TypeVarSet.t
+val free_tyarg_vars : type_arg -> TypeVarSet.t
 val free_bound_type_vars     : ?include_aliases:bool -> typ -> Vars.vars_list
 val free_bound_row_type_vars : ?include_aliases:bool -> row -> Vars.vars_list
 
@@ -394,6 +395,7 @@ val make_pure_function_type : datatype list -> datatype -> datatype
 val make_function_type      : datatype list -> row -> datatype -> datatype
 val make_thunk_type : row -> datatype -> datatype
 
+val typevarset_to_intset : TypeVarSet.t -> Utility.IntSet.t
 
 module type TRANSFORM =
 sig

--- a/core/utility.ml
+++ b/core/utility.ml
@@ -266,6 +266,7 @@ module IntMap = Map.Make(Int)
 module IntPairMap = Map.Make(IntPair)
 
 module type STRINGMAP = Map with type key = string
+module type INTMAP = Map with type key = int
 module StringSet = Set.Make(String)
 module StringMap : STRINGMAP = Map.Make(String)
 

--- a/tests/functions.tests
+++ b/tests/functions.tests
@@ -89,3 +89,8 @@ Type annotation on inner function (correct, recursive)
 ./tests/functions/innerfun3.links
 filemode : true
 stdout : "Hello!" : String
+
+Closure conversion: Test generalization of free type variables during hoisting
+./tests/functions/nested-functions-polymorphic.links
+filemode : true
+stdout : 123 : Int

--- a/tests/functions/nested-functions-polymorphic.links
+++ b/tests/functions/nested-functions-polymorphic.links
@@ -1,0 +1,15 @@
+sig f1 : (a, b, c) {}~> Int
+fun f1(x,y,z) {
+	fun f2 () {
+		fun f3(q) {
+			var r2 = y;
+			var r3 = z;
+			q
+		}
+		f3(123)
+	}
+	f2()
+	
+}
+
+f1(1, "hello", 14.5)


### PR DESCRIPTION
I've adapted closures.ml such that not only free term variables are collected, but also free type variables occuring in functions. We then generalize the function over those free variables that are actually bound further up in the AST.
To make this type-check, I've changed the `Closure (f, v) constructor in IR values to  `Closure (f, targs, v), now carrying a list of type arguments. This means that `Closure now has a built-in type application. We cannot just enclose TApp (f, targs) in `Closure instead for the following reasons: 
- f is a variable, not a value. It is important to keep it that way, because the function f must be looked up in a map telling us the type of the closure environment it needs. In particular, the value `Variable f would not type-check to prevent using functions without providing the necessary closure environment.
- In order to type-check the closure, we need to know the type arguments that are applied.

I have implemented the necessary changes in the IR type checker. This PR is independent from #392, but I will commit an update to that PR to include the new code closure checking code, but commented out for now. 

This fixes #384 