### PR TITLE
Display source position for unbound type constructors

### DIFF
--- a/core/desugarDatatypes.ml
+++ b/core/desugarDatatypes.ml
@@ -3,8 +3,7 @@ open Sugartypes
 open Operators
 open Utility
 open List
-open SourceCode
-open Lexing
+open Errors
 
 module SEnv = Env.String
 
@@ -183,9 +182,7 @@ struct
         | `List k -> `Application (Types.list, [`Type (datatype var_env k)])
         | `TypeApplication (tycon, ts) ->
             begin match SEnv.find alias_env tycon with
-              | None -> let (pos,_,_) = resolve_pos pos in
-                 failwith (Printf.sprintf "%s:%d: Unbound type constructor %s"
-                           (Filename.basename pos.pos_fname) pos.pos_lnum tycon)
+              | None -> raise (UnboundTyCon (pos,tycon))
               | Some (`Alias (qs, _dt)) ->
                  let exception Kind_mismatch (* TODO add more information *) in
                  let match_kinds (q, t) =

--- a/core/desugarModules.ml
+++ b/core/desugarModules.ml
@@ -273,7 +273,7 @@ and perform_renaming module_table path term_ht type_ht =
           (self, `Var fqn)
       | phr -> super#phrasenode phr
 
-    method! datatype = function
+    method! datatypenode = function
       | `Function (dts, row, dt) ->
           let (_, dts') = self#list (fun o -> o#datatype) dts in
           let (_, dt') = self#datatype dt in
@@ -298,7 +298,7 @@ and perform_renaming module_table path term_ht type_ht =
               (o, (fqn, fspec'))) xs in
           let (o, rv') = o#row_var rv in
           (o, `Variant (xs', rv'))
-      | dt -> super#datatype dt
+      | dt -> super#datatypenode dt
 
   end
 

--- a/core/errors.ml
+++ b/core/errors.ml
@@ -12,6 +12,7 @@ exception MultiplyDefinedToplevelNames of ((SourceCode.pos list) stringmap)
 exception RichSyntaxError of synerrspec
 exception SugarError of (SourceCode.pos * string)
 exception Runtime_error of string
+exception UnboundTyCon of (SourceCode.pos * string)
 
 let show_pos : SourceCode.pos -> string =
   fun ((pos : Lexing.position), _, _) ->
@@ -36,6 +37,10 @@ let format_exception = function
       let (pos, _, expr) = SourceCode.resolve_pos pos in
         Printf.sprintf "%s:%d: Type error: %s\nIn expression: %s.\n"
           pos.pos_fname pos.pos_lnum s expr
+  | UnboundTyCon (pos, tycon) ->
+     let (pos,_,_) = SourceCode.resolve_pos pos in
+     Printf.sprintf "%s:%d: Unbound type constructor %s\n"
+                    pos.pos_fname pos.pos_lnum tycon
   | Runtime_error s -> "*** Runtime error: " ^ s
   | SourceCode.ASTSyntaxError (pos, s) ->
       let (pos,_,expr) = SourceCode.resolve_pos pos in
@@ -80,6 +85,10 @@ let format_exception_html = function
       let (pos,_,expr) = SourceCode.resolve_pos pos in
         Printf.sprintf ("<h1>Links type error</h1>\n<p>Type error at <code>%s</code>:%d:</p> <p>%s</p><p>In expression:</p>\n<pre>%s</pre>\n")
           pos.pos_fname pos.pos_lnum s (xml_escape expr)
+  | UnboundTyCon (pos, tycon) ->
+      let (pos,_,_) = SourceCode.resolve_pos pos in
+        Printf.sprintf ("<h1>Links type error</h1>\n<p>Type error at <code>%s</code>:%d:</p> <p>Unbound type constructor:</p>\n<pre>%s</pre>\n")
+          pos.pos_fname pos.pos_lnum tycon
   | MultiplyDefinedToplevelNames duplicates ->
       let show_pos : SourceCode.pos -> string = fun ((pos : Lexing.position), _, _) ->
         Printf.sprintf "file <code>%s</code>, line %d" pos.Lexing.pos_fname pos.Lexing.pos_lnum

--- a/core/errors.mli
+++ b/core/errors.mli
@@ -13,6 +13,7 @@ exception MultiplyDefinedToplevelNames of
 exception Type_error of (SourceCode.pos * string)
 exception RichSyntaxError of synerrspec
 exception SugarError of (SourceCode.pos * string)
+exception UnboundTyCon of (SourceCode.pos * string)
 
 val format_exception : exn -> string
 val format_exception_html : exn -> string

--- a/core/moduleUtils.ml
+++ b/core/moduleUtils.ml
@@ -58,9 +58,9 @@ object
     | `Module _ -> {< has_no_modules = false >}
     | b -> super#bindingnode b
 
-  method! datatype = function
+  method! datatypenode = function
     | `QualifiedTypeApplication _ -> {< has_no_modules = false >}
-    | dt -> super#datatype dt
+    | dt -> super#datatypenode dt
 
   method! phrasenode = function
     | `QualifiedVar _ -> {< has_no_modules = false >}
@@ -139,10 +139,10 @@ let get_data_constructors init_constrs =
             {< constrs = StringSet.add constr constrs >}
         method get_constrs = StringSet.elements constrs
 
-        method! datatype = function
+        method! datatypenode = function
             | `Variant (xs, _) ->
                 self#list (fun o (lbl, _) -> o#add_constr lbl) xs
-            | dt -> super#datatype dt
+            | dt -> super#datatypenode dt
     end
 
 let create_module_info_map program =

--- a/core/parser.mly
+++ b/core/parser.mly
@@ -120,27 +120,27 @@ let subkind_of pos =
   | "Eff"  -> Some (`Unl, `Effect)
   | sk -> raise (ConcreteSyntaxError ("Invalid subkind: " ^ sk, pos))
 
-let attach_kind _pos (t, k) = (t, k, `Rigid)
+let attach_kind (t, k) = (t, k, `Rigid)
 
-let attach_subkind_helper update _pos sk = update sk
+let attach_subkind_helper update sk = update sk
 
-let attach_subkind pos (t, subkind) =
+let attach_subkind (t, subkind) =
   let update sk =
     match t with
     | `TypeVar (x, _, freedom) ->
        `TypeVar (x, sk, freedom)
     | _ -> assert false
   in
-    attach_subkind_helper update pos subkind
+    attach_subkind_helper update subkind
 
-let attach_row_subkind pos (r, subkind) =
+let attach_row_subkind (r, subkind) =
   let update sk =
     match r with
     | `Open (x, _, freedom) ->
        `Open (x, sk, freedom)
     | _ -> assert false
   in
-    attach_subkind_helper update pos subkind
+    attach_subkind_helper update subkind
 
 let row_with field (fields, row_var) = field::fields, row_var
 
@@ -394,7 +394,7 @@ subkind:
 
 typearg:
 | VARIABLE                                                     { (($1, (`Type, None), `Rigid), None) }
-| VARIABLE kind                                                { (attach_kind (pos()) ($1, $2), None) }
+| VARIABLE kind                                                { (attach_kind ($1, $2), None) }
 
 varlist:
 | typearg                                                      { [$1] }
@@ -1117,7 +1117,7 @@ type_var:
 | PERCENT                                                      { fresh_type_variable None }
 
 kinded_type_var:
-| type_var subkind                                             { attach_subkind (pos()) ($1, $2) }
+| type_var subkind                                             { attach_subkind ($1, $2) }
 
 type_arg_list:
 | type_arg                                                     { [$1] }
@@ -1233,10 +1233,10 @@ row_var:
 | LPAREN MU VARIABLE DOT vfields RPAREN                        { `Recursive ($3, $5) }
 
 kinded_nonrec_row_var:
-| nonrec_row_var subkind                                       { attach_row_subkind (pos()) ($1, $2) }
+| nonrec_row_var subkind                                       { attach_row_subkind ($1, $2) }
 
 kinded_row_var:
-| row_var subkind                                              { attach_row_subkind (pos()) ($1, $2) }
+| row_var subkind                                              { attach_row_subkind ($1, $2) }
 
 /*
  * Regular expression grammar

--- a/core/sugarTraversals.ml
+++ b/core/sugarTraversals.ml
@@ -568,7 +568,7 @@ class map =
         let _x = o#string _x in
         let _x_i1 = o#list (fun o -> o#string) _x_i1 in (_x, _x_i1)
 
-    method datatype : datatype -> datatype =
+    method datatypenode : datatypenode -> datatypenode =
       function
       | `TypeVar _x ->
           let _x = o#known_type_variable _x in `TypeVar _x
@@ -623,6 +623,11 @@ class map =
       | `Dual _x ->
         let _x = o#datatype _x in `Dual _x
       | `End -> `End
+
+    method datatype : datatype -> datatype =
+      fun (_x, _x_i1) ->
+        let _x = o#datatypenode _x in
+        let _x_i1 = o#position _x_i1 in (_x, _x_i1)
 
     method type_arg : type_arg -> type_arg =
       function
@@ -1233,7 +1238,7 @@ class fold =
 
     method tyvar : tyvar -> 'self_type = fun _ -> o
 
-    method datatype : datatype -> 'self_type =
+    method datatypenode : datatypenode -> 'self_type =
       function
       | `TypeVar _x ->
           let o = o#known_type_variable _x in o
@@ -1281,6 +1286,10 @@ class fold =
       | `Dual _x ->
         let o = o#datatype _x in o
       | `End -> o
+
+    method datatype : datatype -> 'self_type =
+      fun (_x, _x_i1) ->
+        let o = o#datatypenode _x in let o = o#position _x_i1 in o
 
     method type_arg : type_arg -> 'self_type =
       function
@@ -2003,7 +2012,7 @@ class fold_map =
         let (o, _x_i1) = o#option (fun o -> o#unknown) _x_i1
         in (o, (_x, _x_i1))
 
-    method datatype : datatype -> ('self_type * datatype) =
+    method datatypenode : datatypenode -> ('self_type * datatypenode) =
       function
       | `TypeVar _x ->
           let (o, _x) = o#known_type_variable _x in (o, (`TypeVar _x))
@@ -2063,6 +2072,11 @@ class fold_map =
       | `Dual _x ->
         let (o, _x) = o#datatype _x in (o, `Dual _x)
       | `End -> (o, `End)
+
+    method datatype : datatype -> ('self_type * datatype) =
+      fun (_x, _x_i1) ->
+        let (o, _x) = o#datatypenode _x in
+        let (o, _x_i1) = o#position _x_i1 in (o, (_x, _x_i1))
 
     method type_arg : type_arg -> ('self_type * type_arg) =
       function

--- a/core/sugarTraversals.mli
+++ b/core/sugarTraversals.mli
@@ -58,6 +58,7 @@ class map :
     method fieldconstraint : fieldconstraint -> fieldconstraint
     method directive       : directive -> directive
     method datatype        : datatype -> datatype
+    method datatypenode    : datatypenode -> datatypenode
     method datatype'       : datatype' -> datatype'
     method type_arg        : type_arg -> type_arg
     method constant        : constant -> constant
@@ -130,6 +131,7 @@ class fold :
     method directive       : directive -> 'self
     method tyvar           : tyvar -> 'self
     method datatype        : datatype -> 'self
+    method datatypenode    : datatypenode -> 'self
     method datatype'       : datatype' -> 'self
     method type_arg        : type_arg -> 'self
     method constant        : constant -> 'self
@@ -163,6 +165,7 @@ object ('self)
   method char            : char -> 'self * char
   method constant        : constant -> 'self * constant
   method datatype        : datatype -> 'self * datatype
+  method datatypenode    : datatypenode -> 'self * datatypenode
   method datatype'       : datatype' -> 'self * datatype'
   method directive       : directive -> 'self * directive
   method fieldconstraint : fieldconstraint -> 'self * fieldconstraint

--- a/core/sugartypes.ml
+++ b/core/sugartypes.ml
@@ -69,7 +69,7 @@ let rigidify (name, kind, _) = (name, kind, `Rigid)
 type fieldconstraint = [ `Readonly | `Default ]
     [@@deriving show]
 
-type datatype =
+type datatypenode =
   [ `TypeVar         of known_type_variable
   | `QualifiedTypeApplication of (name list * type_arg list)
   | `Function        of datatype list * row * datatype
@@ -92,6 +92,7 @@ type datatype =
   | `Choice          of row
   | `Dual            of datatype
   | `End ]
+and datatype = datatypenode * position
 and row = (string * fieldspec) list * row_var
 and row_var =
     [ `Closed

--- a/tests/modules.tests
+++ b/tests/modules.tests
@@ -123,5 +123,5 @@ Constructor out of scope
 ./tests/modules/constructor-test-bad.links
 filemode : args
 args : -m --path=tests/modules
-stderr : *** Fatal error : Unbound type constructor DT
+stderr : *** Fatal error : constructor-test-bad.links:5: Unbound type constructor DT
 exit : 1

--- a/tests/modules.tests
+++ b/tests/modules.tests
@@ -123,5 +123,5 @@ Constructor out of scope
 ./tests/modules/constructor-test-bad.links
 filemode : args
 args : -m --path=tests/modules
-stderr : *** Fatal error : constructor-test-bad.links:5: Unbound type constructor DT
+stderr : ./tests/modules/constructor-test-bad.links:5: Unbound type constructor DT
 exit : 1


### PR DESCRIPTION
This PR fixes #187.

Datatype declarations are now annotated with source code position. Following an already existing pattern in `sugartypes.ml`:

```
type phrasenode = [....]
and pharse = phrasenode * position

type patternnode = [....]
and pattern = patternnode * position
```
we now have:
```
type datatypenode = [....]
and datatype = datatypenode * position
```
with appropriate changes made to sugarTraversals. Positions are propagated to a place where an error message for unbound type constructor is raised. If I write a program:

```


sig f : (Foo) -> Foo
fun f(x) { x }
```

I now get an error message:

```
*** Fatal error : T187.links:3: Unbound type constructor Foo
```

It seems to me - and please correct me if I'm wrong - that we don't really have error messages that display source locations, so I took a liberty of designing my own format of the message.

I also removed some unused arguments from a couple of functions in the parser (separate commit).

I have some thoughts on how we could improve our parser. #411 looks like a good place to share them.