### PR TITLE
Refactor nodes with position

### DIFF
--- a/core/chaser.ml
+++ b/core/chaser.ml
@@ -71,7 +71,7 @@ let rec add_module_bindings deps dep_map =
     | [module_name]::ys ->
       (try
         let (bindings, _) = StringMap.find module_name dep_map in
-        Sugartypes.mkWithDPos (`Module (module_name, bindings)) :: (add_module_bindings ys dep_map)
+        Sugartypes.with_dummy_pos (`Module (module_name, bindings)) :: (add_module_bindings ys dep_map)
       with Notfound.NotFound _ ->
         (failwith (Printf.sprintf "Trying to find %s in dep map containing keys: %s\n"
           module_name (print_list (List.map fst (StringMap.bindings dep_map))))));

--- a/core/chaser.ml
+++ b/core/chaser.ml
@@ -71,7 +71,7 @@ let rec add_module_bindings deps dep_map =
     | [module_name]::ys ->
       (try
         let (bindings, _) = StringMap.find module_name dep_map in
-        (`Module (module_name, bindings), Sugartypes.dummy_position) :: (add_module_bindings ys dep_map)
+        Sugartypes.mkWithDPos (`Module (module_name, bindings)) :: (add_module_bindings ys dep_map)
       with Notfound.NotFound _ ->
         (failwith (Printf.sprintf "Trying to find %s in dep map containing keys: %s\n"
           module_name (print_list (List.map fst (StringMap.bindings dep_map))))));

--- a/core/compilePatterns.ml
+++ b/core/compilePatterns.ml
@@ -79,12 +79,12 @@ let rec desugar_pattern : Ir.scope -> Sugartypes.pattern -> pattern * raw_env =
     let pp = desugar_pattern scope in
     let empty = (NEnv.empty, TEnv.empty, Types.make_empty_open_row (`Any, `Any)) in
     let (++) (nenv, tenv, _) (nenv', tenv', eff') = (NEnv.extend nenv nenv', TEnv.extend tenv tenv', eff') in
-    let fresh_binder (nenv, tenv, eff) =
-      function
-        | (name, Some t, _) ->
-            let xb, x = Var.fresh_var (t, name, scope) in
-              xb, (NEnv.bind nenv (name, x), TEnv.bind tenv (x, t), eff)
-        | _ -> assert false
+    let fresh_binder (nenv, tenv, eff) bndr =
+      assert (Sugartypes.binder_has_type bndr);
+      let name = Sugartypes.name_of_binder bndr in
+      let t = Sugartypes.type_of_binder_exn bndr in
+      let xb, x = Var.fresh_var (t, name, scope) in
+      xb, (NEnv.bind nenv (name, x), TEnv.bind tenv (x, t), eff)
     in
       match p with
         | `Any -> `Any, empty
@@ -93,10 +93,10 @@ let rec desugar_pattern : Ir.scope -> Sugartypes.pattern -> pattern * raw_env =
             let p, env = pp p in
             let ps, env' = pp ps in
               `Cons (p, ps), env ++ env'
-        | `List [] -> pp (Sugartypes.mkWithPos `Nil pos)
+        | `List [] -> pp (Sugartypes.with_pos `Nil pos)
         | `List (p::ps) ->
             let p, env = pp p in
-            let ps, env' = pp (Sugartypes.mkWithPos (`List ps) pos) in
+            let ps, env' = pp (Sugartypes.with_pos (`List ps) pos) in
               `Cons (p, ps), env ++ env'
         | `Variant (name, None) -> `Variant (name, `Any), empty
         | `Variant (name, Some p) ->
@@ -131,7 +131,7 @@ let rec desugar_pattern : Ir.scope -> Sugartypes.pattern -> pattern * raw_env =
               `Record (bs, p), env
         | `Tuple ps ->
             let bs = mapIndex (fun p i -> (string_of_int (i+1), p)) ps in
-              pp (Sugartypes.mkWithPos (`Record (bs, None)) pos)
+              pp (Sugartypes.with_pos (`Record (bs, None)) pos)
         | `Constant constant ->
             `Constant constant, empty
         | `Variable b ->

--- a/core/desugarAlienBlocks.ml
+++ b/core/desugarAlienBlocks.ml
@@ -36,16 +36,16 @@ object(self)
   method get_bindings = List.rev bindings
 
   method! binding = function
-    | (`AlienBlock (lang, lib, decls), _) ->
+    | {node=`AlienBlock (lang, lib, decls); _} ->
         self#list (fun o ((bnd, dt)) ->
           let (name, _, pos) = bnd in
-          o#add_binding (`Foreign (bnd, name, lang, lib, dt), pos)) decls
-    | (`Module (name, bindings), pos) ->
+          o#add_binding (mkWithPos (`Foreign (bnd, name, lang, lib, dt)) pos)) decls
+    | {node=`Module (name, bindings); pos} ->
         let flattened_bindings =
           List.concat (
             List.map (fun b -> ((flatten_bindings ())#binding b)#get_bindings) bindings
           ) in
-        self#add_binding (`Module (name, flattened_bindings), pos)
+        self#add_binding (mkWithPos (`Module (name, flattened_bindings)) pos)
     | b -> self#add_binding ((flatten_simple ())#binding b)
 
   method! program = function

--- a/core/desugarAlienBlocks.ml
+++ b/core/desugarAlienBlocks.ml
@@ -38,14 +38,15 @@ object(self)
   method! binding = function
     | {node=`AlienBlock (lang, lib, decls); _} ->
         self#list (fun o ((bnd, dt)) ->
-          let (name, _, pos) = bnd in
-          o#add_binding (mkWithPos (`Foreign (bnd, name, lang, lib, dt)) pos)) decls
+          let name = name_of_binder bnd in
+          let pos = bnd.pos in
+          o#add_binding (with_pos (`Foreign (bnd, name, lang, lib, dt)) pos)) decls
     | {node=`Module (name, bindings); pos} ->
         let flattened_bindings =
           List.concat (
             List.map (fun b -> ((flatten_bindings ())#binding b)#get_bindings) bindings
           ) in
-        self#add_binding (mkWithPos (`Module (name, flattened_bindings)) pos)
+        self#add_binding (with_pos (`Module (name, flattened_bindings)) pos)
     | b -> self#add_binding ((flatten_simple ())#binding b)
 
   method! program = function

