### PR TITLE
Makes 'typecheck_only' a system setting 

### DIFF
--- a/core/basicsettings.ml
+++ b/core/basicsettings.ml
@@ -185,7 +185,7 @@ let websocket_url = Settings.add_string("websocket_url", "/ws/", `User)
 
 (* For testing only. If this is set, programs are not executed, but
    Links terminates after type-checking and compiling to the IR. *)
-let typecheck_only = Settings.add_bool ("typecheck_only", false, `User)
+let typecheck_only = Settings.add_bool ("typecheck_only", false, `System)
 
 (* Handlers stuff *)
 module Handlers = struct


### PR DESCRIPTION
The current behaviour of 'typecheck_only' setting is pointless in the REPL, since turning on the setting and subsequently typing in an expression causes the REPL to quit.