### PR TITLE
Amend type check validation script

### DIFF
--- a/tests/validate_typecheck_testfile.testscript
+++ b/tests/validate_typecheck_testfile.testscript
@@ -7,8 +7,12 @@ missing=""
 
 while read file; do
     if ! grep  -q -E "^$file$" "$typecheck_tests_file"; then
-        echo "FAILURE: Links example file $file is not mentioned in $typecheck_tests_file"
-        missing+="$file "
+        # Only error if the file is tracked.
+        git ls-files --error-unmatch "$file" 2> /dev/null # Returns 1 when the file is untracked.
+        if [[ $? -ne 1 ]]; then
+            echo "FAILURE: Links example file $file is not mentioned in $typecheck_tests_file"
+            missing+="$file "
+        fi
     fi
 done <<< "$(find "$example_folder" -iname "*.links")"
 


### PR DESCRIPTION
It is mildly annoying that the `run-tests` script fails locally because some of my examples are not under revision control. Thus this PR modifies the type check validation script such that it only errors for tracked examples.