--- a/core/desugarCP.ml
+++ b/core/desugarCP.ml
@@ -9,7 +9,7 @@ object (o : 'self_type)
 
   method! phrasenode = function
     | `CP p ->
-       let rec desugar_cp = fun o (p, pos) ->
+       let rec desugar_cp = fun o {node = p; pos} ->
          let add_pos x = (x, pos) in
          let add_withPos x = mkWithPos x pos in
          match p with

--- a/core/desugarCP.ml
+++ b/core/desugarCP.ml
@@ -22,11 +22,11 @@ object (o : 'self_type)
          | `Grab ((c, _), None, p) ->
             let (o, e, t) = desugar_cp o p in
             o, `Block
-                  ([add_pos (`Val ([], add_withPos `Any,
-                                   add_pos (`FnAppl (add_pos (`Var "wait"),
-                                                     [add_pos (`Var c)])),
-                                   `Unknown, None))],
-                   add_pos e), t
+                ([add_withPos (`Val ([], add_withPos `Any,
+                                     add_pos (`FnAppl (add_pos (`Var "wait"),
+                                                       [add_pos (`Var c)])),
+                                     `Unknown, None))],
+                 add_pos e), t
          | `Grab ((c, Some (`Input (_a, s), grab_tyargs)), Some (x, Some u, _), p) -> (* FYI: a = u *)
             let envs = o#backup_envs in
             let venv = TyEnv.bind (TyEnv.bind (o#get_var_env ())
@@ -36,20 +36,20 @@ object (o : 'self_type)
             let (o, e, t) = desugar_cp o p in
             let o = o#restore_envs envs in
             o, `Block
-                  ([add_pos (`Val ([], add_withPos (`Record ([("1", add_withPos (`Variable (x, Some u, pos)));
-                                                              ("2", add_withPos (`Variable (c, Some s, pos)))], None)),
-                                   add_pos (`FnAppl (add_pos (Sugartypes.tappl (`Var "receive", grab_tyargs)),
-                                                     [add_pos (`Var c)])),
-                                   `Unknown, None))],
-                  add_pos e), t
+                ([add_withPos (`Val ([], add_withPos (`Record ([("1", add_withPos (`Variable (x, Some u, pos)));
+                                                                ("2", add_withPos (`Variable (c, Some s, pos)))], None)),
+                                     add_pos (`FnAppl (add_pos (Sugartypes.tappl (`Var "receive", grab_tyargs)),
+                                                       [add_pos (`Var c)])),
+                                     `Unknown, None))],
+                 add_pos e), t
          | `Give ((c, _), None, p) ->
             let (o, e, t) = desugar_cp o p in
             o, `Block
-                  ([add_pos (`Val ([], add_withPos `Any,
-                                   add_pos (`FnAppl (add_pos (`Var "close"),
-                                                     [add_pos (`Var c)])),
-                                   `Unknown, None))],
-                   add_pos e), t
+                ([add_withPos (`Val ([], add_withPos `Any,
+                                     add_pos (`FnAppl (add_pos (`Var "close"),
+                                                       [add_pos (`Var c)])),
+                                     `Unknown, None))],
+                 add_pos e), t
          | `Give ((c, Some (`Output (_t, s), give_tyargs)), Some e, p) ->
             let envs = o#backup_envs in
             let o = {< var_env = TyEnv.bind (o#get_var_env ()) (c, s) >} in
@@ -57,11 +57,11 @@ object (o : 'self_type)
             let (o, p, t) = desugar_cp o p in
             let o = o#restore_envs envs in
             o, `Block
-                  ([add_pos (`Val ([], add_withPos (`Variable (c, Some s, pos)),
-                                   add_pos (`FnAppl (add_pos (Sugartypes.tappl (`Var "send", give_tyargs)),
-                                                     [e; add_pos (`Var c)])),
-                                   `Unknown, None))],
-                   add_pos p), t
+                ([add_withPos (`Val ([], add_withPos (`Variable (c, Some s, pos)),
+                                     add_pos (`FnAppl (add_pos (Sugartypes.tappl (`Var "send", give_tyargs)),
+                                                       [e; add_pos (`Var c)])),
+                                     `Unknown, None))],
+                 add_pos p), t
          | `GiveNothing ((c, Some t, _)) ->
             o, `Var c, t
          | `Select ((c, Some s, _), label, p) ->
@@ -70,10 +70,10 @@ object (o : 'self_type)
             let (o, p, t) = desugar_cp o p in
             let o = o#restore_envs envs in
             o, `Block
-                 ([add_pos (`Val ([], add_withPos (`Variable (c, Some (TypeUtils.select_type label s), pos)),
-                                  add_pos (`Select (label, (add_pos (`Var c)))),
-                                  `Unknown, None))],
-                  add_pos p), t
+                ([add_withPos (`Val ([], add_withPos (`Variable (c, Some (TypeUtils.select_type label s), pos)),
+                                     add_pos (`Select (label, (add_pos (`Var c)))),
+                                     `Unknown, None))],
+                 add_pos p), t
          | `Offer ((c, Some s, _), cases) ->
             let desugar_branch (label, p) (o, cases) =
               let envs = o#backup_envs in
@@ -97,22 +97,22 @@ object (o : 'self_type)
             let (o, right, t) = desugar_cp {< var_env = TyEnv.bind (o#get_var_env ()) (c, Types.dual_type s) >} right in
             let o = o#restore_envs envs in
             let left_block = add_pos (`Spawn (`Angel, `NoSpawnLocation, add_pos (`Block (
-                                     [ add_pos (`Val ([], add_withPos (`Variable (c, Some s, pos)),
-                                                      add_pos (`FnAppl (add_pos (`Var "accept"), [add_pos (`Var c)])),
-                                                      `Unknown, None));
-                                       add_pos (`Val ([], add_withPos (`Variable (c, Some Types.make_endbang_type, pos)),
-                                                      add_pos left, `Unknown, None))],
+                                     [ add_withPos (`Val ([], add_withPos (`Variable (c, Some s, pos)),
+                                                          add_pos (`FnAppl (add_pos (`Var "accept"), [add_pos (`Var c)])),
+                                                          `Unknown, None));
+                                       add_withPos (`Val ([], add_withPos (`Variable (c, Some Types.make_endbang_type, pos)),
+                                                          add_pos left, `Unknown, None))],
                                        add_pos (`FnAppl (add_pos (`Var "close"), [add_pos (`Var c)])))),
                                               Some (Types.make_singleton_closed_row ("wild", `Present Types.unit_type)))) in
             let o = o#restore_envs envs in
             o, `Block
-                  ([add_pos (`Val ([], add_withPos (`Variable (c, Some (`Application (Types.access_point, [`Type s])), pos)),
-                                   add_pos (`FnAppl (add_pos (`Var "new"), [])),
-                                   `Unknown, None));
-                    add_pos (`Val ([], add_withPos `Any, left_block, `Unknown, None));
-                    add_pos (`Val ([], add_withPos (`Variable (c, Some (Types.dual_type s), pos)),
-                                   add_pos (`FnAppl (add_pos (`Var "request"), [add_pos (`Var c)])),
-                                   `Unknown, None))],
+                  ([add_withPos (`Val ([], add_withPos (`Variable (c, Some (`Application (Types.access_point, [`Type s])), pos)),
+                                       add_pos (`FnAppl (add_pos (`Var "new"), [])),
+                                       `Unknown, None));
+                    add_withPos (`Val ([], add_withPos `Any, left_block, `Unknown, None));
+                    add_withPos (`Val ([], add_withPos (`Variable (c, Some (Types.dual_type s), pos)),
+                                       add_pos (`FnAppl (add_pos (`Var "request"), [add_pos (`Var c)])),
+                                       `Unknown, None))],
                    add_pos right), t
          | _ -> assert false in
        desugar_cp o p

--- a/core/desugarCP.ml
+++ b/core/desugarCP.ml
@@ -10,8 +10,7 @@ object (o : 'self_type)
   method! phrasenode = function
     | `CP p ->
        let rec desugar_cp = fun o {node = p; pos} ->
-         let add_pos x = (x, pos) in
-         let add_with_pos x = with_pos x pos in
+         let add_pos x = with_pos x pos in
          match p with
          | `Unquote (bs, e) ->
             let envs = o#backup_envs in
@@ -22,7 +21,7 @@ object (o : 'self_type)
          | `Grab ((c, _), None, p) ->
             let (o, e, t) = desugar_cp o p in
             o, `Block
-                ([add_with_pos (`Val ([], add_with_pos `Any,
+                ([add_pos (`Val ([], add_pos `Any,
                                       add_pos (`FnAppl (add_pos (`Var "wait"),
                                                        [add_pos (`Var c)])),
                                       `Unknown, None))],
@@ -36,8 +35,8 @@ object (o : 'self_type)
             let (o, e, t) = desugar_cp o p in
             let o = o#restore_envs envs in
             o, `Block
-                ([add_with_pos (`Val ([], add_with_pos (`Record ([("1", add_with_pos (`Variable (make_binder x u pos)));
-                                                                  ("2", add_with_pos (`Variable (make_binder c s pos)))], None)),
+                ([add_pos (`Val ([], add_pos (`Record ([("1", add_pos (`Variable (make_binder x u pos)));
+                                                                  ("2", add_pos (`Variable (make_binder c s pos)))], None)),
                                       add_pos (`FnAppl (add_pos (Sugartypes.tappl (`Var "receive", grab_tyargs)),
                                                         [add_pos (`Var c)])),
                                       `Unknown, None))],
@@ -45,7 +44,7 @@ object (o : 'self_type)
          | `Give ((c, _), None, p) ->
             let (o, e, t) = desugar_cp o p in
             o, `Block
-                ([add_with_pos (`Val ([], add_with_pos `Any,
+                ([add_pos (`Val ([], add_pos `Any,
                                       add_pos (`FnAppl (add_pos (`Var "close"),
                                                         [add_pos (`Var c)])),
                                       `Unknown, None))],
@@ -57,7 +56,7 @@ object (o : 'self_type)
             let (o, p, t) = desugar_cp o p in
             let o = o#restore_envs envs in
             o, `Block
-                ([add_with_pos (`Val ([], add_with_pos (`Variable (make_binder c s pos)),
+                ([add_pos (`Val ([], add_pos (`Variable (make_binder c s pos)),
                                       add_pos (`FnAppl (add_pos (Sugartypes.tappl (`Var "send", give_tyargs)),
                                                         [e; add_pos (`Var c)])),
                                       `Unknown, None))],
@@ -70,7 +69,7 @@ object (o : 'self_type)
             let (o, p, t) = desugar_cp o p in
             let o = o#restore_envs envs in
             o, `Block
-                ([add_with_pos (`Val ([], add_with_pos (`Variable (make_binder c (TypeUtils.select_type label s) pos)),
+                ([add_pos (`Val ([], add_pos (`Variable (make_binder c (TypeUtils.select_type label s) pos)),
                                       add_pos (`Select (label, (add_pos (`Var c)))),
                                       `Unknown, None))],
                  add_pos p), t
@@ -79,7 +78,7 @@ object (o : 'self_type)
               let envs = o#backup_envs in
               let o = {< var_env = TyEnv.bind (o#get_var_env ()) (c, TypeUtils.choice_at label s) >} in
               let (o, p, t) = desugar_cp o p in
-              let pat : pattern = add_with_pos (`Variant (label, Some (add_with_pos (`Variable (make_binder c (TypeUtils.choice_at label s) pos))))) in
+              let pat : pattern = add_pos (`Variant (label, Some (add_pos (`Variable (make_binder c (TypeUtils.choice_at label s) pos))))) in
               o#restore_envs envs, ((pat, add_pos p), t) :: cases in
             let (o, cases) = List.fold_right desugar_branch cases (o, []) in
             (match List.split cases with
@@ -97,20 +96,20 @@ object (o : 'self_type)
             let (o, right, t) = desugar_cp {< var_env = TyEnv.bind (o#get_var_env ()) (c, Types.dual_type s) >} right in
             let o = o#restore_envs envs in
             let left_block = add_pos (`Spawn (`Angel, `NoSpawnLocation, add_pos (`Block (
-                                     [ add_with_pos (`Val ([], add_with_pos (`Variable (make_binder c s pos)),
+                                     [ add_pos (`Val ([], add_pos (`Variable (make_binder c s pos)),
                                                            add_pos (`FnAppl (add_pos (`Var "accept"), [add_pos (`Var c)])),
                                                            `Unknown, None));
-                                       add_with_pos (`Val ([], add_with_pos (`Variable (make_binder c Types.make_endbang_type pos)),
+                                       add_pos (`Val ([], add_pos (`Variable (make_binder c Types.make_endbang_type pos)),
                                                            add_pos left, `Unknown, None))],
                                        add_pos (`FnAppl (add_pos (`Var "close"), [add_pos (`Var c)])))),
                                               Some (Types.make_singleton_closed_row ("wild", `Present Types.unit_type)))) in
             let o = o#restore_envs envs in
             o, `Block
-                  ([add_with_pos (`Val ([], add_with_pos (`Variable (make_binder c (`Application (Types.access_point, [`Type s])) pos)),
+                  ([add_pos (`Val ([], add_pos (`Variable (make_binder c (`Application (Types.access_point, [`Type s])) pos)),
                                         add_pos (`FnAppl (add_pos (`Var "new"), [])),
                                         `Unknown, None));
-                    add_with_pos (`Val ([], add_with_pos `Any, left_block, `Unknown, None));
-                    add_with_pos (`Val ([], add_with_pos (`Variable (make_binder c (Types.dual_type s) pos)),
+                    add_pos (`Val ([], add_pos `Any, left_block, `Unknown, None));
+                    add_pos (`Val ([], add_pos (`Variable (make_binder c (Types.dual_type s) pos)),
                                         add_pos (`FnAppl (add_pos (`Var "request"), [add_pos (`Var c)])),
                                         `Unknown, None))],
                    add_pos right), t

--- a/core/desugarCP.ml
+++ b/core/desugarCP.ml
@@ -11,7 +11,7 @@ object (o : 'self_type)
     | `CP p ->
        let rec desugar_cp = fun o {node = p; pos} ->
          let add_pos x = (x, pos) in
-         let add_withPos x = mkWithPos x pos in
+         let add_with_pos x = with_pos x pos in
          match p with
          | `Unquote (bs, e) ->
             let envs = o#backup_envs in
@@ -22,12 +22,12 @@ object (o : 'self_type)
          | `Grab ((c, _), None, p) ->
             let (o, e, t) = desugar_cp o p in
             o, `Block
-                ([add_withPos (`Val ([], add_withPos `Any,
-                                     add_pos (`FnAppl (add_pos (`Var "wait"),
+                ([add_with_pos (`Val ([], add_with_pos `Any,
+                                      add_pos (`FnAppl (add_pos (`Var "wait"),
                                                        [add_pos (`Var c)])),
-                                     `Unknown, None))],
+                                      `Unknown, None))],
                  add_pos e), t
-         | `Grab ((c, Some (`Input (_a, s), grab_tyargs)), Some (x, Some u, _), p) -> (* FYI: a = u *)
+         | `Grab ((c, Some (`Input (_a, s), grab_tyargs)), Some {node=x, Some u; _}, p) -> (* FYI: a = u *)
             let envs = o#backup_envs in
             let venv = TyEnv.bind (TyEnv.bind (o#get_var_env ())
                                               (x, u))
@@ -36,19 +36,19 @@ object (o : 'self_type)
             let (o, e, t) = desugar_cp o p in
             let o = o#restore_envs envs in
             o, `Block
-                ([add_withPos (`Val ([], add_withPos (`Record ([("1", add_withPos (`Variable (x, Some u, pos)));
-                                                                ("2", add_withPos (`Variable (c, Some s, pos)))], None)),
-                                     add_pos (`FnAppl (add_pos (Sugartypes.tappl (`Var "receive", grab_tyargs)),
-                                                       [add_pos (`Var c)])),
-                                     `Unknown, None))],
+                ([add_with_pos (`Val ([], add_with_pos (`Record ([("1", add_with_pos (`Variable (make_binder x u pos)));
+                                                                  ("2", add_with_pos (`Variable (make_binder c s pos)))], None)),
+                                      add_pos (`FnAppl (add_pos (Sugartypes.tappl (`Var "receive", grab_tyargs)),
+                                                        [add_pos (`Var c)])),
+                                      `Unknown, None))],
                  add_pos e), t
          | `Give ((c, _), None, p) ->
             let (o, e, t) = desugar_cp o p in
             o, `Block
-                ([add_withPos (`Val ([], add_withPos `Any,
-                                     add_pos (`FnAppl (add_pos (`Var "close"),
-                                                       [add_pos (`Var c)])),
-                                     `Unknown, None))],
+                ([add_with_pos (`Val ([], add_with_pos `Any,
+                                      add_pos (`FnAppl (add_pos (`Var "close"),
+                                                        [add_pos (`Var c)])),
+                                      `Unknown, None))],
                  add_pos e), t
          | `Give ((c, Some (`Output (_t, s), give_tyargs)), Some e, p) ->
             let envs = o#backup_envs in
@@ -57,29 +57,29 @@ object (o : 'self_type)
             let (o, p, t) = desugar_cp o p in
             let o = o#restore_envs envs in
             o, `Block
-                ([add_withPos (`Val ([], add_withPos (`Variable (c, Some s, pos)),
-                                     add_pos (`FnAppl (add_pos (Sugartypes.tappl (`Var "send", give_tyargs)),
-                                                       [e; add_pos (`Var c)])),
-                                     `Unknown, None))],
+                ([add_with_pos (`Val ([], add_with_pos (`Variable (make_binder c s pos)),
+                                      add_pos (`FnAppl (add_pos (Sugartypes.tappl (`Var "send", give_tyargs)),
+                                                        [e; add_pos (`Var c)])),
+                                      `Unknown, None))],
                  add_pos p), t
-         | `GiveNothing ((c, Some t, _)) ->
+         | `GiveNothing ({node=c, Some t; _}) ->
             o, `Var c, t
-         | `Select ((c, Some s, _), label, p) ->
+         | `Select ({node=c, Some s; _}, label, p) ->
             let envs = o#backup_envs in
             let o = {< var_env = TyEnv.bind (o#get_var_env ()) (c, TypeUtils.select_type label s) >} in
             let (o, p, t) = desugar_cp o p in
             let o = o#restore_envs envs in
             o, `Block
-                ([add_withPos (`Val ([], add_withPos (`Variable (c, Some (TypeUtils.select_type label s), pos)),
-                                     add_pos (`Select (label, (add_pos (`Var c)))),
-                                     `Unknown, None))],
+                ([add_with_pos (`Val ([], add_with_pos (`Variable (make_binder c (TypeUtils.select_type label s) pos)),
+                                      add_pos (`Select (label, (add_pos (`Var c)))),
+                                      `Unknown, None))],
                  add_pos p), t
-         | `Offer ((c, Some s, _), cases) ->
+         | `Offer ({node=c, Some s; _}, cases) ->
             let desugar_branch (label, p) (o, cases) =
               let envs = o#backup_envs in
               let o = {< var_env = TyEnv.bind (o#get_var_env ()) (c, TypeUtils.choice_at label s) >} in
               let (o, p, t) = desugar_cp o p in
-              let pat : pattern = add_withPos (`Variant (label, Some (add_withPos (`Variable (c, Some (TypeUtils.choice_at label s), pos))))) in
+              let pat : pattern = add_with_pos (`Variant (label, Some (add_with_pos (`Variable (make_binder c (TypeUtils.choice_at label s) pos))))) in
               o#restore_envs envs, ((pat, add_pos p), t) :: cases in
             let (o, cases) = List.fold_right desugar_branch cases (o, []) in
             (match List.split cases with
@@ -88,31 +88,31 @@ object (o : 'self_type)
                     o, `Offer (add_pos (`Var c),
                                cases,
                                Some t), t)
-         | `Link ((c, Some ct, _), (d, Some _dt, _)) ->
+         | `Link ({node=c, Some ct; _}, {node=d, Some _; _}) ->
             o, `FnAppl (add_pos (Sugartypes.tappl (`Var "linkSync", [`Type ct; `Row o#lookup_effects])),
                         [add_pos (`Var c); add_pos (`Var d)]), Types.make_endbang_type
-         | `Comp ((c, Some s, _), left, right) ->
+         | `Comp ({node=c, Some s; _}, left, right) ->
             let envs = o#backup_envs in
             let (o, left, _typ) = desugar_cp {< var_env = TyEnv.bind (o#get_var_env ()) (c, s) >} left in
             let (o, right, t) = desugar_cp {< var_env = TyEnv.bind (o#get_var_env ()) (c, Types.dual_type s) >} right in
             let o = o#restore_envs envs in
             let left_block = add_pos (`Spawn (`Angel, `NoSpawnLocation, add_pos (`Block (
-                                     [ add_withPos (`Val ([], add_withPos (`Variable (c, Some s, pos)),
-                                                          add_pos (`FnAppl (add_pos (`Var "accept"), [add_pos (`Var c)])),
-                                                          `Unknown, None));
-                                       add_withPos (`Val ([], add_withPos (`Variable (c, Some Types.make_endbang_type, pos)),
-                                                          add_pos left, `Unknown, None))],
+                                     [ add_with_pos (`Val ([], add_with_pos (`Variable (make_binder c s pos)),
+                                                           add_pos (`FnAppl (add_pos (`Var "accept"), [add_pos (`Var c)])),
+                                                           `Unknown, None));
+                                       add_with_pos (`Val ([], add_with_pos (`Variable (make_binder c Types.make_endbang_type pos)),
+                                                           add_pos left, `Unknown, None))],
                                        add_pos (`FnAppl (add_pos (`Var "close"), [add_pos (`Var c)])))),
                                               Some (Types.make_singleton_closed_row ("wild", `Present Types.unit_type)))) in
             let o = o#restore_envs envs in
             o, `Block
-                  ([add_withPos (`Val ([], add_withPos (`Variable (c, Some (`Application (Types.access_point, [`Type s])), pos)),
-                                       add_pos (`FnAppl (add_pos (`Var "new"), [])),
-                                       `Unknown, None));
-                    add_withPos (`Val ([], add_withPos `Any, left_block, `Unknown, None));
-                    add_withPos (`Val ([], add_withPos (`Variable (c, Some (Types.dual_type s), pos)),
-                                       add_pos (`FnAppl (add_pos (`Var "request"), [add_pos (`Var c)])),
-                                       `Unknown, None))],
+                  ([add_with_pos (`Val ([], add_with_pos (`Variable (make_binder c (`Application (Types.access_point, [`Type s])) pos)),
+                                        add_pos (`FnAppl (add_pos (`Var "new"), [])),
+                                        `Unknown, None));
+                    add_with_pos (`Val ([], add_with_pos `Any, left_block, `Unknown, None));
+                    add_with_pos (`Val ([], add_with_pos (`Variable (make_binder c (Types.dual_type s) pos)),
+                                        add_pos (`FnAppl (add_pos (`Var "request"), [add_pos (`Var c)])),
+                                        `Unknown, None))],
                    add_pos right), t
          | _ -> assert false in
        desugar_cp o p

--- a/core/desugarDatatypes.ml
+++ b/core/desugarDatatypes.ml
@@ -116,7 +116,7 @@ struct
   let rec datatype var_env (alias_env : Types.tycon_environment) t' =
     let datatype var_env t' = datatype var_env alias_env t' in
     match t' with
-    | (t, pos) ->
+    | {node = t; pos} ->
       let lookup_type t = StringMap.find t var_env.tenv in
       match t with
         | `TypeVar (s, _, _) -> (try `MetaTypeVar (lookup_type s)
@@ -286,14 +286,14 @@ struct
          unbound effect variable.  *)
       try List.map
             (function
-            | (name, `Present (`Function (domain, (fields, rv), codomain), pos)) as op
+            | (name, `Present { node = `Function (domain, (fields, rv), codomain); pos}) as op
                 when not (TypeUtils.is_builtin_effect name) ->
                (* Elaborates `Op : a -> b' to `Op : a {}-> b' *)
                begin match rv, fields with
                | `Closed, [] -> op
                | `Open _, []
                | (`Recursive _), [] -> (* might need an extra check on recursive rows *)
-                  (name, `Present (`Function (domain, ([], `Closed), codomain), pos))
+                  (name, `Present { node = `Function (domain, ([], `Closed), codomain); pos})
                | _,_ -> raise (UnexpectedOperationEffects name)
                end
             | x -> x)

--- a/core/desugarDbs.ml
+++ b/core/desugarDbs.ml
@@ -1,3 +1,5 @@
+open Sugartypes
+
 (*
   Desugaring database stuff
   -------------------------
@@ -35,8 +37,6 @@ move insert into the IR
 
 *)
 
-
-let dp = Sugartypes.dummy_position
 
 class desugar_dbs env =
 object (o : 'self_type)
@@ -151,13 +151,15 @@ object (o : 'self_type)
             | None ->
                 (o,
                  `FnAppl
-                   ((`TAppl ((`Var "InsertRows", dp), [`Type read_type; `Type write_type; `Type needed_type; `Type value_type; `Row eff]), dp),
+                   (with_dummy_pos (`TAppl (with_dummy_pos (`Var "InsertRows"),
+                             [`Type read_type; `Type write_type; `Type needed_type; `Type value_type; `Row eff])),
                     [table; rows]))
             | Some field ->
                 let o, field, _ = o#phrase field in
                   (o,
                    `FnAppl
-                     ((`TAppl ((`Var "InsertReturning", dp), [`Type read_type; `Type write_type; `Type needed_type; `Type value_type; `Row eff]), dp),
+                     (with_dummy_pos (`TAppl (with_dummy_pos (`Var "InsertReturning"),
+                               [`Type read_type; `Type write_type; `Type needed_type; `Type value_type; `Row eff])),
                       [table; rows; field]))
         in
           o, e, Types.unit_type

--- a/core/desugarFormlets.ml
+++ b/core/desugarFormlets.ml
@@ -1,15 +1,15 @@
 open Utility
 open Sugartypes
 
-let rec is_raw (phrase, pos) =
-  match phrase with
+let rec is_raw phrase =
+  match phrase.node with
     | `TextNode _ -> true
     | `Block _    -> true
     | `FormBinding _ -> false
     | `Xml (_, _, _, children) ->
         List.for_all is_raw children
     | _ ->
-        raise (Errors.SugarError (pos, "Invalid element in formlet literal"))
+        raise (Errors.SugarError (phrase.pos, "Invalid element in formlet literal"))
 
 let tt =
   function
@@ -27,11 +27,11 @@ object (o : 'self_type)
     (this roughly corresponds to the dagger transformation)
   *)
   method formlet_patterns : Sugartypes.phrase -> (Sugartypes.pattern list * Sugartypes.phrase list * Types.datatype list) =
-    fun (e, pos) ->
+    fun ph ->
       let dp = Sugartypes.dummy_position in
-      match e with
-        | _ when is_raw (e, pos) ->
-            [with_dummy_pos (`Tuple [])], [(`TupleLit []), dp], [Types.unit_type]
+      match ph.node with
+        | _ when is_raw ph ->
+            [with_dummy_pos (`Tuple [])], [with_dummy_pos (`TupleLit [])], [Types.unit_type]
         | `FormBinding (f, p) ->
             let (_o, _f, ft) = o#phrase f in
             let t = Types.fresh_type_variable (`Any, `Any) in
@@ -39,7 +39,7 @@ object (o : 'self_type)
               Unify.datatypes
                 (ft, Instantiate.alias "Formlet" [`Type t] tycon_env) in
             let var = Utility.gensym ~prefix:"_formlet_" () in
-            let (xb, x) = (make_binder var t dp), ((`Var var), dp) in
+            let (xb, x) = (make_binder var t dp), (with_dummy_pos (`Var var)) in
               [with_dummy_pos (`As (xb, p))], [x], [t]
         | `Xml (_, _, _, [node]) ->
             o#formlet_patterns node
@@ -51,7 +51,7 @@ object (o : 'self_type)
                      match ps', vs', ts' with
                        | [p], [v], [t] -> p::ps, v::vs, t::ts
                        | _ ->
-                           with_dummy_pos (`Tuple ps')::ps, ((`TupleLit vs'), dp)::vs, (Types.make_tuple_type ts')::ts)
+                           with_dummy_pos (`Tuple ps')::ps, (with_dummy_pos (`TupleLit vs'))::vs, (Types.make_tuple_type ts')::ts)
                 ([], [], []) contents
             in
               List.rev ps, List.rev vs, List.rev ts
@@ -66,10 +66,10 @@ object (o : 'self_type)
           | `TextNode s ->
               let e =
                 `FnAppl
-                  ((`TAppl ((`Var "xml", dp), [`Row (o#lookup_effects)]), dp),
-                   [`FnAppl
-                      ((`TAppl ((`Var "stringToXml", dp), [`Row (o#lookup_effects)]), dp),
-                       [`Constant (`String s), dp]), dp])
+                  (with_dummy_pos (`TAppl (with_dummy_pos (`Var "xml"), [`Row (o#lookup_effects)])),
+                   [with_dummy_pos (`FnAppl
+                    (with_dummy_pos (`TAppl (with_dummy_pos (`Var "stringToXml"), [`Row (o#lookup_effects)])),
+                     [with_dummy_pos (`Constant (`String s))]))])
               in
                 (o, e, Types.xml_type)
           | `Block (bs, e) ->
@@ -77,13 +77,14 @@ object (o : 'self_type)
                 o#phrasenode
                   (`Block
                      (bs,
-                      (`FnAppl
-                         ((`TAppl ((`Var "xml", dp), [`Row (o#lookup_effects)]), dp),
-                          [e]), dp)))
+                      with_dummy_pos
+                        (`FnAppl
+                         (with_dummy_pos (`TAppl (with_dummy_pos (`Var "xml"), [`Row (o#lookup_effects)])),
+                          [e]))))
               in
                 (o, e, Types.xml_type)
           | `FormBinding (f, _) ->
-              let (o, (f, _), ft) = o#phrase f in
+              let (o, {node=f; _}, ft) = o#phrase f in
                 (o, f, ft)
           | `Xml ("#", [], None, contents) ->
               (* pure (fun ps -> vs) <*> e1 <*> ... <*> ek *)
@@ -99,7 +100,7 @@ object (o : 'self_type)
                                *)
                                [p]::pss, v::vs, t::ts
                            | _ ->
-                               [with_dummy_pos (`Tuple ps')]::pss, (`TupleLit vs', dp)::vs, (Types.make_tuple_type ts')::ts)
+                               [with_dummy_pos (`Tuple ps')]::pss, with_dummy_pos (`TupleLit vs')::vs, (Types.make_tuple_type ts')::ts)
                     ([], [], []) contents
                 in
                   List.rev pss, List.rev vs, List.rev ts in
@@ -118,29 +119,31 @@ object (o : 'self_type)
                         in
                           (o,
                            (`FnAppl
-                              ((`TAppl ((`Var "xml", dp), [`Row (o#lookup_effects)]), dp), [e, dp])),
+                              (with_dummy_pos (`TAppl (with_dummy_pos (`Var "xml"), [`Row (o#lookup_effects)])), [with_dummy_pos e])),
                            Types.xml_type)
                     | _ ->
                         let (o, es, _) = TransformSugar.list o (fun o -> o#formlet_body) contents in
                         let mb = `Row (o#lookup_effects) in
                         let base : phrase =
-                          (`FnAppl
-                             ((`TAppl ((`Var "pure", dp), [`Type ft; mb]), dp),
-                              [`FunLit (Some (List.rev args), `Unl, (List.rev pss, (`TupleLit vs, dp)), `Unknown), dp]), dp) in
-                        let (e, _), et =
+                          with_dummy_pos
+                            (`FnAppl
+                             (with_dummy_pos (`TAppl (with_dummy_pos (`Var "pure"), [`Type ft; mb])),
+                              [with_dummy_pos (`FunLit (Some (List.rev args), `Unl,
+                                                       (List.rev pss, with_dummy_pos (`TupleLit vs)), `Unknown))])) in
+                        let p, et =
                           List.fold_right
                             (fun arg (base, ft) ->
                                let arg_type = List.hd (TypeUtils.arg_types ft) in
                                let ft = TypeUtils.return_type ft in
                                let base : phrase =
-                                 (`FnAppl
-                                    (((`TAppl (((`Var "@@@"), dp), [`Type arg_type; `Type ft; mb]), dp) : phrase),
-                                     [arg; base]), dp)
-                               in
-                                 base, ft)
+                                 with_dummy_pos (`FnAppl
+                                  (with_dummy_pos (`TAppl
+                                   (with_dummy_pos (`Var "@@@"), [`Type arg_type; `Type ft; mb])),
+                                   [arg; base]))
+                               in base, ft)
                             es (base, ft)
                         in
-                          (o, e, et)
+                          (o, p.node, et)
                 end
           | `Xml(tag, attrs, attrexp, contents) ->
               (* plug (fun x -> (<tag attrs>{x}</tag>)) (<#>contents</#>)^o*)
@@ -148,28 +151,28 @@ object (o : 'self_type)
               let eff = o#lookup_effects in
               let context : phrase =
                 let var = Utility.gensym ~prefix:"_formlet_" () in
-                let (xb, x) = (make_binder var (Types.xml_type) dp), ((`Var var), dp) in
-                  (`FunLit (Some [Types.make_tuple_type [Types.xml_type], eff],
+                let (xb, x) = (make_binder var (Types.xml_type) dp), (with_dummy_pos (`Var var)) in
+                  with_dummy_pos
+                    (`FunLit (Some [Types.make_tuple_type [Types.xml_type], eff],
                             `Unl,
                             ([[with_dummy_pos (`Variable xb)]],
-                             (`Xml (tag, attrs, attrexp, [`Block ([], x), dp]), dp)), `Unknown), dp) in
-              let (o, e, t) = o#formlet_body (`Xml ("#", [], None, contents), dp) in
+                               with_dummy_pos (`Xml (tag, attrs, attrexp, [with_dummy_pos (`Block ([], x))]))), `Unknown)) in
+              let (o, e, t) = o#formlet_body (with_dummy_pos (`Xml ("#", [], None, contents))) in
                 (o,
                  `FnAppl
-                   ((`TAppl ((`Var "plug", dp), [`Type t; `Row eff]), dp),
+                   (with_dummy_pos (`TAppl (with_dummy_pos (`Var "plug"), [`Type t; `Row eff])),
                     [context; e]),
                  t)
           | _ -> assert false
 
   method formlet_body : Sugartypes.phrase -> ('self_type * Sugartypes.phrase * Types.datatype) =
-    fun (e, pos) ->
-      let (o, e, t) = o#formlet_body_node e in (o, (e, pos), t)
+    fun {node; pos} ->
+      let (o, node, t) = o#formlet_body_node node in (o, {node; pos}, t)
 
   method! phrasenode  : phrasenode -> ('self_type * phrasenode * Types.datatype) = function
     | `Formlet (body, yields) ->
         (* pure (fun q^ -> [[e]]* ) <*> q^o *)
         (* let e_in = `Formlet (body, yields) in *)
-        let dp = Sugartypes.dummy_position in
         let empty_eff = Types.make_empty_closed_row () in
         let (ps, _, ts) = o#formlet_patterns body in
         let (o, body, _body_type) = o#formlet_body body in
@@ -186,11 +189,10 @@ object (o : 'self_type)
 
         let e =
           `FnAppl
-            ((`TAppl ((`Var "@@@", dp), [`Type arg_type; `Type yields_type; mb]), dp),
-             [body;
-              `FnAppl
-                ((`TAppl ((`Var "pure", dp), [`Type (`Function (Types.make_tuple_type [arg_type], empty_eff, yields_type)); mb]), dp),
-                 [`FunLit (Some [Types.make_tuple_type [arg_type], empty_eff], `Unl, (pss, yields), `Unknown), dp]), dp])
+            (with_dummy_pos (`TAppl (with_dummy_pos (`Var "@@@"), [`Type arg_type; `Type yields_type; mb])),
+             [body; with_dummy_pos (`FnAppl (with_dummy_pos (`TAppl (with_dummy_pos (`Var "pure"),
+                    [`Type (`Function (Types.make_tuple_type [arg_type], empty_eff, yields_type)); mb])),
+                      [with_dummy_pos (`FunLit (Some [Types.make_tuple_type [arg_type], empty_eff], `Unl, (pss, yields), `Unknown))]))])
         in
           (o, e, Instantiate.alias "Formlet" [`Type yields_type] tycon_env)
     | e -> super#phrasenode e

--- a/core/desugarFormlets.ml
+++ b/core/desugarFormlets.ml
@@ -31,7 +31,7 @@ object (o : 'self_type)
       let dp = Sugartypes.dummy_position in
       match e with
         | _ when is_raw (e, pos) ->
-            [mkWithPos (`Tuple []) dp], [(`TupleLit []), dp], [Types.unit_type]
+            [mkWithDPos (`Tuple [])], [(`TupleLit []), dp], [Types.unit_type]
         | `FormBinding (f, p) ->
             let (_o, _f, ft) = o#phrase f in
             let t = Types.fresh_type_variable (`Any, `Any) in
@@ -40,7 +40,7 @@ object (o : 'self_type)
                 (ft, Instantiate.alias "Formlet" [`Type t] tycon_env) in
             let var = Utility.gensym ~prefix:"_formlet_" () in
             let (xb, x) = (var, Some t, dp), ((`Var var), dp) in
-              [mkWithPos (`As (xb, p)) dp], [x], [t]
+              [mkWithDPos (`As (xb, p))], [x], [t]
         | `Xml (_, _, _, [node]) ->
             o#formlet_patterns node
         | `Xml (_, _, _, contents) ->
@@ -51,7 +51,7 @@ object (o : 'self_type)
                      match ps', vs', ts' with
                        | [p], [v], [t] -> p::ps, v::vs, t::ts
                        | _ ->
-                           mkWithPos (`Tuple ps') dp::ps, ((`TupleLit vs'), dp)::vs, (Types.make_tuple_type ts')::ts)
+                           mkWithDPos (`Tuple ps')::ps, ((`TupleLit vs'), dp)::vs, (Types.make_tuple_type ts')::ts)
                 ([], [], []) contents
             in
               List.rev ps, List.rev vs, List.rev ts
@@ -99,7 +99,7 @@ object (o : 'self_type)
                                *)
                                [p]::pss, v::vs, t::ts
                            | _ ->
-                               [mkWithPos (`Tuple ps') dp]::pss, (`TupleLit vs', dp)::vs, (Types.make_tuple_type ts')::ts)
+                               [mkWithDPos (`Tuple ps')]::pss, (`TupleLit vs', dp)::vs, (Types.make_tuple_type ts')::ts)
                     ([], [], []) contents
                 in
                   List.rev pss, List.rev vs, List.rev ts in
@@ -151,7 +151,7 @@ object (o : 'self_type)
                 let (xb, x) = (var, Some (Types.xml_type), dp), ((`Var var), dp) in
                   (`FunLit (Some [Types.make_tuple_type [Types.xml_type], eff],
                             `Unl,
-                            ([[mkWithPos (`Variable xb) dp]],
+                            ([[mkWithDPos (`Variable xb)]],
                              (`Xml (tag, attrs, attrexp, [`Block ([], x), dp]), dp)), `Unknown), dp) in
               let (o, e, t) = o#formlet_body (`Xml ("#", [], None, contents), dp) in
                 (o,
@@ -179,7 +179,7 @@ object (o : 'self_type)
         let pss =
           match ps with
             | [p] -> [[p]]
-            | _ -> [[mkWithPos (`Tuple ps) dp]] in
+            | _ -> [[mkWithDPos (`Tuple ps)]] in
 
         let arg_type = Types.make_tuple_type ts in
         let mb = `Row (o#lookup_effects) in

--- a/core/desugarFormlets.ml
+++ b/core/desugarFormlets.ml
@@ -31,7 +31,7 @@ object (o : 'self_type)
       let dp = Sugartypes.dummy_position in
       match e with
         | _ when is_raw (e, pos) ->
-            [mkWithDPos (`Tuple [])], [(`TupleLit []), dp], [Types.unit_type]
+            [with_dummy_pos (`Tuple [])], [(`TupleLit []), dp], [Types.unit_type]
         | `FormBinding (f, p) ->
             let (_o, _f, ft) = o#phrase f in
             let t = Types.fresh_type_variable (`Any, `Any) in
@@ -39,8 +39,8 @@ object (o : 'self_type)
               Unify.datatypes
                 (ft, Instantiate.alias "Formlet" [`Type t] tycon_env) in
             let var = Utility.gensym ~prefix:"_formlet_" () in
-            let (xb, x) = (var, Some t, dp), ((`Var var), dp) in
-              [mkWithDPos (`As (xb, p))], [x], [t]
+            let (xb, x) = (make_binder var t dp), ((`Var var), dp) in
+              [with_dummy_pos (`As (xb, p))], [x], [t]
         | `Xml (_, _, _, [node]) ->
             o#formlet_patterns node
         | `Xml (_, _, _, contents) ->
@@ -51,7 +51,7 @@ object (o : 'self_type)
                      match ps', vs', ts' with
                        | [p], [v], [t] -> p::ps, v::vs, t::ts
                        | _ ->
-                           mkWithDPos (`Tuple ps')::ps, ((`TupleLit vs'), dp)::vs, (Types.make_tuple_type ts')::ts)
+                           with_dummy_pos (`Tuple ps')::ps, ((`TupleLit vs'), dp)::vs, (Types.make_tuple_type ts')::ts)
                 ([], [], []) contents
             in
               List.rev ps, List.rev vs, List.rev ts
@@ -99,7 +99,7 @@ object (o : 'self_type)
                                *)
                                [p]::pss, v::vs, t::ts
                            | _ ->
-                               [mkWithDPos (`Tuple ps')]::pss, (`TupleLit vs', dp)::vs, (Types.make_tuple_type ts')::ts)
+                               [with_dummy_pos (`Tuple ps')]::pss, (`TupleLit vs', dp)::vs, (Types.make_tuple_type ts')::ts)
                     ([], [], []) contents
                 in
                   List.rev pss, List.rev vs, List.rev ts in
@@ -148,10 +148,10 @@ object (o : 'self_type)
               let eff = o#lookup_effects in
               let context : phrase =
                 let var = Utility.gensym ~prefix:"_formlet_" () in
-                let (xb, x) = (var, Some (Types.xml_type), dp), ((`Var var), dp) in
+                let (xb, x) = (make_binder var (Types.xml_type) dp), ((`Var var), dp) in
                   (`FunLit (Some [Types.make_tuple_type [Types.xml_type], eff],
                             `Unl,
-                            ([[mkWithDPos (`Variable xb)]],
+                            ([[with_dummy_pos (`Variable xb)]],
                              (`Xml (tag, attrs, attrexp, [`Block ([], x), dp]), dp)), `Unknown), dp) in
               let (o, e, t) = o#formlet_body (`Xml ("#", [], None, contents), dp) in
                 (o,
@@ -179,7 +179,7 @@ object (o : 'self_type)
         let pss =
           match ps with
             | [p] -> [[p]]
-            | _ -> [[mkWithDPos (`Tuple ps)]] in
+            | _ -> [[with_dummy_pos (`Tuple ps)]] in
 
         let arg_type = Types.make_tuple_type ts in
         let mb = `Row (o#lookup_effects) in

--- a/core/desugarFormlets.ml
+++ b/core/desugarFormlets.ml
@@ -31,7 +31,7 @@ object (o : 'self_type)
       let dp = Sugartypes.dummy_position in
       match e with
         | _ when is_raw (e, pos) ->
-            [(`Tuple []), dp], [(`TupleLit []), dp], [Types.unit_type]
+            [mkWithPos (`Tuple []) dp], [(`TupleLit []), dp], [Types.unit_type]
         | `FormBinding (f, p) ->
             let (_o, _f, ft) = o#phrase f in
             let t = Types.fresh_type_variable (`Any, `Any) in
@@ -40,7 +40,7 @@ object (o : 'self_type)
                 (ft, Instantiate.alias "Formlet" [`Type t] tycon_env) in
             let var = Utility.gensym ~prefix:"_formlet_" () in
             let (xb, x) = (var, Some t, dp), ((`Var var), dp) in
-              [(`As (xb, p)), dp], [x], [t]
+              [mkWithPos (`As (xb, p)) dp], [x], [t]
         | `Xml (_, _, _, [node]) ->
             o#formlet_patterns node
         | `Xml (_, _, _, contents) ->
@@ -51,7 +51,7 @@ object (o : 'self_type)
                      match ps', vs', ts' with
                        | [p], [v], [t] -> p::ps, v::vs, t::ts
                        | _ ->
-                           ((`Tuple ps'), dp)::ps, ((`TupleLit vs'), dp)::vs, (Types.make_tuple_type ts')::ts)
+                           mkWithPos (`Tuple ps') dp::ps, ((`TupleLit vs'), dp)::vs, (Types.make_tuple_type ts')::ts)
                 ([], [], []) contents
             in
               List.rev ps, List.rev vs, List.rev ts
@@ -99,7 +99,7 @@ object (o : 'self_type)
                                *)
                                [p]::pss, v::vs, t::ts
                            | _ ->
-                               [`Tuple ps', dp]::pss, (`TupleLit vs', dp)::vs, (Types.make_tuple_type ts')::ts)
+                               [mkWithPos (`Tuple ps') dp]::pss, (`TupleLit vs', dp)::vs, (Types.make_tuple_type ts')::ts)
                     ([], [], []) contents
                 in
                   List.rev pss, List.rev vs, List.rev ts in
@@ -151,7 +151,7 @@ object (o : 'self_type)
                 let (xb, x) = (var, Some (Types.xml_type), dp), ((`Var var), dp) in
                   (`FunLit (Some [Types.make_tuple_type [Types.xml_type], eff],
                             `Unl,
-                            ([[`Variable xb, dp]],
+                            ([[mkWithPos (`Variable xb) dp]],
                              (`Xml (tag, attrs, attrexp, [`Block ([], x), dp]), dp)), `Unknown), dp) in
               let (o, e, t) = o#formlet_body (`Xml ("#", [], None, contents), dp) in
                 (o,
@@ -179,7 +179,7 @@ object (o : 'self_type)
         let pss =
           match ps with
             | [p] -> [[p]]
-            | _ -> [[`Tuple ps, dp]] in
+            | _ -> [[mkWithPos (`Tuple ps) dp]] in
 
         let arg_type = Types.make_tuple_type ts in
         let mb = `Row (o#lookup_effects) in

--- a/core/desugarFors.ml
+++ b/core/desugarFors.ml
@@ -65,14 +65,14 @@ let results :  Types.row ->
             let ((qsb, qs) : Sugartypes.pattern list * Sugartypes.phrase list) =
               List.split
                 (List.map2 (fun x t ->
-                              (`Variable (x, Some t, dp), dp), ((`Var x), dp)) xs ts) in
-            let qb, q = (`Variable (x, Some t, dp), dp), ((`Var x), dp) in
+                              (mkWithPos (`Variable (x, Some t, dp)) dp), ((`Var x), dp)) xs ts) in
+            let qb, q = (mkWithPos (`Variable (x, Some t, dp)) dp, ((`Var x), dp)) in
 
             let inner : Sugartypes.phrase =
               let ps =
                 match qsb with
                   | [p] -> [p]
-                  | _ -> [`Tuple qsb, dp] in
+                  | _ -> [mkWithPos (`Tuple qsb) dp] in
               let a =
                 match ts with
                   | [t] -> Types.make_tuple_type [t]
@@ -126,7 +126,7 @@ object (o : 'self_type)
 
                    let var = Utility.gensym ~prefix:"_for_" () in
                    let (xb, x) = (var, Some t, dp), var in
-                     o, (e::es, ((`As (xb, p)), dp)::ps, x::xs, element_type::ts)
+                     o, (e::es, (mkWithPos (`As (xb, p)) dp)::ps, x::xs, element_type::ts)
                | `Table (p, e) ->
                    let (o, e, t) = o#phrase e in
                    let (o, p) = o#pattern p in
@@ -138,11 +138,11 @@ object (o : 'self_type)
                    let n = `Type (TypeUtils.table_needed_type t) in
                    let eff = `Row (o#lookup_effects) in
 
-                   let e = `FnAppl ((`TAppl ((`Var ("AsList"), dp),
+                   let e = `FnAppl ((`TAppl (((`Var ("AsList")), dp),
                                              [r; w; n; eff]), dp), [e]), dp in
                    let var = Utility.gensym ~prefix:"_for_" () in
                    let (xb, x) = (var, Some t, dp), var in
-                     o, (e::es, ((`As (xb, p)), dp)::ps, x::xs, element_type::ts))
+                     o, (e::es, (mkWithPos (`As (xb, p)) dp)::ps, x::xs, element_type::ts))
           (o, ([], [], [], []))
           qs
       in
@@ -168,7 +168,7 @@ object (o : 'self_type)
         let arg =
           match ps with
             | [p] -> [p]
-            | ps -> [`Tuple ps, dp] in
+            | ps -> [mkWithPos (`Tuple ps) dp] in
 
         let arg_type =
           match ts with

--- a/core/desugarFors.ml
+++ b/core/desugarFors.ml
@@ -65,14 +65,14 @@ let results :  Types.row ->
             let ((qsb, qs) : Sugartypes.pattern list * Sugartypes.phrase list) =
               List.split
                 (List.map2 (fun x t ->
-                              (mkWithDPos (`Variable (x, Some t, dp))), ((`Var x), dp)) xs ts) in
-            let qb, q = (mkWithDPos (`Variable (x, Some t, dp)), ((`Var x), dp)) in
+                              (with_dummy_pos (`Variable (make_binder x t dp))), ((`Var x), dp)) xs ts) in
+            let qb, q = (with_dummy_pos (`Variable (make_binder x t dp)), ((`Var x), dp)) in
 
             let inner : Sugartypes.phrase =
               let ps =
                 match qsb with
                   | [p] -> [p]
-                  | _ -> [mkWithDPos (`Tuple qsb)] in
+                  | _ -> [with_dummy_pos (`Tuple qsb)] in
               let a =
                 match ts with
                   | [t] -> Types.make_tuple_type [t]
@@ -125,8 +125,8 @@ object (o : 'self_type)
                    let element_type = TypeUtils.element_type t in
 
                    let var = Utility.gensym ~prefix:"_for_" () in
-                   let (xb, x) = (var, Some t, dp), var in
-                     o, (e::es, mkWithDPos (`As (xb, p))::ps, x::xs, element_type::ts)
+                   let xb = make_binder var t dp in
+                     o, (e::es, with_dummy_pos (`As (xb, p))::ps, var::xs, element_type::ts)
                | `Table (p, e) ->
                    let (o, e, t) = o#phrase e in
                    let (o, p) = o#pattern p in
@@ -141,8 +141,8 @@ object (o : 'self_type)
                    let e = `FnAppl ((`TAppl (((`Var ("AsList")), dp),
                                              [r; w; n; eff]), dp), [e]), dp in
                    let var = Utility.gensym ~prefix:"_for_" () in
-                   let (xb, x) = (var, Some t, dp), var in
-                     o, (e::es, mkWithDPos (`As (xb, p))::ps, x::xs, element_type::ts))
+                   let xb = make_binder var t dp in
+                     o, (e::es, with_dummy_pos (`As (xb, p))::ps, var::xs, element_type::ts))
           (o, ([], [], [], []))
           qs
       in
@@ -168,7 +168,7 @@ object (o : 'self_type)
         let arg =
           match ps with
             | [p] -> [p]
-            | ps -> [mkWithDPos (`Tuple ps)] in
+            | ps -> [with_dummy_pos (`Tuple ps)] in
 
         let arg_type =
           match ts with

--- a/core/desugarFors.ml
+++ b/core/desugarFors.ml
@@ -65,14 +65,14 @@ let results :  Types.row ->
             let ((qsb, qs) : Sugartypes.pattern list * Sugartypes.phrase list) =
               List.split
                 (List.map2 (fun x t ->
-                              (mkWithPos (`Variable (x, Some t, dp)) dp), ((`Var x), dp)) xs ts) in
-            let qb, q = (mkWithPos (`Variable (x, Some t, dp)) dp, ((`Var x), dp)) in
+                              (mkWithDPos (`Variable (x, Some t, dp))), ((`Var x), dp)) xs ts) in
+            let qb, q = (mkWithDPos (`Variable (x, Some t, dp)), ((`Var x), dp)) in
 
             let inner : Sugartypes.phrase =
               let ps =
                 match qsb with
                   | [p] -> [p]
-                  | _ -> [mkWithPos (`Tuple qsb) dp] in
+                  | _ -> [mkWithDPos (`Tuple qsb)] in
               let a =
                 match ts with
                   | [t] -> Types.make_tuple_type [t]
@@ -126,7 +126,7 @@ object (o : 'self_type)
 
                    let var = Utility.gensym ~prefix:"_for_" () in
                    let (xb, x) = (var, Some t, dp), var in
-                     o, (e::es, (mkWithPos (`As (xb, p)) dp)::ps, x::xs, element_type::ts)
+                     o, (e::es, mkWithDPos (`As (xb, p))::ps, x::xs, element_type::ts)
                | `Table (p, e) ->
                    let (o, e, t) = o#phrase e in
                    let (o, p) = o#pattern p in
@@ -142,7 +142,7 @@ object (o : 'self_type)
                                              [r; w; n; eff]), dp), [e]), dp in
                    let var = Utility.gensym ~prefix:"_for_" () in
                    let (xb, x) = (var, Some t, dp), var in
-                     o, (e::es, (mkWithPos (`As (xb, p)) dp)::ps, x::xs, element_type::ts))
+                     o, (e::es, mkWithDPos (`As (xb, p))::ps, x::xs, element_type::ts))
           (o, ([], [], [], []))
           qs
       in
@@ -168,7 +168,7 @@ object (o : 'self_type)
         let arg =
           match ps with
             | [p] -> [p]
-            | ps -> [mkWithPos (`Tuple ps) dp] in
+            | ps -> [mkWithDPos (`Tuple ps)] in
 
         let arg_type =
           match ts with

--- a/core/desugarFuns.ml
+++ b/core/desugarFuns.ml
@@ -101,7 +101,7 @@ object (o : 'self_type)
         let ft : Types.datatype = `ForAll (Types.box_quantifiers [ab; rhob;  effb],
                                            `Function (Types.make_tuple_type [r], eff, a)) in
 
-        let pss = [[`Variable (x, Some r, dp), dp]] in
+        let pss = [[mkWithPos (`Variable (x, Some r, dp)) dp]] in
         let body = `Projection ((`Var x, dp), name), dp in
         let e : phrasenode =
           `Block

--- a/core/desugarFuns.ml
+++ b/core/desugarFuns.ml
@@ -34,7 +34,7 @@ let dp = Sugartypes.dummy_position
 (* unwrap a curried function definition as
    a collection of nested functions
 *)
-let unwrap_def ((f, ft, fpos), lin, (tyvars, lam), location, t) =
+let unwrap_def ({node=f, ft; pos=fpos}, lin, (tyvars, lam), location, t) =
   let ft = val_of ft in
   let rt = TypeUtils.return_type ft in
   let lam =
@@ -46,8 +46,8 @@ let unwrap_def ((f, ft, fpos), lin, (tyvars, lam), location, t) =
             let rt = TypeUtils.return_type t in
               ([ps],
                (`Block
-                  ([mkWithDPos
-                      (`Fun ((g, Some t, dp),
+                  ([with_dummy_pos
+                      (`Fun (make_binder g t dp,
                              lin,
                              ([], make_lam rt (pss, body)),
                              location,
@@ -57,7 +57,7 @@ let unwrap_def ((f, ft, fpos), lin, (tyvars, lam), location, t) =
     in
     make_lam rt lam
   in
-    ((f, Some ft, fpos), lin, (tyvars, lam), location, t)
+    (make_binder f ft fpos, lin, (tyvars, lam), location, t)
 
 (*
   unwrap a curried function definition
@@ -85,7 +85,7 @@ object (o : 'self_type)
         let f = gensym ~prefix:"_fun_" () in
         let e =
           `Block
-            ([mkWithDPos (`Fun (unwrap_def ( (f, Some ft, dp), lin, ([], lam)
+            ([with_dummy_pos (`Fun (unwrap_def ( make_binder f ft dp, lin, ([], lam)
                                            , location, None)))],
              ((`Var f), dp))
         in
@@ -102,11 +102,11 @@ object (o : 'self_type)
         let ft : Types.datatype = `ForAll (Types.box_quantifiers [ab; rhob;  effb],
                                            `Function (Types.make_tuple_type [r], eff, a)) in
 
-        let pss = [[mkWithDPos (`Variable (x, Some r, dp))]] in
+        let pss = [[with_dummy_pos (`Variable (make_binder x r dp))]] in
         let body = `Projection ((`Var x, dp), name), dp in
         let e : phrasenode =
           `Block
-            ([mkWithDPos (`Fun ( (f, Some ft, dp), `Unl
+            ([with_dummy_pos (`Fun ( make_binder f ft dp, `Unl
                                , ([ab; rhob; effb], (pss, body)), `Unknown, None))],
              ((`Var f), dp))
         in

--- a/core/desugarFuns.ml
+++ b/core/desugarFuns.ml
@@ -86,7 +86,7 @@ object (o : 'self_type)
         let e =
           `Block
             ([with_dummy_pos (`Fun (unwrap_def ( make_binder f ft dp, lin, ([], lam)
-                                           , location, None)))],
+                                               , location, None)))],
              (with_dummy_pos (`Var f)))
         in
           (o, e, ft)

--- a/core/desugarFuns.ml
+++ b/core/desugarFuns.ml
@@ -101,7 +101,7 @@ object (o : 'self_type)
         let ft : Types.datatype = `ForAll (Types.box_quantifiers [ab; rhob;  effb],
                                            `Function (Types.make_tuple_type [r], eff, a)) in
 
-        let pss = [[mkWithPos (`Variable (x, Some r, dp)) dp]] in
+        let pss = [[mkWithDPos (`Variable (x, Some r, dp))]] in
         let body = `Projection ((`Var x, dp), name), dp in
         let e : phrasenode =
           `Block

--- a/core/desugarFuns.ml
+++ b/core/desugarFuns.ml
@@ -46,11 +46,12 @@ let unwrap_def ((f, ft, fpos), lin, (tyvars, lam), location, t) =
             let rt = TypeUtils.return_type t in
               ([ps],
                (`Block
-                  ([`Fun ((g, Some t, dp),
-                          lin,
-                          ([], make_lam rt (pss, body)),
-                          location,
-                          None), dp],
+                  ([mkWithDPos
+                      (`Fun ((g, Some t, dp),
+                             lin,
+                             ([], make_lam rt (pss, body)),
+                             location,
+                             None))],
                    ((`Var g), dp)), dp))
         | _, _ -> assert false
     in
@@ -84,8 +85,8 @@ object (o : 'self_type)
         let f = gensym ~prefix:"_fun_" () in
         let e =
           `Block
-            ([`Fun (unwrap_def ((f, Some ft, dp), lin, ([], lam), location, None)),
-              dp],
+            ([mkWithDPos (`Fun (unwrap_def ( (f, Some ft, dp), lin, ([], lam)
+                                           , location, None)))],
              ((`Var f), dp))
         in
           (o, e, ft)
@@ -105,7 +106,8 @@ object (o : 'self_type)
         let body = `Projection ((`Var x, dp), name), dp in
         let e : phrasenode =
           `Block
-            ([`Fun ((f, Some ft, dp), `Unl, ([ab; rhob; effb], (pss, body)), `Unknown, None), dp],
+            ([mkWithDPos (`Fun ( (f, Some ft, dp), `Unl
+                               , ([ab; rhob; effb], (pss, body)), `Unknown, None))],
              ((`Var f), dp))
         in
           (o, e, ft)

--- a/core/desugarFuns.ml
+++ b/core/desugarFuns.ml
@@ -44,15 +44,15 @@ let unwrap_def ({node=f, ft; pos=fpos}, lin, (tyvars, lam), location, t) =
         | (ps::pss, body) ->
             let g = gensym ~prefix:"_fun_" () in
             let rt = TypeUtils.return_type t in
-              ([ps],
-               (`Block
+              ([ps], with_dummy_pos
+                 (`Block
                   ([with_dummy_pos
                       (`Fun (make_binder g t dp,
                              lin,
                              ([], make_lam rt (pss, body)),
                              location,
                              None))],
-                   ((`Var g), dp)), dp))
+                   (with_dummy_pos (`Var g)))))
         | _, _ -> assert false
     in
     make_lam rt lam
@@ -87,7 +87,7 @@ object (o : 'self_type)
           `Block
             ([with_dummy_pos (`Fun (unwrap_def ( make_binder f ft dp, lin, ([], lam)
                                            , location, None)))],
-             ((`Var f), dp))
+             (with_dummy_pos (`Var f)))
         in
           (o, e, ft)
     | `Section (`Project name) ->
@@ -103,12 +103,12 @@ object (o : 'self_type)
                                            `Function (Types.make_tuple_type [r], eff, a)) in
 
         let pss = [[with_dummy_pos (`Variable (make_binder x r dp))]] in
-        let body = `Projection ((`Var x, dp), name), dp in
+        let body = with_dummy_pos (`Projection (with_dummy_pos (`Var x), name)) in
         let e : phrasenode =
           `Block
             ([with_dummy_pos (`Fun ( make_binder f ft dp, `Unl
-                               , ([ab; rhob; effb], (pss, body)), `Unknown, None))],
-             ((`Var f), dp))
+                                   , ([ab; rhob; effb], (pss, body)), `Unknown, None))],
+             (with_dummy_pos (`Var f)))
         in
           (o, e, ft)
     | e -> super#phrasenode e

--- a/core/desugarHandlers.ml
+++ b/core/desugarHandlers.ml
@@ -163,7 +163,7 @@ let split_handler_cases : (pattern * phrase) list -> (pattern * phrase) list * (
     | [] ->
        let x = "x" in
        let xb = (x, None, dp) in
-       let id = (mkWithPos (`Variable xb) dp, (`Var x, dp)) in
+       let id = (mkWithDPos (`Variable xb), (`Var x, dp)) in
        ([id], List.rev ops)
     | _ ->
        (List.rev ret, List.rev ops)

--- a/core/desugarInners.ml
+++ b/core/desugarInners.ml
@@ -34,10 +34,10 @@ object (o : 'self_type)
     {< extra_env = StringMap.remove f extra_env >}
 
   method! phrasenode = function
-    | `TAppl (((`Var name), pos), tyargs) when StringMap.mem name extra_env ->
+    | `TAppl ({node=`Var name;_} as phn, tyargs) when StringMap.mem name extra_env ->
         let extras = StringMap.find name extra_env in
         let tyargs = add_extras (extras, tyargs) in
-          super#phrasenode (`TAppl (((`Var name), pos), tyargs))
+          super#phrasenode (`TAppl (phn, tyargs))
     | `InfixAppl ((tyargs, `Name name), e1, e2) when StringMap.mem name extra_env ->
         let extras = StringMap.find name extra_env in
         let tyargs = add_extras (extras, tyargs) in

--- a/core/desugarInners.ml
+++ b/core/desugarInners.ml
@@ -76,9 +76,9 @@ object (o : 'self_type)
         (* put the extras in the environment *)
         let o =
           List.fold_left
-            (fun o ((f, _, _), _, ((_tyvars, dt_opt), _), _, _, _) ->
+            (fun o (bndr, _, ((_tyvars, dt_opt), _), _, _, _) ->
                match dt_opt with
-                 | Some (_, extras) -> o#bind f extras
+                 | Some (_, extras) -> o#bind (name_of_binder bndr) extras
                  | None -> assert false
             )
             o defs in
@@ -88,7 +88,7 @@ object (o : 'self_type)
           let rec list o =
             function
               | [] -> (o, [])
-              | ((_, Some outer, _) as f, lin, ((tyvars, Some (_inner, extras)), lam), location, t, pos)::defs ->
+              | ({node=_, Some outer; _} as f, lin, ((tyvars, Some (_inner, extras)), lam), location, t, pos)::defs ->
                   let (o, defs) = list o defs in
                   let extras = List.map (fun _ -> None) extras in
                     (o, (f, lin, ((tyvars, Some (outer, extras)), lam), location, t, pos)::defs)
@@ -109,18 +109,18 @@ object (o : 'self_type)
         (* remove the extras from the environment *)
         let o =
           List.fold_left
-            (fun o ((f, _, _), _, ((_tyvars, _), _), _, _, _) ->
-               o#unbind f)
+            (fun o (bndr, _, ((_tyvars, _), _), _, _, _) ->
+               o#unbind (name_of_binder bndr))
             o defs
         in
           (o, (`Funs defs))
     | b -> super#bindingnode b
 
   method! binder : binder -> ('self_type * binder) = function
-      | (_, None, _) -> assert false
-      | (name, Some t, pos) ->
-          let var_env = Env.String.bind var_env (name, t) in
-            ({< var_env=var_env; extra_env=extra_env >}, (name, Some t, pos))
+      | {node=_, None; _} -> assert false
+      | bndr ->
+         let var_env = Env.String.bind var_env (name_of_binder bndr, type_of_binder_exn bndr) in
+         ({< var_env=var_env; extra_env=extra_env >}, bndr)
 end
 
 let desugar_inners env = ((new desugar_inners env) : desugar_inners :> TransformSugar.transform)

--- a/core/desugarLAttributes.ml
+++ b/core/desugarLAttributes.ml
@@ -74,7 +74,7 @@ let desugar_lonevent : phrasenode -> phrasenode =
     | (name, [rhs]) ->
         let event_name = StringLabels.sub ~pos:4 ~len:(String.length name - 4) name in
           `TupleLit [`Constant (`String event_name), pos;
-                     `FunLit (None, `Unl, ([[mkWithPos (`Variable ("event", None, pos)) pos]], rhs), `Client), pos], pos
+                     `FunLit (None, `Unl, ([[with_pos (`Variable (make_untyped_binder "event"  pos)) pos]], rhs), `Client), pos], pos
     | _ -> assert false
   in function
     | `Xml (tag, attrs, attrexp, children)
@@ -108,7 +108,7 @@ let desugar_lnames (p : phrasenode) : phrasenode * (string * string * position) 
     p', !lnames
 
 let let_in pos name rhs body : phrase =
-  `Block ([mkWithPos (`Val ([], (mkWithPos (`Variable (name,None,pos)) pos), rhs
+  `Block ([with_pos (`Val ([], (with_pos (`Variable (make_untyped_binder name pos)) pos), rhs
                            , `Unknown, None)) pos], body), pos
 
 let bind_lname_vars lnames = function

--- a/core/desugarLAttributes.ml
+++ b/core/desugarLAttributes.ml
@@ -74,7 +74,7 @@ let desugar_lonevent : phrasenode -> phrasenode =
     | (name, [rhs]) ->
         let event_name = StringLabels.sub ~pos:4 ~len:(String.length name - 4) name in
           `TupleLit [`Constant (`String event_name), pos;
-                     `FunLit (None, `Unl, ([[`Variable ("event", None, pos), pos]], rhs), `Client), pos], pos
+                     `FunLit (None, `Unl, ([[mkWithPos (`Variable ("event", None, pos)) pos]], rhs), `Client), pos], pos
     | _ -> assert false
   in function
     | `Xml (tag, attrs, attrexp, children)
@@ -108,7 +108,7 @@ let desugar_lnames (p : phrasenode) : phrasenode * (string * string * position) 
     p', !lnames
 
 let let_in pos name rhs body : phrase =
-  `Block ([`Val ([], (`Variable (name,None,pos), pos), rhs, `Unknown, None), pos], body), pos
+  `Block ([`Val ([], (mkWithPos (`Variable (name,None,pos)) pos), rhs, `Unknown, None), pos], body), pos
 
 let bind_lname_vars lnames = function
   | "l:action" as attr, es ->

--- a/core/desugarLAttributes.ml
+++ b/core/desugarLAttributes.ml
@@ -108,7 +108,8 @@ let desugar_lnames (p : phrasenode) : phrasenode * (string * string * position) 
     p', !lnames
 
 let let_in pos name rhs body : phrase =
-  `Block ([`Val ([], (mkWithPos (`Variable (name,None,pos)) pos), rhs, `Unknown, None), pos], body), pos
+  `Block ([mkWithPos (`Val ([], (mkWithPos (`Variable (name,None,pos)) pos), rhs
+                           , `Unknown, None)) pos], body), pos
 
 let bind_lname_vars lnames = function
   | "l:action" as attr, es ->

--- a/core/desugarModules.ml
+++ b/core/desugarModules.ml
@@ -126,9 +126,10 @@ let rec rename_binders_get_shadow_tbl module_table
         {< term_shadow_table = term_ht; type_shadow_table = type_ht >}
 
     method! binder = function
-      | (n, dt_opt, pos) ->
-          let fqn = make_path_string path n in
-          (self#bind_shadow_term n fqn, (fqn, dt_opt, pos))
+      | bndr ->
+         let n = name_of_binder bndr in
+         let fqn = make_path_string path n in
+         (self#bind_shadow_term n fqn, set_binder_name bndr fqn)
 
     method! bindingnode = function
       | `Fun (bnd, lin, (tvs, fnlit), loc, dt_opt) ->
@@ -185,9 +186,10 @@ and perform_renaming module_table path term_ht type_ht =
         {< type_shadow_table = shadow_binding name fqn type_shadow_table >}
 
     method! binder = function
-      | (n, dt_opt, pos) ->
-          let fqn = make_path_string path n in
-          (self#bind_shadow_term n fqn, (fqn, dt_opt, pos))
+      | bndr ->
+         let n = name_of_binder bndr in
+         let fqn = make_path_string path n in
+         (self#bind_shadow_term n fqn, set_binder_name bndr fqn)
 
     method! patternnode = function
       | `Variant (n, p_opt) ->

--- a/core/desugarModules.ml
+++ b/core/desugarModules.ml
@@ -62,9 +62,9 @@ object(self)
   method get_bindings = List.rev bindings
 
   method! binding = function
-    | (`Module (_, bindings), _) ->
+    | {node = `Module (_, bindings); _} ->
         self#list (fun o -> o#binding) bindings
-    | (`QualifiedImport _, _) -> self
+    | {node = `QualifiedImport _; _} -> self
     | b -> self#add_binding ((flatten_simple ())#binding b)
 
   method! program = function
@@ -93,7 +93,7 @@ let group_bindings : binding list -> binding list list = fun bindings ->
   let rec group_bindings_inner acc ret = function
     | [] when acc = [] -> List.rev ret
     | [] -> List.rev ((List.rev acc) :: ret)
-    | ((`Fun (_, _, _, _, _), _) as bnd) :: bs ->
+    | ({node=`Fun (_, _, _, _, _); _} as bnd) :: bs ->
         group_bindings_inner (bnd :: acc) ret bs
     | b :: bs ->
         (* End block of functions, need to start a new scope *)

--- a/core/desugarPages.ml
+++ b/core/desugarPages.ml
@@ -51,7 +51,7 @@ let rec desugar_page (o, page_type) =
                         [(`FunLit
                             (Some ([Types.make_tuple_type [Types.xml_type], o#lookup_effects]),
                              `Unl,
-                             ([[`Variable (x, Some (Types.xml_type), pos), pos]],
+                             ([[mkWithPos (`Variable (x, Some (Types.xml_type), pos)) pos]],
                               (`Xml (name, attrs, dynattrs,
                                      [`Block ([], (`Var x, pos)), pos]), pos)), `Unknown), pos);
                          desugar_nodes pos children]), pos)

--- a/core/desugarPages.ml
+++ b/core/desugarPages.ml
@@ -51,7 +51,7 @@ let rec desugar_page (o, page_type) =
                         [(`FunLit
                             (Some ([Types.make_tuple_type [Types.xml_type], o#lookup_effects]),
                              `Unl,
-                             ([[mkWithPos (`Variable (x, Some (Types.xml_type), pos)) pos]],
+                             ([[with_pos (`Variable (make_binder x Types.xml_type pos)) pos]],
                               (`Xml (name, attrs, dynattrs,
                                      [`Block ([], (`Var x, pos)), pos]), pos)), `Unknown), pos);
                          desugar_nodes pos children]), pos)

--- a/core/desugarProcesses.ml
+++ b/core/desugarProcesses.ml
@@ -12,8 +12,6 @@ open Sugartypes
 *)
 
 
-let dp = Sugartypes.dummy_position
-
 class desugar_processes env =
 object (o : 'self_type)
   inherit (TransformSugar.transform env) as super
@@ -31,8 +29,8 @@ object (o : 'self_type)
 
         let e : phrasenode =
           `FnAppl
-            ((`TAppl ((`Var "spawnWait", dp), [`Row inner_eff; `Type body_type; `Row outer_eff]), dp),
-             [(`FunLit (Some [(Types.make_tuple_type [], inner_eff)], `Unl, ([[]], body), `Unknown), dp)])
+            (with_dummy_pos (`TAppl (with_dummy_pos (`Var "spawnWait"), [`Row inner_eff; `Type body_type; `Row outer_eff])),
+             [with_dummy_pos (`FunLit (Some [(Types.make_tuple_type [], inner_eff)], `Unl, ([[]], body), `Unknown))])
         in
           (o, e, body_type)
     | `Spawn (k, spawn_loc, body, Some inner_eff) ->
@@ -49,8 +47,10 @@ object (o : 'self_type)
         let spawn_loc_phr =
           match spawn_loc with
             | `ExplicitSpawnLocation phr -> phr
-            | `SpawnClient -> (`FnAppl ((`Var "there", dp), [(`TupleLit [], dp)]), dp)
-            | `NoSpawnLocation -> (`FnAppl ((`Var "here", dp), [(`TupleLit [], dp)]), dp) in
+            | `SpawnClient -> with_dummy_pos (`FnAppl (with_dummy_pos (`Var "there"),
+                                                      [with_dummy_pos (`TupleLit [])]))
+            | `NoSpawnLocation -> with_dummy_pos (`FnAppl (with_dummy_pos (`Var "here"),
+                                                          [with_dummy_pos (`TupleLit [])])) in
 
         let spawn_fun =
           match k with
@@ -64,8 +64,10 @@ object (o : 'self_type)
 
         let e : phrasenode =
           `FnAppl
-            ((`TAppl ((`Var spawn_fun, dp), [`Row inner_eff; `Type body_type; `Row outer_eff]), dp),
-             [(`FunLit (Some [(Types.make_tuple_type [], inner_eff)], `Unl, ([[]], body), `Unknown), dp);
+            (with_dummy_pos (`TAppl (with_dummy_pos (`Var spawn_fun),
+                                     [`Row inner_eff; `Type body_type; `Row outer_eff])),
+             [with_dummy_pos (`FunLit (Some [(Types.make_tuple_type [], inner_eff)],
+                                       `Unl, ([[]], body), `Unknown));
               spawn_loc_phr])
         in
           (o, e, process_type)
@@ -76,12 +78,12 @@ object (o : 'self_type)
             match StringMap.find "hear" fields with
               | (`Present mbt) ->
                   o#phrasenode
-                    (`Switch
-                       ((`FnAppl
-                           ((`TAppl ((`Var "recv", dp), [`Type mbt; `Row other_effects]), dp),
-                            []), dp),
-                        cases,
-                        Some t))
+                    (`Switch (with_dummy_pos
+                     (`FnAppl (with_dummy_pos
+                      (`TAppl (with_dummy_pos (`Var "recv"), [`Type mbt; `Row other_effects])),
+                               [])),
+                              cases,
+                              Some t))
               | _ -> assert false
         end
     | e -> super#phrasenode e

--- a/core/desugarRegexes.ml
+++ b/core/desugarRegexes.ml
@@ -39,11 +39,11 @@ let desugar_regex phrase regex_type pos : regex -> phrasenode =
                                                                           pos), Some regex_type)
       | `Replace (re, (`Splice e)) -> `ConstructorLit("Replace", Some (`TupleLit ([(aux re, pos); expr e]), pos), Some regex_type)
   in fun e ->
-    let e = aux e in
-      `Block (List.map (fun (v, e1, t) ->
-                  (mkWithPos (`Val ([], (mkWithPos (`Variable (v, Some t, pos)) pos), e1, `Unknown, None)) pos))
-                       !exprs,
-              (e, pos))
+     let e = aux e in
+     `Block (List.map (fun (v, e1, t) ->
+                 (with_pos (`Val ([], (with_pos (`Variable (make_binder v t pos)) pos), e1, `Unknown, None)) pos))
+                      !exprs,
+             (e, pos))
 
 let appl pos name tyargs args =
   (`FnAppl ((tappl (`Var name, tyargs), pos), args), pos : phrase)

--- a/core/desugarRegexes.ml
+++ b/core/desugarRegexes.ml
@@ -40,7 +40,7 @@ let desugar_regex phrase regex_type pos : regex -> phrasenode =
       | `Replace (re, (`Splice e)) -> `ConstructorLit("Replace", Some (`TupleLit ([(aux re, pos); expr e]), pos), Some regex_type)
   in fun e ->
     let e = aux e in
-      `Block (List.map (fun (v, e1, t) -> (`Val ([], (`Variable (v, Some t, pos), pos), e1, `Unknown, None), pos)) !exprs,
+      `Block (List.map (fun (v, e1, t) -> (`Val ([], (mkWithPos (`Variable (v, Some t, pos)) pos), e1, `Unknown, None), pos)) !exprs,
               (e, pos))
 
 let appl pos name tyargs args =

--- a/core/desugarRegexes.ml
+++ b/core/desugarRegexes.ml
@@ -40,7 +40,9 @@ let desugar_regex phrase regex_type pos : regex -> phrasenode =
       | `Replace (re, (`Splice e)) -> `ConstructorLit("Replace", Some (`TupleLit ([(aux re, pos); expr e]), pos), Some regex_type)
   in fun e ->
     let e = aux e in
-      `Block (List.map (fun (v, e1, t) -> (`Val ([], (mkWithPos (`Variable (v, Some t, pos)) pos), e1, `Unknown, None), pos)) !exprs,
+      `Block (List.map (fun (v, e1, t) ->
+                  (mkWithPos (`Val ([], (mkWithPos (`Variable (v, Some t, pos)) pos), e1, `Unknown, None)) pos))
+                       !exprs,
               (e, pos))
 
 let appl pos name tyargs args =

--- a/core/desugarRegexes.ml
+++ b/core/desugarRegexes.ml
@@ -15,38 +15,50 @@ let desugar_regex phrase regex_type pos : regex -> phrasenode =
     let v = Utility.gensym ~prefix:"_regex_" () in
       begin
         exprs := (v, e, t) :: !exprs;
-        `Var v, pos
+        with_pos (`Var v) pos
       end in
   let rec aux : regex -> phrasenode =
     function
-      | `Range (f, t)       -> `ConstructorLit ("Range", Some (`TupleLit [`Constant (`Char f), pos;
-                                                                          `Constant (`Char t), pos], pos), Some regex_type)
-      | `Simply s           -> `ConstructorLit ("Simply", Some (`Constant (`String s), pos), Some regex_type)
-      | `Quote s            -> `ConstructorLit ("Quote", Some (aux s, pos), Some regex_type)
+      | `Range (f, t)       -> `ConstructorLit ("Range",
+                                 Some (with_pos (`TupleLit [with_pos (`Constant (`Char f)) pos;
+                                                            with_pos (`Constant (`Char t)) pos]) pos),
+                                 Some regex_type)
+      | `Simply s           -> `ConstructorLit ("Simply", Some (with_pos (`Constant (`String s)) pos), Some regex_type)
+      | `Quote s            -> `ConstructorLit ("Quote", Some (with_pos (aux s) pos), Some regex_type)
       | `Any                -> `ConstructorLit ("Any", None, Some regex_type)
       | `StartAnchor        -> `ConstructorLit ("StartAnchor", None, Some regex_type)
       | `EndAnchor          -> `ConstructorLit ("EndAnchor", None, Some regex_type)
-      | `Seq rs             -> `ConstructorLit ("Seq", Some (`ListLit (List.map (fun s -> aux s, pos) rs,
-                                                                       Some (Types.make_list_type regex_type)),
+      | `Seq rs             -> `ConstructorLit ("Seq", Some (with_pos (`ListLit (List.map (fun s -> with_pos (aux s) pos) rs,
+                                                                         Some (Types.make_list_type regex_type)))
                                                              pos), Some regex_type)
-      | `Alternate (r1, r2) -> `ConstructorLit ("Alternate",  Some (`TupleLit [aux r1, pos; aux r2, pos], pos), Some regex_type)
-      | `Group s            -> `ConstructorLit ("Group", Some (aux s, pos), Some regex_type)
-      | `Repeat (rep, r)    -> `ConstructorLit ("Repeat", Some (`TupleLit [desugar_repeat regex_type rep, pos;
-                                                                        aux r, pos], pos), Some regex_type)
-      | `Splice e           -> `ConstructorLit ("Quote", Some(`ConstructorLit ("Simply", Some (expr e), Some regex_type), pos), Some regex_type)
-      | `Replace (re, (`Literal tmpl)) -> `ConstructorLit("Replace", Some (`TupleLit ([(aux re, pos);
-                                                                                      (`Constant (`String tmpl), pos)]),
-                                                                          pos), Some regex_type)
-      | `Replace (re, (`Splice e)) -> `ConstructorLit("Replace", Some (`TupleLit ([(aux re, pos); expr e]), pos), Some regex_type)
+      | `Alternate (r1, r2) -> `ConstructorLit ("Alternate",
+                                 Some (with_pos (`TupleLit [ with_pos (aux r1) pos
+                                                           ; with_pos (aux r2) pos]) pos),
+                                 Some regex_type)
+      | `Group s            -> `ConstructorLit ("Group", Some (with_pos (aux s) pos), Some regex_type)
+      | `Repeat (rep, r)    -> `ConstructorLit ("Repeat",
+                                 Some (with_pos (`TupleLit [with_pos (desugar_repeat regex_type rep) pos;
+                                                            with_pos (aux r) pos]) pos),
+                                 Some regex_type)
+      | `Splice e           -> `ConstructorLit ("Quote",
+                                 Some (with_pos (`ConstructorLit ("Simply", Some (expr e), Some regex_type)) pos),
+                                 Some regex_type)
+      | `Replace (re, (`Literal tmpl)) -> `ConstructorLit("Replace",
+                                 Some (with_pos (`TupleLit ([with_pos (aux re) pos;
+                                                             with_pos (`Constant (`String tmpl)) pos])) pos),
+                                 Some regex_type)
+      | `Replace (re, (`Splice e)) -> `ConstructorLit("Replace",
+                                 Some (with_pos (`TupleLit ([with_pos (aux re) pos; expr e])) pos),
+                                 Some regex_type)
   in fun e ->
      let e = aux e in
      `Block (List.map (fun (v, e1, t) ->
                  (with_pos (`Val ([], (with_pos (`Variable (make_binder v t pos)) pos), e1, `Unknown, None)) pos))
                       !exprs,
-             (e, pos))
+             with_pos e pos)
 
 let appl pos name tyargs args =
-  (`FnAppl ((tappl (`Var name, tyargs), pos), args), pos : phrase)
+  with_pos (`FnAppl (with_pos (tappl (`Var name, tyargs)) pos, args)) pos
 
 let desugar_regexes env =
 object(self)
@@ -55,14 +67,15 @@ object(self)
 
   val regex_type = Instantiate.alias "Regex" [] env.Types.tycon_env
 
-  method! phrase (p, pos) = match p with
-    | `InfixAppl ((tyargs, `RegexMatch flags), e1, (`Regex((`Replace(_,_) as r)), _)) ->
+  method! phrase ({node=p; pos} as ph) = match p with
+    | `InfixAppl ((tyargs, `RegexMatch flags), e1, {node=`Regex((`Replace(_,_) as r)); _}) ->
         let libfn =
           if List.exists ((=)`RegexNative) flags
           then "sntilde"
           else "stilde" in
-          self#phrase (appl pos libfn tyargs [e1; (desugar_regex self#phrase regex_type pos r, pos)])
-    | `InfixAppl ((tyargs, `RegexMatch flags), e1, (`Regex r, _)) ->
+          self#phrase (appl pos libfn tyargs
+                            [e1; {node=desugar_regex self#phrase regex_type pos r; pos}])
+    | `InfixAppl ((tyargs, `RegexMatch flags), e1, {node=`Regex r; _}) ->
         let nativep = List.exists ((=) `RegexNative) flags
         and listp   = List.exists ((=) `RegexList)   flags in
         let libfn = match listp, nativep with
@@ -70,10 +83,11 @@ object(self)
           | true, false  -> "ltilde"
           | false, false -> "tilde"
           | false, true  -> "ntilde" in
-          self#phrase (appl pos libfn tyargs [e1; (desugar_regex self#phrase regex_type pos r, pos)])
+          self#phrase (appl pos libfn tyargs
+                            [e1; {node=desugar_regex self#phrase regex_type pos r; pos}])
     | `InfixAppl ((_tyargs, `RegexMatch _), _, _) ->
         raise (Errors.SugarError (pos, "Internal error: unexpected rhs of regex operator"))
-    | p -> super#phrase (p, pos)
+    | _ -> super#phrase ph
 end
 
 let has_no_regexes =

--- a/core/desugarSessionExceptions.ml
+++ b/core/desugarSessionExceptions.ml
@@ -18,7 +18,7 @@ module TyEnv = Env.String
 let failure_op_name = Value.session_exception_operation
 
 let dp = Sugartypes.dummy_position
-let mk_var_pat name : pattern = mkWithPos (`Variable (name, Some `Not_typed, dp)) dp
+let mk_var_pat name : pattern = mkWithDPos (`Variable (name, Some `Not_typed, dp))
 let dummy_pat () = mk_var_pat @@ Utility.gensym ~prefix:"dsh" ()
 
 class insert_toplevel_handlers env =
@@ -72,7 +72,7 @@ object (o : 'self_type)
         let cont_pat = dummy_pat () in
 
         let otherwise_pat : Sugartypes.pattern =
-          mkWithPos (`Effect (failure_op_name, [], cont_pat)) dp in
+          mkWithDPos (`Effect (failure_op_name, [], cont_pat)) in
 
         let otherwise_clause = (otherwise_pat, otherwise_phr) in
 

--- a/core/desugarSessionExceptions.ml
+++ b/core/desugarSessionExceptions.ml
@@ -18,7 +18,7 @@ module TyEnv = Env.String
 let failure_op_name = Value.session_exception_operation
 
 let dp = Sugartypes.dummy_position
-let mk_var_pat name : pattern = mkWithDPos (`Variable (name, Some `Not_typed, dp))
+let mk_var_pat name : pattern = with_dummy_pos (`Variable (make_binder name `Not_typed dp))
 let dummy_pat () = mk_var_pat @@ Utility.gensym ~prefix:"dsh" ()
 
 class insert_toplevel_handlers env =
@@ -72,7 +72,7 @@ object (o : 'self_type)
         let cont_pat = dummy_pat () in
 
         let otherwise_pat : Sugartypes.pattern =
-          mkWithDPos (`Effect (failure_op_name, [], cont_pat)) in
+          with_dummy_pos (`Effect (failure_op_name, [], cont_pat)) in
 
         let otherwise_clause = (otherwise_pat, otherwise_phr) in
 
@@ -164,7 +164,7 @@ let wrap_linear_handlers prog =
       method! phrase = function
         | (`TryInOtherwise (l, x, m, n, dtopt), pos) ->
             let fresh_var = Utility.gensym ?prefix:(Some "try_x") () in
-            let fresh_pat = mkWithPos (`Variable (fresh_var, None, pos)) pos in
+            let fresh_pat = with_pos (`Variable (make_untyped_binder fresh_var pos)) pos in
             (`Switch (
               (`TryInOtherwise
                 (super#phrase l,
@@ -173,8 +173,8 @@ let wrap_linear_handlers prog =
                  (`ConstructorLit ("Nothing", None, None), pos), dtopt),
                  pos),
               [
-                (mkWithPos (`Variant ("Just", (Some x))) pos, super#phrase m);
-                (mkWithPos (`Variant ("Nothing", None)) pos, super#phrase n)
+                (with_pos (`Variant ("Just", (Some x))) pos, super#phrase m);
+                (with_pos (`Variant ("Nothing", None)) pos, super#phrase n)
               ], None)), pos
         | p -> super#phrase p
     end

--- a/core/desugarSessionExceptions.ml
+++ b/core/desugarSessionExceptions.ml
@@ -18,7 +18,7 @@ module TyEnv = Env.String
 let failure_op_name = Value.session_exception_operation
 
 let dp = Sugartypes.dummy_position
-let mk_var_pat name : pattern = (`Variable (name, Some `Not_typed, dp), dp)
+let mk_var_pat name : pattern = mkWithPos (`Variable (name, Some `Not_typed, dp)) dp
 let dummy_pat () = mk_var_pat @@ Utility.gensym ~prefix:"dsh" ()
 
 class insert_toplevel_handlers env =
@@ -72,7 +72,7 @@ object (o : 'self_type)
         let cont_pat = dummy_pat () in
 
         let otherwise_pat : Sugartypes.pattern =
-          ((`Effect (failure_op_name, [], cont_pat)), dp) in
+          mkWithPos (`Effect (failure_op_name, [], cont_pat)) dp in
 
         let otherwise_clause = (otherwise_pat, otherwise_phr) in
 
@@ -164,7 +164,7 @@ let wrap_linear_handlers prog =
       method! phrase = function
         | (`TryInOtherwise (l, x, m, n, dtopt), pos) ->
             let fresh_var = Utility.gensym ?prefix:(Some "try_x") () in
-            let fresh_pat = `Variable (fresh_var, None, pos), pos in
+            let fresh_pat = mkWithPos (`Variable (fresh_var, None, pos)) pos in
             (`Switch (
               (`TryInOtherwise
                 (super#phrase l,
@@ -173,8 +173,8 @@ let wrap_linear_handlers prog =
                  (`ConstructorLit ("Nothing", None, None), pos), dtopt),
                  pos),
               [
-                ((`Variant ("Just", (Some x)), pos), super#phrase m);
-                ((`Variant ("Nothing", None), pos), super#phrase n)
+                (mkWithPos (`Variant ("Just", (Some x))) pos, super#phrase m);
+                (mkWithPos (`Variant ("Nothing", None)) pos, super#phrase n)
               ], None)), pos
         | p -> super#phrase p
     end

--- a/core/dumpTypes.ml
+++ b/core/dumpTypes.ml
@@ -37,7 +37,7 @@ let program =
 
       method! phrase =
         function
-          | `Var x, pos when o#bound x ->
+          | {Sugartypes.node=`Var x; Sugartypes.pos} when o#bound x ->
               o#use (x, o#lookup x, pos)
           | e -> super#phrase e
     end in

--- a/core/dumpTypes.ml
+++ b/core/dumpTypes.ml
@@ -30,7 +30,7 @@ let program =
         Env.String.lookup env x
 
       method! binder =
-        fun (x, t, pos) ->
+        fun {Sugartypes.node=x,t; Sugartypes.pos} ->
           o#option
             (fun o t -> o#bind (x, t, pos))
             t

--- a/core/lens/lensQueryHelpers.ml
+++ b/core/lens/lensQueryHelpers.ml
@@ -38,18 +38,18 @@ let translate_op_to_sql = function
     | a -> a
 
 let name_of_var (expr: phrase) =
-    let expr,_ = expr in
-    match expr with
+    match expr.node with
     | `Var n -> n
     | _ -> failwith "Expected var."
 
-let rec lens_phrase_of_phrase : phrase -> lens_phrase = function
-    | `Constant c, _ -> `Constant c
-    | `Var v, _ -> `Var v
-    | `UnaryAppl ((_, op), phrase),_ -> `UnaryAppl (op, lens_phrase_of_phrase phrase)
-    | `InfixAppl ((_, op), phrase1, phrase2),_ -> `InfixAppl (op, lens_phrase_of_phrase phrase1, lens_phrase_of_phrase phrase2)
-    | `TupleLit l, _ -> `TupleLit (List.map lens_phrase_of_phrase l)
-    | `FnAppl (fn, arg), _ ->
+let rec lens_phrase_of_phrase : phrase -> lens_phrase = fun p ->
+    match p.node with
+    | `Constant c -> `Constant c
+    | `Var v -> `Var v
+    | `UnaryAppl ((_, op), phrase) -> `UnaryAppl (op, lens_phrase_of_phrase phrase)
+    | `InfixAppl ((_, op), phrase1, phrase2) -> `InfixAppl (op, lens_phrase_of_phrase phrase1, lens_phrase_of_phrase phrase2)
+    | `TupleLit l -> `TupleLit (List.map lens_phrase_of_phrase l)
+    | `FnAppl (fn, arg) ->
         begin
             match name_of_var fn with
             | "not" -> `UnaryAppl ((`Name "!"), lens_phrase_of_phrase (List.hd arg))

--- a/core/lens/lensTypes.ml
+++ b/core/lens/lensTypes.ml
@@ -3,6 +3,7 @@ open Utility
 open LensUtility
 open LensQueryHelpers
 open LensRecordHelpers
+open Sugartypes
 
 let unpack_field_spec (typ : Types.field_spec) =
     match typ with
@@ -36,13 +37,13 @@ let sort_cols_of_table (tableName : string) (t : Types.typ) =
     let rt = extract_record_type t in
     sort_cols_of_record tableName rt
 
-let var_name (var, _pos : Sugartypes.phrase) =
-    match var with
+let var_name (var : phrase) =
+    match var.node with
     | `Var name -> name
     | _ -> failwith "Expected a `Var type"
 
-let cols_of_phrase (key, _pos : Sugartypes.phrase) : string list =
-    match key with
+let cols_of_phrase (key : phrase) : string list =
+    match key.node with
     | `TupleLit keys -> List.map var_name keys
     | `Var name -> [name]
     | _ -> failwith "Expected a tuple or a variable."

--- a/core/moduleUtils.ml
+++ b/core/moduleUtils.ml
@@ -100,7 +100,7 @@ let get_pat_vars () =
       | `Record (ls, p_opt) ->
           let o1 = self#list (fun o (_, p) -> o#pattern p) ls in
           o1#option (fun o p -> o#pattern p) p_opt
-      | `Variable (n, _, _) -> self#add_binding n
+      | `Variable bndr -> self#add_binding (Sugartypes.name_of_binder bndr)
       | p -> super#patternnode p
   end
 
@@ -169,8 +169,10 @@ let create_module_info_map program =
     (* Getting binding names -- we're interested in function and value names *)
     let rec get_binding_names = function
       | [] -> []
-      | {node = `Val (_, pat, _, _, _); _} :: bs -> (get_pattern_variables pat) @ get_binding_names bs
-      | {node = `Fun ((n, _, _), _, _, _, _); _} :: bs -> n :: (get_binding_names bs)
+      | {node = `Val (_, pat, _, _, _); _} :: bs ->
+         (get_pattern_variables pat) @ get_binding_names bs
+      | {node = `Fun (bndr, _, _, _, _); _} :: bs ->
+         Sugartypes.name_of_binder bndr :: (get_binding_names bs)
       | _ :: bs -> get_binding_names bs in (* Other binding types are uninteresting for this pass *)
 
     (* Getting type names -- we're interested in typename decls *)

--- a/core/moduleUtils.ml
+++ b/core/moduleUtils.ml
@@ -1,5 +1,6 @@
 open Utility
 open Printf
+open Sugartypes
 
 let module_sep = "."
 
@@ -71,7 +72,7 @@ end
 let separate_modules =
   List.fold_left (fun (mods, binds) b ->
     match b with
-      | (`Module _, _) as m -> (m :: mods, binds)
+      | {node = `Module _; _} as m -> (m :: mods, binds)
       | b -> (mods, b :: binds)) ([], [])
 
 type module_info = {
@@ -157,7 +158,7 @@ let create_module_info_map program =
     (* Recursively traverse a list of modules *)
     let rec traverse_modules = function
       | [] -> []
-      | (`Module (submodule_name, mod_bs), _) :: bs ->
+      | {node=`Module (submodule_name, mod_bs);_} :: bs ->
           (* Recursively process *)
           let new_path = if name = "" then [] else parent_path @ [name] in
           create_and_add_module_info new_path submodule_name mod_bs;
@@ -168,14 +169,14 @@ let create_module_info_map program =
     (* Getting binding names -- we're interested in function and value names *)
     let rec get_binding_names = function
       | [] -> []
-      | (`Val (_, pat, _, _, _), _) :: bs -> (get_pattern_variables pat) @ get_binding_names bs
-      | (`Fun ((n, _, _), _, _, _, _), _) :: bs -> n :: (get_binding_names bs)
+      | {node = `Val (_, pat, _, _, _); _} :: bs -> (get_pattern_variables pat) @ get_binding_names bs
+      | {node = `Fun ((n, _, _), _, _, _, _); _} :: bs -> n :: (get_binding_names bs)
       | _ :: bs -> get_binding_names bs in (* Other binding types are uninteresting for this pass *)
 
     (* Getting type names -- we're interested in typename decls *)
     let rec get_type_names = function
       | [] -> []
-      | (`Type (n, _, _), _) :: bs -> n :: (get_type_names bs)
+      | { node = `Type (n, _, _); _} :: bs -> n :: (get_type_names bs)
       | _ :: bs -> get_type_names bs in
 
     (* Gets data constructors for variants *)

--- a/core/moduleUtils.mli
+++ b/core/moduleUtils.mli
@@ -17,7 +17,7 @@ val contains_modules : Sugartypes.program -> bool
 val separate_modules : Sugartypes.binding list -> (Sugartypes.binding list * Sugartypes.binding list)
 val get_ffi_files : Sugartypes.program -> string list
 val shadow_open : string -> string -> module_info stringmap -> term_shadow_table -> type_shadow_table -> (term_shadow_table * type_shadow_table)
-val shadow_binding : string -> string -> (string list) stringmap -> (string list stringmap)
+val shadow_binding : string -> string -> (string list) stringmap -> string list stringmap
 val create_module_info_map : Sugartypes.program -> module_info stringmap
 val lst_to_path : string list -> string
 val make_path_string : string list -> string -> string

--- a/core/parser.mly
+++ b/core/parser.mly
@@ -983,9 +983,9 @@ just_datatype:
 | datatype END                                                 { $1 }
 
 datatype:
-| mu_datatype                                                  { $1, pos() }
-| straight_arrow                                               { $1, pos() }
-| squiggly_arrow                                               { $1, pos() }
+| mu_datatype                                                  { mkWithPos $1 (pos()) }
+| straight_arrow                                               { mkWithPos $1 (pos()) }
+| squiggly_arrow                                               { mkWithPos $1 (pos()) }
 
 arrow_prefix:
 | LBRACE RBRACE                                                { ([], `Closed) }
@@ -1004,17 +1004,17 @@ squig_arrow_prefix:
 
 hear_arrow_prefix:
 | LBRACE COLON datatype COMMA efields RBRACE                   { row_with
-                                                                   ("wild", `Present (`Unit, dummy_position))
+                                                                   ("wild", `Present (mkWithPos `Unit dummy_position))
                                                                    (row_with
                                                                       ("hear", `Present $3)
                                                                       $5) }
-| LBRACE COLON datatype RBRACE                                 { ([("wild", `Present (`Unit, dummy_position));
+| LBRACE COLON datatype RBRACE                                 { ([("wild", `Present (mkWithPos `Unit dummy_position));
                                                                    ("hear", `Present $3)],
                                                                   `Closed) }
-| LBRACE COLON datatype VBAR nonrec_row_var RBRACE             { ([("wild", `Present (`Unit, dummy_position));
+| LBRACE COLON datatype VBAR nonrec_row_var RBRACE             { ([("wild", `Present (mkWithPos `Unit dummy_position));
                                                                    ("hear", `Present $3)],
                                                                   $5) }
-| LBRACE COLON datatype VBAR kinded_nonrec_row_var RBRACE      { ([("wild", `Present (`Unit, dummy_position));
+| LBRACE COLON datatype VBAR kinded_nonrec_row_var RBRACE      { ([("wild", `Present (mkWithPos `Unit dummy_position));
                                                                    ("hear", `Present $3)],
                                                                   $5) }
 
@@ -1032,29 +1032,29 @@ squiggly_arrow:
 | parenthesized_datatypes
   squig_arrow_prefix SQUIGRARROW datatype                      { `Function ($1,
                                                                                row_with
-                                                                                 ("wild", `Present (`Unit, dummy_position))
+                                                                                 ("wild", `Present (mkWithPos `Unit dummy_position))
                                                                                  $2,
                                                                                $4) }
 | parenthesized_datatypes
   squig_arrow_prefix SQUIGLOLLI datatype                       { `Lolli ($1,
                                                                             row_with
-                                                                              ("wild", `Present (`Unit, dummy_position))
+                                                                              ("wild", `Present (mkWithPos `Unit dummy_position))
                                                                             $2,
                                                                             $4) }
 /*| parenthesized_datatypes hear_arrow_prefix
   SQUIGRARROW datatype                                         { `Function ($1, $2, $4) }
 */
 | parenthesized_datatypes SQUIGRARROW datatype                 { `Function ($1,
-                                                                               ([("wild", `Present (`Unit, pos()))],
+                                                                               ([("wild", `Present (mkWithPos `Unit (pos())))],
                                                                                  fresh_rigid_row_variable None),
                                                                                 $3) }
 | parenthesized_datatypes SQUIGLOLLI datatype                  { `Lolli ($1,
-                                                                            ([("wild", `Present (`Unit, dummy_position))],
+                                                                            ([("wild", `Present (mkWithPos `Unit dummy_position))],
                                                                              fresh_rigid_row_variable None),
                                                                             $3) }
 
 mu_datatype:
-| MU VARIABLE DOT mu_datatype                                  { `Mu ($2, ($4, pos())) }
+| MU VARIABLE DOT mu_datatype                                  { `Mu ($2, (mkWithPos $4 (pos()))) }
 | forall_datatype                                              { $1 }
 
 forall_datatype:
@@ -1081,13 +1081,13 @@ session_datatype:
 
 parenthesized_datatypes:
 | LPAREN RPAREN                                                { [] }
-| LPAREN qualified_type_name RPAREN                            { [`QualifiedTypeApplication ($2, []), pos()] }
+| LPAREN qualified_type_name RPAREN                            { [mkWithPos (`QualifiedTypeApplication ($2, [])) (pos())] }
 | LPAREN datatypes RPAREN                                      { $2 }
 
 primary_datatype:
 | parenthesized_datatypes                                      { match $1 with
                                                                    | [] -> `Unit
-                                                                   | [t,_] -> t
+                                                                   | [{ node  ; _ }] -> node
                                                                    | ts  -> `Tuple ts }
 | LPAREN rfields RPAREN                                        { `Record $2 }
 | TABLEHANDLE
@@ -1154,7 +1154,7 @@ fields:
 | field COMMA fields                                           { $1 :: fst $3, snd $3 }
 
 field:
-| field_label                                                  { $1, `Present (`Unit, dummy_position) }
+| field_label                                                  { $1, `Present (mkWithPos `Unit dummy_position) }
 | field_label fieldspec                                        { $1, $2 }
 
 field_label:
@@ -1189,7 +1189,7 @@ vfields:
 | vfield VBAR vfields                                          { $1 :: fst $3, snd $3 }
 
 vfield:
-| CONSTRUCTOR                                                  { $1, `Present (`Unit, dummy_position) }
+| CONSTRUCTOR                                                  { $1, `Present (mkWithPos `Unit dummy_position) }
 | CONSTRUCTOR fieldspec                                        { $1, $2 }
 
 efields:
@@ -1201,7 +1201,7 @@ efields:
 | efield COMMA efields                                         { $1 :: fst $3, snd $3 }
 
 efield:
-| effect_label                                                 { $1, `Present (`Unit, dummy_position) }
+| effect_label                                                 { $1, `Present (mkWithPos `Unit dummy_position) }
 | effect_label fieldspec                                       { $1, $2 }
 
 effect_label:
@@ -1281,7 +1281,8 @@ regex_pattern_sequence:
  */
 pattern:
 | typed_pattern                                             { $1 }
-| typed_pattern COLON primary_datatype                      { (`HasType ($1, datatype ($3, pos())), pos()) }
+| typed_pattern COLON primary_datatype                      { (`HasType ($1, datatype (mkWithPos $3 (pos()))), pos()) }
+/* FIXME: in production above $3 is annotated with position of whole production */
 
 typed_pattern:
 | cons_pattern                                              { $1 }

--- a/core/parser.mly
+++ b/core/parser.mly
@@ -1325,7 +1325,6 @@ regex_pattern_sequence:
 pattern:
 | typed_pattern                                             { $1 }
 | typed_pattern COLON primary_datatype                      { with_pos (`HasType ($1, datatype (with_pos $3 (pos())))) (pos()) }
-/* FIXME: in production above $3 is annotated with position of whole production */
 
 typed_pattern:
 | cons_pattern                                              { $1 }

--- a/core/parser.mly
+++ b/core/parser.mly
@@ -166,7 +166,7 @@ let parseRegexFlags f =
 
 let datatype d = d, None
 
-let cp_unit p = `Unquote ([], (`TupleLit [], p)), p
+let cp_unit p = mkWithPos (`Unquote ([], (`TupleLit [], p))) p
 %}
 
 %token END
@@ -468,17 +468,17 @@ perhaps_name:
 | cp_name                                                      { Some $1 }
 
 cp_expression:
-| LBRACE block_contents RBRACE                                 { `Unquote $2, pos () }
-| cp_name LPAREN perhaps_name RPAREN DOT cp_expression         { `Grab ((fst3 $1, None), $3, $6), pos () }
-| cp_name LPAREN perhaps_name RPAREN                           { `Grab ((fst3 $1, None), $3, cp_unit(pos())), pos () }
-| cp_name LBRACKET exp RBRACKET DOT cp_expression              { `Give ((fst3 $1, None), Some $3, $6), pos () }
-| cp_name LBRACKET exp RBRACKET                                { `Give ((fst3 $1, None), Some $3, cp_unit(pos())), pos () }
-| cp_name LBRACKET RBRACKET                                    { `GiveNothing $1, pos () }
-| OFFER cp_name LBRACE perhaps_cp_cases RBRACE                 { `Offer ($2, $4), pos () }
-| cp_label cp_name DOT cp_expression                           { `Select ($2, $1, $4), pos () }
-| cp_label cp_name                                             { `Select ($2, $1, cp_unit(pos())), pos () }
-| cp_name LRARROW cp_name                                      { `Link ($1, $3), pos () }
-| NU cp_name DOT LPAREN cp_expression VBAR cp_expression RPAREN { `Comp ($2, $5, $7), pos () }
+| LBRACE block_contents RBRACE                                 { mkWithPos (`Unquote $2) (pos()) }
+| cp_name LPAREN perhaps_name RPAREN DOT cp_expression         { mkWithPos (`Grab ((fst3 $1, None), $3, $6)) (pos()) }
+| cp_name LPAREN perhaps_name RPAREN                           { mkWithPos (`Grab ((fst3 $1, None), $3, cp_unit(pos()))) (pos()) }
+| cp_name LBRACKET exp RBRACKET DOT cp_expression              { mkWithPos (`Give ((fst3 $1, None), Some $3, $6)) (pos()) }
+| cp_name LBRACKET exp RBRACKET                                { mkWithPos (`Give ((fst3 $1, None), Some $3, cp_unit(pos()))) (pos()) }
+| cp_name LBRACKET RBRACKET                                    { mkWithPos (`GiveNothing $1) (pos()) }
+| OFFER cp_name LBRACE perhaps_cp_cases RBRACE                 { mkWithPos (`Offer ($2, $4)) (pos()) }
+| cp_label cp_name DOT cp_expression                           { mkWithPos (`Select ($2, $1, $4)) (pos()) }
+| cp_label cp_name                                             { mkWithPos (`Select ($2, $1, cp_unit(pos()))) (pos()) }
+| cp_name LRARROW cp_name                                      { mkWithPos (`Link ($1, $3)) (pos()) }
+| NU cp_name DOT LPAREN cp_expression VBAR cp_expression RPAREN { mkWithPos (`Comp ($2, $5, $7)) (pos()) }
 
 primary_expression:
 | atomic_expression                                            { $1 }

--- a/core/sugarTraversals.ml
+++ b/core/sugarTraversals.ml
@@ -450,7 +450,7 @@ class map =
       | `Comp (c, p, q) -> `Comp (c, o#cp_phrase p, o#cp_phrase q)
 
     method cp_phrase : cp_phrase -> cp_phrase =
-      fun (p, pos) -> (o#cp_phrasenode p, o#position pos)
+      fun {node; pos} -> mkWithPos (o#cp_phrasenode node) (o#position pos)
 
     method patternnode : patternnode -> patternnode =
       function
@@ -1134,7 +1134,7 @@ class fold =
       | `Comp (_c, p, q) -> (o#cp_phrase p)#cp_phrase q
 
     method cp_phrase : cp_phrase -> 'self_node =
-      fun (p, pos) -> (o#cp_phrasenode p)#position pos
+      fun {node; pos} -> (o#cp_phrasenode node)#position pos
 
     method patternnode : patternnode -> 'self_type =
       function
@@ -1888,10 +1888,10 @@ class fold_map =
          o, `Comp (c, p, q)
 
     method cp_phrase : cp_phrase -> ('self_type * cp_phrase) =
-      fun (p, pos) ->
-      let o, p = o#cp_phrasenode p in
-      let o, pos = o#position pos in
-      o, (p, pos)
+      fun {node; pos} ->
+      let o, node = o#cp_phrasenode node in
+      let o, pos  = o#position pos in
+      o, {node; pos}
 
     method patternnode : patternnode -> ('self_type * patternnode) =
       function

--- a/core/sugarTraversals.ml
+++ b/core/sugarTraversals.ml
@@ -625,9 +625,10 @@ class map =
       | `End -> `End
 
     method datatype : datatype -> datatype =
-      fun (_x, _x_i1) ->
-        let _x = o#datatypenode _x in
-        let _x_i1 = o#position _x_i1 in (_x, _x_i1)
+      fun {node; pos} ->
+        let node = o#datatypenode node in
+        let pos  = o#position pos in
+        {node; pos}
 
     method type_arg : type_arg -> type_arg =
       function
@@ -1288,8 +1289,10 @@ class fold =
       | `End -> o
 
     method datatype : datatype -> 'self_type =
-      fun (_x, _x_i1) ->
-        let o = o#datatypenode _x in let o = o#position _x_i1 in o
+      fun {node; pos} ->
+        let o = o#datatypenode node in
+        let o = o#position pos in
+        o
 
     method type_arg : type_arg -> 'self_type =
       function
@@ -2074,9 +2077,9 @@ class fold_map =
       | `End -> (o, `End)
 
     method datatype : datatype -> ('self_type * datatype) =
-      fun (_x, _x_i1) ->
-        let (o, _x) = o#datatypenode _x in
-        let (o, _x_i1) = o#position _x_i1 in (o, (_x, _x_i1))
+      fun {node; pos} ->
+        let (o, node) = o#datatypenode node in
+        let (o, pos) = o#position pos in (o, {node; pos})
 
     method type_arg : type_arg -> ('self_type * type_arg) =
       function

--- a/core/sugarTraversals.ml
+++ b/core/sugarTraversals.ml
@@ -47,10 +47,11 @@ class map =
       fun (_x, _x_i1) -> (_x, o#unary_op _x_i1)
 
     method binder : binder -> binder =
-      fun (_x, _x_i1, _x_i2) ->
-        let _x = o#name _x in
-        let _x_i1 = o#option (fun o -> o#unknown) _x_i1 in
-        let _x_i2 = o#position _x_i2 in (_x, _x_i1, _x_i2)
+      fun bndr ->
+        let name = o#name (name_of_binder bndr) in
+        let ty  = o#option (fun o -> o#unknown) (type_of_binder bndr) in
+        let pos = o#position bndr.pos in
+        {node=(name,ty); pos}
 
     method sentence : sentence -> sentence =
       function
@@ -450,7 +451,7 @@ class map =
       | `Comp (c, p, q) -> `Comp (c, o#cp_phrase p, o#cp_phrase q)
 
     method cp_phrase : cp_phrase -> cp_phrase =
-      fun {node; pos} -> mkWithPos (o#cp_phrasenode node) (o#position pos)
+      fun {node; pos} -> with_pos (o#cp_phrasenode node) (o#position pos)
 
     method patternnode : patternnode -> patternnode =
       function
@@ -771,10 +772,10 @@ class fold =
       fun (_x, _x_i1) -> o#unary_op _x_i1
 
     method binder : binder -> 'self_type =
-      fun (_x, _x_i1, _x_i2) ->
-        let o = o#name _x in
-        let o = o#option (fun o -> o#unknown) _x_i1 in
-        let o = o#position _x_i2 in o
+      fun bndr ->
+        let o = o#name (name_of_binder bndr) in
+        let o = o#option (fun o -> o#unknown) (type_of_binder bndr) in
+        let o = o#position bndr.pos in o
 
     method sentence : sentence -> 'self_type =
       function
@@ -2190,10 +2191,11 @@ class fold_map =
         (o, {node; pos})
 
     method binder : binder -> ('self_type * binder) =
-      fun (_x, _x_i1, _x_i2) ->
-        let (o, _x) = o#name _x in
-        let (o, _x_i1) = o#option (fun o -> o#unknown) _x_i1 in
-        let (o, _x_i2) = o#position _x_i2 in (o, (_x, _x_i1, _x_i2))
+      fun bndr ->
+        let (o, name) = o#name (name_of_binder bndr) in
+        let (o, ty  ) = o#option (fun o -> o#unknown) (type_of_binder bndr) in
+        let (o, pos ) = o#position bndr.pos in
+        (o, {node=name,ty;pos})
 
     method unknown : 'a. 'a -> ('self_type * 'a) = fun x -> (o, x)
   end

--- a/core/sugarTraversals.ml
+++ b/core/sugarTraversals.ml
@@ -492,9 +492,9 @@ class map =
           let _x_i1 = o#datatype' _x_i1 in `HasType ((_x, _x_i1))
 
     method pattern : pattern -> pattern =
-      fun (_x, _x_i1) ->
-        let _x = o#patternnode _x in
-        let _x_i1 = o#position _x_i1 in (_x, _x_i1)
+      fun {node; pos} ->
+        let node = o#patternnode node in
+        let pos = o#position pos in {node; pos}
 
     method operator : operator -> operator =
       function
@@ -1169,8 +1169,10 @@ class fold =
           let o = o#pattern _x in let o = o#datatype' _x_i1 in o
 
     method pattern : pattern -> 'self_type =
-      fun (_x, _x_i1) ->
-        let o = o#patternnode _x in let o = o#position _x_i1 in o
+      fun {node; pos} ->
+        let o = o#patternnode node in
+        let o = o#position pos in
+        o
 
     method operator : operator -> 'self_type =
       function
@@ -1932,9 +1934,10 @@ class fold_map =
           let (o, _x_i1) = o#datatype' _x_i1 in (o, (`HasType ((_x, _x_i1))))
 
     method pattern : pattern -> ('self_type * pattern) =
-      fun (_x, _x_i1) ->
-        let (o, _x) = o#patternnode _x in
-        let (o, _x_i1) = o#position _x_i1 in (o, (_x, _x_i1))
+      fun {node; pos} ->
+        let (o, node) = o#patternnode node in
+        let (o, pos ) = o#position pos in
+        (o, {node; pos})
 
     method operator : operator -> ('self_type * operator) =
       function

--- a/core/sugarTraversals.ml
+++ b/core/sugarTraversals.ml
@@ -724,9 +724,10 @@ class map =
           `AlienBlock (lang, lib, dts)
 
     method binding : binding -> binding =
-      fun (_x, _x_i1) ->
-        let _x = o#bindingnode _x in
-        let _x_i1 = o#position _x_i1 in (_x, _x_i1)
+      fun {node; pos} ->
+        let node = o#bindingnode node in
+        let pos  = o#position    pos  in
+        {node; pos}
 
     method program : program -> program =
       fun (bindings, phrase) ->
@@ -1386,15 +1387,16 @@ class fold =
           o
 
     method binding : binding -> 'self_type =
-      fun (_x, _x_i1) ->
-        let o = o#bindingnode _x in let o = o#position _x_i1 in o
+      fun {node; pos} ->
+        let o = o#bindingnode node in
+        let o = o#position    pos  in
+        o
 
     method program : program -> 'self_type =
       fun (bindings, phrase) ->
         let o = o#list (fun o -> o#binding) bindings in
         let o = o#option (fun o -> o#phrase) phrase in
-          o
-
+        o
 
     method unknown : 'a. 'a -> 'self_type = fun _ -> o
   end
@@ -2182,9 +2184,10 @@ class fold_map =
           (o, (`AlienBlock (lang, lib, dts)))
 
     method binding : binding -> ('self_type * binding) =
-      fun (_x, _x_i1) ->
-        let (o, _x) = o#bindingnode _x in
-        let (o, _x_i1) = o#position _x_i1 in (o, (_x, _x_i1))
+      fun {node; pos} ->
+        let (o, node) = o#bindingnode node in
+        let (o, pos ) = o#position    pos  in
+        (o, {node; pos})
 
     method binder : binder -> ('self_type * binder) =
       fun (_x, _x_i1, _x_i2) ->

--- a/core/sugarTraversals.ml
+++ b/core/sugarTraversals.ml
@@ -435,9 +435,10 @@ class map =
 
 
     method phrase : phrase -> phrase =
-      fun (_x, _x_i1) ->
-        let _x = o#phrasenode _x in
-        let _x_i1 = o#position _x_i1 in (_x, _x_i1)
+      fun {node; pos} ->
+        let node = o#phrasenode node in
+        let pos  = o#position pos in
+        {node; pos}
 
     method cp_phrasenode : cp_phrasenode -> cp_phrasenode =
       function
@@ -1121,8 +1122,8 @@ class fold =
       | `Raise -> o
 
     method phrase : phrase -> 'self_type =
-      fun (_x, _x_i1) ->
-        let o = o#phrasenode _x in let o = o#position _x_i1 in o
+      fun {node; pos} ->
+        let o = o#phrasenode node in let o = o#position pos in o
 
     method cp_phrasenode : cp_phrasenode -> 'self_type =
       function
@@ -1855,9 +1856,10 @@ class fold_map =
       | `Raise -> (o, `Raise)
 
     method phrase : phrase -> ('self_type * phrase) =
-      fun (_x, _x_i1) ->
-        let (o, _x) = o#phrasenode _x in
-        let (o, _x_i1) = o#position _x_i1 in (o, (_x, _x_i1))
+      fun {node; pos} ->
+        let (o, node) = o#phrasenode node in
+        let (o, pos ) = o#position   pos  in
+        (o, {node; pos})
 
     method cp_phrasenode : cp_phrasenode -> ('self_type * cp_phrasenode) =
       function

--- a/core/sugartoir.ml
+++ b/core/sugartoir.ml
@@ -1060,7 +1060,7 @@ struct
     let ev = evalv env in
       match bs' with
         | [] -> ec e
-        | (b,_)::bs ->
+        | { Sugartypes.node = b; _ }::bs ->
             begin
               match b with
                 | `Val (_, {Sugartypes.node=`Variable (x, Some xt, _xpos); _}, body, _, _) ->

--- a/core/sugartoir.ml
+++ b/core/sugartoir.ml
@@ -1063,7 +1063,7 @@ struct
         | (b,_)::bs ->
             begin
               match b with
-                | `Val (_, (`Variable (x, Some xt, _xpos), _), body, _, _) ->
+                | `Val (_, {Sugartypes.node=`Variable (x, Some xt, _xpos); _}, body, _, _) ->
                     let x_info = (xt, x, scope) in
                       I.letvar
                         (x_info,

--- a/core/sugartypes.ml
+++ b/core/sugartypes.ml
@@ -8,8 +8,12 @@ type name = string [@@deriving show]
 type position = SourceCode.pos
 let dummy_position = SourceCode.dummy_pos
 
+type 'a with_pos = { node : 'a
+                   ; pos  : position }
+
 let pp_position : Format.formatter -> position -> unit = fun fmt _ -> Utility.format_omission fmt
 
+(* JSTOLAREK: change here *)
 type binder = name * Types.datatype option * position
     [@@deriving show]
 
@@ -92,6 +96,7 @@ type datatypenode =
   | `Choice          of row
   | `Dual            of datatype
   | `End ]
+(* JSTOLAREK: change here *)
 and datatype = datatypenode * position
 and row = (string * fieldspec) list * row_var
 and row_var =
@@ -130,6 +135,7 @@ type patternnode = [
 | `As       of binder * pattern
 | `HasType  of pattern * datatype'
 ]
+(* JSTOLAREK: change here *)
 and pattern = patternnode * position
     [@@deriving show]
 
@@ -252,6 +258,7 @@ and phrasenode = [
 | `TryInOtherwise   of (phrase * pattern * phrase * phrase * Types.datatype option)
 | `Raise
 ]
+(* JSTOLAREK: change here *)
 and phrase = phrasenode * position
 and bindingnode = [
 (*
@@ -273,6 +280,7 @@ and bindingnode = [
 | `Module  of name * binding list
 | `AlienBlock of (name * name * ((binder * datatype') list))
 ]
+(* JSTOLAREK: change here *)
 and binding = bindingnode * position
 and directive = string * string list
 and sentence = [
@@ -288,6 +296,7 @@ and cp_phrasenode = [
 | `Offer of binder * (string * cp_phrase) list
 | `Link of binder * binder
 | `Comp of binder * cp_phrase * cp_phrase ]
+(* JSTOLAREK: change here *)
 and cp_phrase = cp_phrasenode * position
     [@@deriving show]
 

--- a/core/sugartypes.ml
+++ b/core/sugartypes.ml
@@ -15,12 +15,9 @@ type 'a with_pos = { node : 'a
                    ; pos  : position }
                      [@@deriving show]
 
-let with_pos       node pos = { node; pos }
-let with_dummy_pos node     = { node; pos = dummy_position }
+let with_pos           node pos   = { node; pos }
+let with_dummy_pos     node       = { node; pos = dummy_position }
 let tuple_of_with_pos {node; pos} = (node, pos)
-
-let split_node_positions : 'a with_pos list -> 'a list * position list =
-  fun nodes_with_pos -> ListUtils.split_with tuple_of_with_pos nodes_with_pos
 
 type binder = (name * Types.datatype option) with_pos
     [@@deriving show]
@@ -29,10 +26,8 @@ let name_of_binder     {node=(n,_ );_} = n
 let type_of_binder     {node=(_,ty);_} = ty
 let type_of_binder_exn {node=(_,ty);_} =
   OptionUtils.val_of ty (* raises exception when ty = None *)
-(* JSTOLAREK: merge make_binder and make_untyped_binder into a single function
-   with a default ty=None argument? *)
-let make_binder         n ty pos = { node=(n   , Some ty); pos }
-let make_untyped_binder n    pos = { node=(n   , None   ); pos }
+let make_binder         n ty pos = with_pos (n, Some ty) pos
+let make_untyped_binder n    pos = with_pos (n, None   ) pos
 let set_binder_name {node=(_   ,ty); pos} name = { node=(name, ty     ); pos }
 let set_binder_type {node=(name,_ ); pos} ty   = { node=(name, Some ty); pos }
 let binder_has_type {node=(_,ty)   ; _  }      = Utility.OptionUtils.is_some ty
@@ -278,7 +273,6 @@ and phrasenode = [
 ]
 and phrase = phrasenode with_pos
 and bindingnode = [
-(* JSTOLAREK: clean this up *)
 (*
    TODO: (aesthetic change)
      change `Val constructor to:

--- a/core/sugartypes.ml
+++ b/core/sugartypes.ml
@@ -8,10 +8,14 @@ type name = string [@@deriving show]
 type position = SourceCode.pos
 let dummy_position = SourceCode.dummy_pos
 
+let pp_position : Format.formatter -> position -> unit = fun fmt _ -> Utility.format_omission fmt
+
 type 'a with_pos = { node : 'a
                    ; pos  : position }
+                     [@@deriving show]
 
-let pp_position : Format.formatter -> position -> unit = fun fmt _ -> Utility.format_omission fmt
+let mkWithPos node pos = { node; pos }
+
 
 (* JSTOLAREK: change here *)
 type binder = name * Types.datatype option * position
@@ -97,7 +101,7 @@ type datatypenode =
   | `Dual            of datatype
   | `End ]
 (* JSTOLAREK: change here *)
-and datatype = datatypenode * position
+and datatype = datatypenode with_pos
 and row = (string * fieldspec) list * row_var
 and row_var =
     [ `Closed

--- a/core/sugartypes.ml
+++ b/core/sugartypes.ml
@@ -15,7 +15,8 @@ type 'a with_pos = { node : 'a
                      [@@deriving show]
 
 let mkWithPos node pos = { node; pos }
-
+(* JSTOLAREK: attaching dummy_position is common pattern in desugar*.ml modules
+- worth having a separate mkWithDPos for it *)
 
 (* JSTOLAREK: change here *)
 type binder = name * Types.datatype option * position
@@ -100,7 +101,6 @@ type datatypenode =
   | `Choice          of row
   | `Dual            of datatype
   | `End ]
-(* JSTOLAREK: change here *)
 and datatype = datatypenode with_pos
 and row = (string * fieldspec) list * row_var
 and row_var =
@@ -139,8 +139,7 @@ type patternnode = [
 | `As       of binder * pattern
 | `HasType  of pattern * datatype'
 ]
-(* JSTOLAREK: change here *)
-and pattern = patternnode * position
+and pattern = patternnode with_pos
     [@@deriving show]
 
 type spawn_kind = [ `Angel | `Demon | `Wait ]
@@ -355,7 +354,7 @@ struct
   let union_map f = union_all -<- List.map f
   let option_map f = opt_app f empty
 
-  let rec pattern (p, _ : pattern) : StringSet.t = match p with
+  let rec pattern ({node; _} : pattern) : StringSet.t = match node with
     | `Any
     | `Nil
     | `Constant _

--- a/core/sugartypes.ml
+++ b/core/sugartypes.ml
@@ -14,9 +14,8 @@ type 'a with_pos = { node : 'a
                    ; pos  : position }
                      [@@deriving show]
 
-let mkWithPos node pos = { node; pos }
-(* JSTOLAREK: attaching dummy_position is common pattern in desugar*.ml modules
-- worth having a separate mkWithDPos for it *)
+let mkWithPos  node pos = { node; pos }
+let mkWithDPos node     = { node; pos = dummy_position }
 
 (* JSTOLAREK: change here *)
 type binder = name * Types.datatype option * position

--- a/core/sugartypes.ml
+++ b/core/sugartypes.ml
@@ -298,8 +298,7 @@ and cp_phrasenode = [
 | `Offer of binder * (string * cp_phrase) list
 | `Link of binder * binder
 | `Comp of binder * cp_phrase * cp_phrase ]
-(* JSTOLAREK: change here *)
-and cp_phrase = cp_phrasenode * position
+and cp_phrase = cp_phrasenode with_pos
     [@@deriving show]
 
 type program = binding list * phrase option
@@ -539,7 +538,7 @@ struct
     | `Splice p -> phrase p
     | `Replace (r, `Literal _) -> regex r
     | `Replace (r, `Splice p) -> union (regex r) (phrase p)
-  and cp_phrase (p, _pos) = match p with
+  and cp_phrase {node = p; _ } = match p with
     | `Unquote e -> block e
     | `Grab ((c, _t), Some (x, _u, _), p) -> union (singleton c) (diff (cp_phrase p) (singleton x))
     | `Grab ((c, _t), None, p) -> union (singleton c) (cp_phrase p)

--- a/core/sugartypes.ml
+++ b/core/sugartypes.ml
@@ -282,8 +282,7 @@ and bindingnode = [
 | `Module  of name * binding list
 | `AlienBlock of (name * name * ((binder * datatype') list))
 ]
-(* JSTOLAREK: change here *)
-and binding = bindingnode * position
+and binding = bindingnode with_pos
 and directive = string * string list
 and sentence = [
 | `Definitions of binding list
@@ -488,8 +487,8 @@ struct
     | `QualifiedVar _ -> empty
     | `TryInOtherwise (p1, pat, p2, p3, _ty) -> union (union_map phrase [p1; p2; p3]) (pattern pat)
     | `Raise -> empty
-  and binding (binding, _: binding) : StringSet.t (* vars bound in the pattern *)
-                                    * StringSet.t (* free vars in the rhs *) =
+  and binding ({node = binding; _}: binding) : StringSet.t (* vars bound in the pattern *)
+                                             * StringSet.t (* free vars in the rhs *) =
     match binding with
     | `Val (_, pat, rhs, _, _) -> pattern pat, phrase rhs
     | `Handler ((name,_,_), hnlit, _) -> singleton name, (diff (handlerlit hnlit) (singleton name))

--- a/core/transformSugar.ml
+++ b/core/transformSugar.ml
@@ -355,7 +355,7 @@ class transform (env : Types.typing_environment) =
           let (o, e, t) = o#phrase e in
           let o = o#restore_quantifiers outer_tyvars in
           let t = Types.for_all (qs, t) in
-            (o, tabstr (qs, fst e), t)
+            (o, tabstr (qs, e.node), t)
       | `TAppl (e, tyargs) ->
           let (o, e, t) = o#phrase e in
             check_type_application
@@ -619,8 +619,9 @@ class transform (env : Types.typing_environment) =
       | e -> failwith ("oops: "^show_phrasenode  e)
 
     method phrase : phrase -> ('self_type * phrase * Types.datatype) =
-      fun (e, pos) ->
-        let (o, e, t) = o#phrasenode e in (o, (e, pos), t)
+      fun {node; pos} ->
+        let (o, node, t) = o#phrasenode node in
+        (o, {node;pos}, t)
 
     method patternnode : patternnode -> ('self_type * patternnode) =
       function

--- a/core/transformSugar.ml
+++ b/core/transformSugar.ml
@@ -658,8 +658,8 @@ class transform (env : Types.typing_environment) =
           let (o, p) = o#pattern p in (o, (`HasType (p, t)))
 
     method pattern : pattern -> ('self_type * pattern) =
-      fun (p, pos) ->
-        let (o, p) = o#patternnode p in (o, (p, pos))
+      fun {node; pos} ->
+        let (o, node) = o#patternnode node in (o, {node; pos})
 
     method iterpatt : iterpatt -> ('self_type * iterpatt) =
       function

--- a/core/transformSugar.ml
+++ b/core/transformSugar.ml
@@ -806,8 +806,8 @@ class transform (env : Types.typing_environment) =
       | `QualifiedImport _ -> assert false
 
     method binding : binding -> ('self_type * binding) =
-      fun (b, pos) ->
-        let (o, b) = o#bindingnode b in (o, (b, pos))
+      fun {node; pos} ->
+        let (o, node) = o#bindingnode node in (o, {node; pos})
 
     method binder : binder -> ('self_type * binder) =
       function

--- a/core/transformSugar.ml
+++ b/core/transformSugar.ml
@@ -817,9 +817,9 @@ class transform (env : Types.typing_environment) =
       | _ -> assert false
 
     method cp_phrase : cp_phrase -> ('self_type * cp_phrase * Types.datatype) =
-      fun (p, pos) ->
-      let (o, p, t) = o#cp_phrasenode p in
-      (o, (p, pos), t)
+      fun {node; pos} ->
+      let (o, node, t) = o#cp_phrasenode node in
+      (o, {node; pos}, t)
 
     (* TODO: should really invoke o#datatype on type annotations! *)
     method cp_phrasenode : cp_phrasenode -> ('self_type * cp_phrasenode * Types.datatype) = function

--- a/core/typeSugar.ml
+++ b/core/typeSugar.ml
@@ -3895,7 +3895,7 @@ and type_bindings (globals : context)  bindings =
                    body_usage uinf
   in
     tyenv, List.rev bindings, usage_builder
-and type_cp (context : context) = fun (p, pos) ->
+and type_cp (context : context) = fun {node = p; pos} ->
   let with_channel = fun c s (p, t, u) ->
     if uses_of c u <> 1 then
       if Types.type_can_be_unl s then
@@ -4027,7 +4027,7 @@ and type_cp (context : context) = fun (p, pos) ->
        let right, t', u' = with_channel c (`Dual s) (type_cp (bind_var context (c, `Dual s)) right) in
        unify ~pos:pos ~handle:Gripers.cp_comp_left (Types.make_endbang_type, t);
        `Comp ((c, Some s, binder_pos), left, right), t', merge_usages [u; u'] in
-  (p, pos), t, u
+  {node = p; pos}, t, u
 
 let show_pre_sugar_typing = Basicsettings.TypeSugar.show_pre_sugar_typing
 

--- a/core/utility.ml
+++ b/core/utility.ml
@@ -484,12 +484,28 @@ struct
     | _, [] -> []
     | x :: xs, y :: ys -> (x, y) :: zip xs ys
 
+  let rec zip_with f xs ys =
+    match xs, ys with
+    | [], _
+    | _, [] -> []
+    | x :: xs, y :: ys -> f x y :: zip_with f xs ys
+
+  let split_with : ('a -> 'b * 'c) -> 'a list -> 'b list * 'c list = fun f xs ->
+    List.fold_right (fun a (bs, cs) -> let (b, c) = f a in (b::bs, c::cs))
+                    xs ([], [])
+
   exception Lists_length_mismatch
 
   let rec zip' xs ys =
     match xs, ys with
     | [], [] -> []
     | x :: xs, y :: ys -> (x, y) :: zip' xs ys
+    | _, _ -> raise Lists_length_mismatch
+
+  let rec zip_with' f xs ys =
+    match xs, ys with
+    | [], [] -> []
+    | x :: xs, y :: ys -> f x y :: zip_with' f xs ys
     | _, _ -> raise Lists_length_mismatch
 
   let rec transpose : 'a list list -> 'a list list = function


### PR DESCRIPTION
This is a WIP on #418.

I did some prototype work on defining a separate datatype to attach source position to various syntax tree nodes (patterns, phrases, etc.). So far I have refactored definitions of `datatype` and `pattern`. The first one was easy, but the second one was quite a lot of work. There are several other datatypes that will most likely require a lot more work. I would be happy to hear your opinions at this point, before I commit to further work. Do you think this should be done differently? Do you think this shouldn't be done at all?

One thing that I'm planning to change is defining a separate function for attaching a dummy position to a node. This is a common pattern in various desugar* modules and it is worth having a function for it.

A separate thought is that if desugaring discards so many source positions and replaces them with dummies then we perhaps we could rethink our data representations. But I'd say this is not in scope of this ticket/PR.

This PR is based on #417 work.