### PR TITLE
Grammar cleanup

### DIFF
--- a/core/dune
+++ b/core/dune
@@ -3,7 +3,7 @@
 
 (menhir
   (modules parser jsonparse xmlParser)
-  (flags "--table" "--explain" "--dump") ;; slower parser, but compilation *much* faster
+  (flags "--table") ;; slower parser, but compilation *much* faster
 )
 
 (library

--- a/core/dune
+++ b/core/dune
@@ -3,7 +3,7 @@
 
 (menhir
   (modules parser jsonparse xmlParser)
-  (flags "--table") ;; slower parser, but compilation *much* faster
+  (flags "--table" "--explain" "--dump") ;; slower parser, but compilation *much* faster
 )
 
 (library

--- a/core/parser.mly
+++ b/core/parser.mly
@@ -560,8 +560,7 @@ parenthesized_thing:
 | LPAREN binop RPAREN                                          { with_pos $loc (`Section $2)              }
 | LPAREN DOT record_label RPAREN                               { with_pos $loc (`Section (`Project $3))   }
 | LPAREN RPAREN                                                { with_pos $loc (`RecordLit ([], None))    }
-| LPAREN labeled_exps VBAR exp RPAREN                          { with_pos $loc (`RecordLit ($2, Some $4)) }
-| LPAREN labeled_exps RPAREN                                   { with_pos $loc (`RecordLit ($2, None))    }
+| LPAREN labeled_exps preceded(VBAR, exp)? RPAREN              { with_pos $loc (`RecordLit ($2, $3))      }
 | LPAREN exps RPAREN                                           { with_pos $loc (`TupleLit ($2))           }
 | LPAREN exp WITH labeled_exps RPAREN                          { with_pos $loc (`With ($2, $4))           }
 
@@ -571,36 +570,16 @@ binop:
 | op                                                           { `Name ($1.node) }
 
 op:
-| INFIX0                                                       { with_pos $loc $1 }
-| INFIXL0                                                      { with_pos $loc $1 }
-| INFIXR0                                                      { with_pos $loc $1 }
-| INFIX1                                                       { with_pos $loc $1 }
-| INFIXL1                                                      { with_pos $loc $1 }
-| INFIXR1                                                      { with_pos $loc $1 }
-| INFIX2                                                       { with_pos $loc $1 }
-| INFIXL2                                                      { with_pos $loc $1 }
-| INFIXR2                                                      { with_pos $loc $1 }
-| INFIX3                                                       { with_pos $loc $1 }
-| INFIXL3                                                      { with_pos $loc $1 }
-| INFIXR3                                                      { with_pos $loc $1 }
-| INFIX4                                                       { with_pos $loc $1 }
-| INFIXL4                                                      { with_pos $loc $1 }
-| INFIXR4                                                      { with_pos $loc $1 }
-| INFIX5                                                       { with_pos $loc $1 }
-| INFIXL5                                                      { with_pos $loc $1 }
-| INFIXR5                                                      { with_pos $loc $1 }
-| INFIX6                                                       { with_pos $loc $1 }
-| INFIXL6                                                      { with_pos $loc $1 }
-| INFIXR6                                                      { with_pos $loc $1 }
-| INFIX7                                                       { with_pos $loc $1 }
-| INFIXL7                                                      { with_pos $loc $1 }
-| INFIXR7                                                      { with_pos $loc $1 }
-| INFIX8                                                       { with_pos $loc $1 }
-| INFIXL8                                                      { with_pos $loc $1 }
-| INFIXR8                                                      { with_pos $loc $1 }
-| INFIX9                                                       { with_pos $loc $1 }
-| INFIXL9                                                      { with_pos $loc $1 }
-| INFIXR9                                                      { with_pos $loc $1 }
+| INFIX0 | INFIXL0 | INFIXR0
+| INFIX1 | INFIXL1 | INFIXR1
+| INFIX2 | INFIXL2 | INFIXR2
+| INFIX3 | INFIXL3 | INFIXR3
+| INFIX4 | INFIXL4 | INFIXR4
+| INFIX5 | INFIXL5 | INFIXR5
+| INFIX6 | INFIXL6 | INFIXR6
+| INFIX7 | INFIXL7 | INFIXR7
+| INFIX8 | INFIXL8 | INFIXR8
+| INFIX9 | INFIXL9 | INFIXR9                                   { with_pos $loc $1 }
 
 spawn_expression:
 | SPAWNAT LPAREN exp COMMA block RPAREN                        { with_pos $loc
@@ -655,7 +634,7 @@ unary_expression:
 
 infixr_9:
 | unary_expression                                             { $1 }
-| unary_expression INFIX9 unary_expression                     { with_pos $loc (`InfixAppl (([], `Name $2), $1, $3)) }
+| unary_expression INFIX9 unary_expression
 | unary_expression INFIXR9 infixr_9                            { with_pos $loc (`InfixAppl (([], `Name $2), $1, $3)) }
 
 infixl_9:
@@ -664,7 +643,7 @@ infixl_9:
 
 infixr_8:
 | infixl_9                                                     { $1 }
-| infixl_9 INFIX8  infixl_9                                    { with_pos $loc (`InfixAppl (([], `Name $2), $1, $3)) }
+| infixl_9 INFIX8  infixl_9
 | infixl_9 INFIXR8 infixr_8                                    { with_pos $loc (`InfixAppl (([], `Name $2), $1, $3)) }
 | infixl_9 COLONCOLON infixr_8                                 { with_pos $loc (`InfixAppl (([], `Cons   ), $1, $3)) }
 
@@ -674,7 +653,7 @@ infixl_8:
 
 infixr_7:
 | infixl_8                                                     { $1 }
-| infixl_8 INFIX7  infixl_8                                    { with_pos $loc (`InfixAppl (([], `Name $2), $1, $3)) }
+| infixl_8 INFIX7  infixl_8
 | infixl_8 INFIXR7 infixr_7                                    { with_pos $loc (`InfixAppl (([], `Name $2), $1, $3)) }
 
 infixl_7:
@@ -683,7 +662,7 @@ infixl_7:
 
 infixr_6:
 | infixl_7                                                     { $1 }
-| infixl_7 INFIX6  infixl_7                                    { with_pos $loc (`InfixAppl (([], `Name $2), $1, $3)) }
+| infixl_7 INFIX6  infixl_7
 | infixl_7 INFIXR6 infixr_6                                    { with_pos $loc (`InfixAppl (([], `Name $2), $1, $3)) }
 
 infixl_6:
@@ -696,7 +675,7 @@ infixl_6:
 
 infixr_5:
 | infixl_6                                                     { $1 }
-| infixl_6 INFIX5  infixl_6                                    { with_pos $loc (`InfixAppl (([], `Name $2), $1, $3)) }
+| infixl_6 INFIX5  infixl_6
 | infixl_6 INFIXR5 infixr_5                                    { with_pos $loc (`InfixAppl (([], `Name $2), $1, $3)) }
 
 infixl_5:
@@ -705,7 +684,7 @@ infixl_5:
 
 infixr_4:
 | infixl_5                                                     { $1 }
-| infixl_5 INFIX4    infixl_5                                  { with_pos $loc (`InfixAppl (([], `Name $2), $1, $3)) }
+| infixl_5 INFIX4    infixl_5
 | infixl_5 INFIXR4   infixr_4                                  { with_pos $loc (`InfixAppl (([], `Name $2), $1, $3)) }
 | infixr_5 EQUALSTILDE regex                                   { let r, flags = $3 in
                                                                  with_pos $loc (`InfixAppl (([], `RegexMatch flags), $1, r)) }
@@ -716,7 +695,7 @@ infixl_4:
 
 infixr_3:
 | infixl_4                                                     { $1 }
-| infixl_4 INFIX3  infixl_4                                    { with_pos $loc (`InfixAppl (([], `Name $2), $1, $3)) }
+| infixl_4 INFIX3  infixl_4
 | infixl_4 INFIXR3 infixr_3                                    { with_pos $loc (`InfixAppl (([], `Name $2), $1, $3)) }
 
 infixl_3:
@@ -725,7 +704,7 @@ infixl_3:
 
 infixr_2:
 | infixl_3                                                     { $1 }
-| infixl_3 INFIX2  infixl_3                                    { with_pos $loc (`InfixAppl (([], `Name $2), $1, $3)) }
+| infixl_3 INFIX2  infixl_3
 | infixl_3 INFIXR2 infixr_2                                    { with_pos $loc (`InfixAppl (([], `Name $2), $1, $3)) }
 
 infixl_2:
@@ -734,7 +713,7 @@ infixl_2:
 
 infixr_1:
 | infixl_2                                                     { $1 }
-| infixl_2 INFIX1  infixl_2                                    { with_pos $loc (`InfixAppl (([], `Name $2), $1, $3)) }
+| infixl_2 INFIX1  infixl_2
 | infixl_2 INFIXR1 infixr_1                                    { with_pos $loc (`InfixAppl (([], `Name $2), $1, $3)) }
 
 infixl_1:
@@ -743,7 +722,7 @@ infixl_1:
 
 infixr_0:
 | infixl_1                                                     { $1 }
-| infixl_1 INFIX0    infixl_1                                  { with_pos $loc (`InfixAppl (([], `Name $2), $1, $3)) }
+| infixl_1 INFIX0    infixl_1
 | infixl_1 INFIXR0   infixr_0                                  { with_pos $loc (`InfixAppl (([], `Name $2), $1, $3)) }
 
 infixl_0:
@@ -780,18 +759,18 @@ attrs:
 | attr_list block                                              { $1, Some (with_pos $loc($2) (`Block $2)) }
 
 attr_list:
-| attr                                                         { [$1] }
-| attr_list attr                                               { $2 :: $1 }
+| rev(nonempty_list(attr))                                     { $1 }
 
 attr:
 | xmlid EQ LQUOTE attr_val RQUOTE                              { ($1, $4) }
 | xmlid EQ LQUOTE RQUOTE                                       { ($1, [with_pos $loc($3) (`Constant (`String ""))]) }
 
 attr_val:
-| block                                                        { [with_pos $loc (`Block $1)] }
-| STRING                                                       { [with_pos $loc (`Constant (`String $1))] }
-| block attr_val                                               {  with_pos $loc($1) (`Block $1) :: $2 }
-| STRING attr_val                                              {  with_pos $loc($1) (`Constant (`String $1)) :: $2}
+| nonempty_list(attr_val_entry)                                { $1 }
+
+attr_val_entry:
+| block                                                        { with_pos $loc (`Block $1) }
+| STRING                                                       { with_pos $loc (`Constant (`String $1)) }
 
 xml_tree:
 | LXML SLASHRXML                                               { with_pos $loc (`Xml ($1, [], None, [])) }
@@ -802,14 +781,11 @@ xml_tree:
 | LXML attrs RXML xml_contents_list ENDTAG                     { ensure_match $loc $1 $5 (with_pos $loc (`Xml ($1, fst $2, snd $2, $4))) }
 
 xml_contents_list:
-| xml_contents                                                 { [$1] }
-| xml_contents xml_contents_list                               { $1 :: $2 }
+| nonempty_list( xml_contents )                                { $1 }
 
 xml_contents:
 | block                                                        { with_pos $loc (`Block $1) }
-| formlet_binding                                              { $1 }
-| formlet_placement                                            { $1 }
-| page_placement                                               { $1 }
+| formlet_binding | formlet_placement | page_placement
 | xml_tree                                                     { $1 }
 | CDATA                                                        { with_pos $loc (`TextNode (Utility.xml_unescape $1)) }
 
@@ -836,16 +812,14 @@ conditional_expression:
 | session_expression                                           { $1 }
 | IF LPAREN exp RPAREN exp ELSE exp                            { with_pos $loc (`Conditional ($3, $5, $7)) }
 
-cases:
-| case                                                         { [$1] }
-| case cases                                                   { $1 :: $2 }
-
 case:
 | CASE pattern RARROW block_contents                           { $2, with_pos $loc($4) (`Block ($4)) }
 
+cases:
+| nonempty_list(case)                                          { $1 }
+
 perhaps_cases:
-| /* empty */                                                  { [] }
-| cases                                                        { $1 }
+| list(case)                                                   { $1 }
 
 case_expression:
 | conditional_expression                                       { $1 }
@@ -860,8 +834,8 @@ case_expression:
 | TRY exp AS pattern IN exp OTHERWISE exp                      { with_pos $loc (`TryInOtherwise ($2, $4, $6, $8, None)) }
 
 handle_params:
-| logical_expression RARROW pattern { [($1, $3)] }
-| handle_params COMMA logical_expression RARROW pattern  { ($3,$5) :: $1 }
+| rev(separated_nonempty_list(COMMA,
+      separated_pair(logical_expression, RARROW, pattern)))    { $1 }
 
 iteration_expression:
 | case_expression                                              { $1 }
@@ -871,12 +845,7 @@ iteration_expression:
       exp                                                      { with_pos $loc (`Iteration ($3, $7, $5, $6)) }
 
 perhaps_generators:
-| /* empty */                                                  { [] }
-| generators                                                   { $1 }
-
-generators:
-| generator                                                    { [$1] }
-| generator COMMA generators                                   { $1 :: $3 }
+| separated_list(COMMA, generator)                             { $1 }
 
 generator:
 | list_generator                                               { `List $1 }
@@ -918,12 +887,11 @@ perhaps_table_constraints:
 | /* empty */                                                  { [] }
 
 table_constraints:
-| record_label field_constraints                               { [($1, $2)] }
-| record_label field_constraints COMMA table_constraints       { ($1, $2) :: $4 }
+| separated_nonempty_list(COMMA,
+    pair(record_label, field_constraints))                     { $1 }
 
 field_constraints:
-| field_constraint                                             { [$1] }
-| field_constraint field_constraints                           { $1 :: $2 }
+| nonempty_list(field_constraint)                              { $1 }
 
 field_constraint:
 | READONLY                                                     { `Readonly }
@@ -939,7 +907,6 @@ perhaps_db_driver:
 
 database_expression:
 | table_expression                                             { $1 }
-| INSERT exp VALUES LPAREN RPAREN exp                          { with_pos $loc (`DBInsert ($2, [], $6, None)) }
 | INSERT exp VALUES LPAREN record_labels RPAREN exp            { with_pos $loc (`DBInsert ($2, $5, $7, None)) }
 | INSERT exp VALUES
   LBRACKET LPAREN labeled_exps RPAREN RBRACKET                 { with_pos $loc (`DBInsert ($2,
@@ -948,9 +915,6 @@ database_expression:
                                                                                    (`ListLit ([with_pos $loc($6)
                                                                                                         (`RecordLit ($6, None))], None)),
                                                                           None)) }
-| INSERT exp VALUES LPAREN RPAREN db_expression
-  RETURNING VARIABLE                                           { with_pos $loc (`DBInsert ($2, [], $6,
-                                                                          Some (with_pos $loc($8) (`Constant (`String $8))))) }
 | INSERT exp VALUES LPAREN record_labels RPAREN db_expression
   RETURNING VARIABLE                                           { with_pos $loc (`DBInsert ($2, $5, $7,
                                                                           Some (with_pos $loc($9) (`Constant (`String $9))))) }
@@ -997,7 +961,7 @@ lens_expression:
 
 
 record_labels:
-| separated_nonempty_list(COMMA, record_label)                 { $1 }
+| separated_list(COMMA, record_label)                          { $1 }
 
 links_open:
 | OPEN separated_nonempty_list(DOT, CONSTRUCTOR)               { with_pos $loc (`QualifiedImport $2) }
@@ -1183,8 +1147,10 @@ row:
 
 fields:
 | field                                                        { [$1], `Closed }
-| list(field) VBAR row_var                                     {  $1 , $3 }
-| list(field) VBAR kinded_row_var                              {  $1 , $3 }
+| field VBAR row_var                                           { [$1], $3 }
+| field VBAR kinded_row_var                                    { [$1], $3 }
+| VBAR row_var                                                 {  [] , $2 }
+| VBAR kinded_row_var                                          {  [] , $2 }
 | field COMMA fields                                           { $1 :: fst $3, snd $3 }
 
 field:
@@ -1199,8 +1165,10 @@ field_label:
 
 rfields:
 | rfield                                                       { [$1], `Closed }
-| list(rfield) VBAR row_var                                    {  $1, $3 }
-| list(rfield) VBAR kinded_row_var                             {  $1, $3 }
+| rfield VBAR row_var                                          { [$1], $3 }
+| rfield VBAR kinded_row_var                                   { [$1], $3 }
+| VBAR row_var                                                 { []  , $2 }
+| VBAR kinded_row_var                                          { []  , $2 }
 | rfield COMMA rfields                                         { $1 :: fst $3, snd $3 }
 
 rfield:

--- a/core/parser.mly
+++ b/core/parser.mly
@@ -384,8 +384,7 @@ module_name:
 | CONSTRUCTOR                                                  { $1 }
 
 fun_declarations:
-| fun_declarations fun_declaration                             { $1 @ [$2] }
-| fun_declaration                                              { [$1] }
+| fun_declaration+                                             { $1 }
 
 fun_declaration:
 | tlfunbinding                                                 { let (bndr,lin,p,l) = $1
@@ -452,11 +451,11 @@ varlist:
 | typearg COMMA varlist                                        { $1 :: $3 }
 
 fixity:
-| INFIX                                                        { `None, $1 }
-| INFIXL                                                       { `Left, $1 }
+| INFIX                                                        { `None , $1 }
+| INFIXL                                                       { `Left , $1 }
 | INFIXR                                                       { `Right, $1 }
-| PREFIX                                                       { `Pre, $1 }
-| POSTFIX                                                      { `Post, $1 }
+| PREFIX                                                       { `Pre  , $1 }
+| POSTFIX                                                      { `Post , $1 }
 
 perhaps_location:
 | SERVER                                                       { `Server }
@@ -538,12 +537,12 @@ primary_expression:
                                                                   let hnlit = ($1, $2, body, args) in
                                                                   with_pos $loc (`HandlerLit hnlit) }
 handler_parameterization:
-| handler_body                         { ($1, None) }
-| arg_lists handler_body               { ($2, Some $1) }
+| handler_body                                                 { ($1, None) }
+| arg_lists handler_body                                       { ($2, Some $1) }
 
 handler_depth:
-| HANDLER                    { `Deep }
-| SHALLOWHANDLER             { `Shallow }
+| HANDLER                                                      { `Deep }
+| SHALLOWHANDLER                                               { `Shallow }
 
 handler_body:
 | LBRACE cases RBRACE                                          { $2 }

--- a/core/parser.mly
+++ b/core/parser.mly
@@ -1061,9 +1061,7 @@ just_datatype:
 | datatype END                                                 { $1 }
 
 datatype:
-| mu_datatype                                                  { with_pos $loc $1 }
-| straight_arrow                                               { with_pos $loc $1 }
-| squiggly_arrow                                               { with_pos $loc $1 }
+| mu_datatype | straight_arrow | squiggly_arrow                { with_pos $loc $1 }
 
 arrow_prefix:
 | LBRACE RBRACE                                                { ([], `Closed) }
@@ -1144,8 +1142,6 @@ primary_datatype:
 | LPAREN rfields RPAREN                                        { `Record $2 }
 | TABLEHANDLE
      LPAREN datatype COMMA datatype COMMA datatype RPAREN      { `Table ($3, $5, $7) }
-/* | TABLEHANDLE datatype perhaps_table_constraints            { `Table ($2, $3) } */
-
 | LBRACKETBAR vrow BARRBRACKET                                 { `Variant $2 }
 | LBRACKET datatype RBRACKET                                   { `List $2 }
 | type_var                                                     { $1 }
@@ -1172,8 +1168,7 @@ kinded_type_var:
 | type_var subkind                                             { attach_subkind ($1, $2) }
 
 type_arg_list:
-| type_arg                                                     { [$1] }
-| type_arg COMMA type_arg_list                                 { $1 :: $3 }
+| separated_nonempty_list(COMMA, type_arg)                     { $1 }
 
 /* TODO: fix the syntax for type arguments
    (TYPE, ROW, and PRESENCE are no longer tokens...)
@@ -1190,8 +1185,7 @@ vrow:
 | /* empty */                                                  { [], `Closed }
 
 datatypes:
-| datatype                                                     { [$1] }
-| datatype COMMA datatypes                                     { $1 :: $3 }
+| separated_nonempty_list(COMMA, datatype)                     { $1 }
 
 row:
 | fields                                                       { $1 }
@@ -1199,10 +1193,8 @@ row:
 
 fields:
 | field                                                        { [$1], `Closed }
-| field VBAR row_var                                           { [$1], $3 }
-| field VBAR kinded_row_var                                    { [$1], $3 }
-| VBAR row_var                                                 { [], $2 }
-| VBAR kinded_row_var                                          { [], $2 }
+| list(field) VBAR row_var                                     {  $1 , $3 }
+| list(field) VBAR kinded_row_var                              {  $1 , $3 }
 | field COMMA fields                                           { $1 :: fst $3, snd $3 }
 
 field:
@@ -1217,10 +1209,8 @@ field_label:
 
 rfields:
 | rfield                                                       { [$1], `Closed }
-| rfield VBAR row_var                                          { [$1], $3 }
-| rfield VBAR kinded_row_var                                   { [$1], $3 }
-| VBAR row_var                                                 { [], $2 }
-| VBAR kinded_row_var                                          { [], $2 }
+| list(rfield) VBAR row_var                                    {  $1, $3 }
+| list(rfield) VBAR kinded_row_var                             {  $1, $3 }
 | rfield COMMA rfields                                         { $1 :: fst $3, snd $3 }
 
 rfield:
@@ -1228,7 +1218,6 @@ rfield:
    the type (a,b,c) a record with fields a, b, c or a polymorphic tuple
    with type variables a, b, c?
 */
-/*| record_label                                               { $1, `Present `Unit } */
 | record_label fieldspec                                       { $1, $2 }
 
 record_label:

--- a/core/parser.mly
+++ b/core/parser.mly
@@ -1304,18 +1304,19 @@ kinded_row_var:
  * Regular expression grammar
  */
 regex:
-| SLASH regex_pattern_alternate regex_flags_opt                                  { with_pos $loc($2) (`Regex $2), $3 }
-| SLASH regex_flags_opt                                                          { with_pos $loc (`Regex (`Simply "")), $2 }
-| SSLASH regex_pattern_alternate SLASH regex_replace regex_flags_opt             { with_pos $loc (`Regex (`Replace ($2, $4))),
-                                                                                   `RegexReplace :: $5 }
+| SLASH regex_pattern_alternate regex_flags_opt                { with_pos $loc($2) (`Regex $2), $3 }
+| SLASH regex_flags_opt                                        { with_pos $loc (`Regex (`Simply "")), $2 }
+| SSLASH regex_pattern_alternate SLASH regex_replace
+    regex_flags_opt                                            { with_pos $loc (`Regex (`Replace ($2, $4))),
+                                                                 `RegexReplace :: $5 }
 
 regex_flags_opt:
-| SLASH                                                        {[]}
-| SLASHFLAGS                                                   {parseRegexFlags $1}
+| SLASH                                                        { [] }
+| SLASHFLAGS                                                   { parseRegexFlags $1 }
 
 regex_replace:
-| /* empty */                                                  { `Literal ""}
-| REGEXREPL                                                    { `Literal $1}
+| /* empty */                                                  { `Literal "" }
+| REGEXREPL                                                    { `Literal $1 }
 | block                                                        { `Splice (with_pos $loc (`Block $1)) }
 
 regex_pattern:
@@ -1336,8 +1337,7 @@ regex_pattern_alternate:
 | regex_pattern_sequence ALTERNATE regex_pattern_alternate     { `Alternate (`Seq $1, $3) }
 
 regex_pattern_sequence:
-| regex_pattern                                                { [$1] }
-| regex_pattern regex_pattern_sequence                         { $1 :: $2 }
+| nonempty_list(regex_pattern)                                 { $1 }
 
 /*
  * Pattern grammar

--- a/core/parser.mly
+++ b/core/parser.mly
@@ -306,6 +306,13 @@ let hear = "hear"
 
 %%
 
+(* soption = singleton option.  Allows an argument to appear optionally.  If it
+   does, it is placed in a singleton list.  This combinator is useful when
+   defining various *field productions.  *)
+%inline soption(X):
+| /* nothing */   { []  }
+| x = X           { [x] }
+
 interactive:
 | nofun_declaration                                            { `Definitions [$1] }
 | fun_declarations SEMICOLON                                   { `Definitions $1 }
@@ -1138,10 +1145,8 @@ row:
 
 fields:
 | field                                                        { [$1], `Closed }
-| field VBAR row_var                                           { [$1], $3 }
-| field VBAR kinded_row_var                                    { [$1], $3 }
-| VBAR row_var                                                 {  [] , $2 }
-| VBAR kinded_row_var                                          {  [] , $2 }
+| soption(field) VBAR row_var                                  {  $1 , $3 }
+| soption(field) VBAR kinded_row_var                           {  $1 , $3 }
 | field COMMA fields                                           { $1 :: fst $3, snd $3 }
 
 field:
@@ -1156,10 +1161,8 @@ field_label:
 
 rfields:
 | rfield                                                       { [$1], `Closed }
-| rfield VBAR row_var                                          { [$1], $3 }
-| rfield VBAR kinded_row_var                                   { [$1], $3 }
-| VBAR row_var                                                 { []  , $2 }
-| VBAR kinded_row_var                                          { []  , $2 }
+| soption(rfield) VBAR row_var                                 {  $1 , $3 }
+| soption(rfield) VBAR kinded_row_var                          {  $1 , $3 }
 | rfield COMMA rfields                                         { $1 :: fst $3, snd $3 }
 
 rfield:
@@ -1184,10 +1187,8 @@ vfield:
 
 efields:
 | efield                                                       { [$1], `Closed }
-| efield VBAR nonrec_row_var                                   { [$1], $3 }
-| efield VBAR kinded_nonrec_row_var                            { [$1], $3 }
-| VBAR nonrec_row_var                                          { [], $2 }
-| VBAR kinded_nonrec_row_var                                   { [], $2 }
+| soption(efield) VBAR nonrec_row_var                          {  $1 , $3 }
+| soption(efield) VBAR kinded_nonrec_row_var                   {  $1 , $3 }
 | efield COMMA efields                                         { $1 :: fst $3, snd $3 }
 
 efield:

--- a/core/parser.mly
+++ b/core/parser.mly
@@ -396,17 +396,16 @@ fun_declaration:
 
 typed_handler_binding:
 | handler_depth optional_computation_parameter var
-                handler_parameterization                       { let binder = make_untyped_binder $3 in
-                                                                 let hnlit  = ($1, $2, fst $4, snd $4) in
-                                                                 (binder, hnlit, None) }
+                handler_parameterization                        { let binder = make_untyped_binder $3 in
+                                                                  let hnlit  = ($1, $2, fst $4, snd $4) in
+                                                                  (binder, hnlit, None) }
 
 optional_computation_parameter:
-| /* empty */                                                 { with_pos $sloc `Any }
-| LBRACKET pattern RBRACKET                                   { $2 }
+| /* empty */                                                  { with_pos $sloc `Any }
+| LBRACKET pattern RBRACKET                                    { $2 }
 
 perhaps_uinteger:
-| /* empty */                                                  { None }
-| UINTEGER                                                     { Some $1 }
+| UINTEGER?                                                    { $1 }
 
 prefixop:
 | PREFIXOP                                                     { with_pos $loc $1 }
@@ -506,12 +505,10 @@ cp_cases:
 | cp_case cp_cases                                             { $1 :: $2 }
 
 perhaps_cp_cases:
-| /* empty */                                                  { [] }
-| cp_cases                                                     { $1 }
+| loption(cp_cases)                                            { $1 }
 
 perhaps_name:
-|                                                              { None }
-| cp_name                                                      { Some $1 }
+| cp_name?                                                     { $1 }
 
 cp_expression:
 | LBRACE block_contents RBRACE                                  { with_pos $loc (`Unquote $2) }
@@ -856,7 +853,7 @@ table_generator:
 | pattern LLARROW exp                                          { ($1, $3) }
 
 perhaps_where:
-| /* empty */                                                  { None }
+| /* empty */                                                  { None    }
 | WHERE LPAREN exp RPAREN                                      { Some $3 }
 
 perhaps_orderby:
@@ -881,8 +878,7 @@ table_expression:
             TABLEKEYS exp FROM exp                             { with_pos $loc (`TableLit ($2, datatype $4, $5, $7, $9))}
 
 perhaps_table_constraints:
-| WHERE table_constraints                                      { $2 }
-| /* empty */                                                  { [] }
+| loption(preceded(WHERE, table_constraints))                  { $1 }
 
 table_constraints:
 | separated_nonempty_list(COMMA,
@@ -896,8 +892,7 @@ field_constraint:
 | DEFAULT                                                      { `Default }
 
 perhaps_db_args:
-| atomic_expression                                            { Some $1 }
-| /* empty */                                                  { None }
+| atomic_expression?                                           { $1 }
 
 perhaps_db_driver:
 | atomic_expression perhaps_db_args                            { Some $1, $2 }

--- a/core/parser.mly
+++ b/core/parser.mly
@@ -52,37 +52,44 @@ end
 let type_variable_counter = ref 0
 
 let fresh_type_variable : subkind option -> datatypenode =
-  function subkind ->
-    incr type_variable_counter; `TypeVar ("_" ^ string_of_int (!type_variable_counter), subkind, `Flexible)
+  fun subkind ->
+    incr type_variable_counter;
+    `TypeVar ("_" ^ string_of_int (!type_variable_counter), subkind, `Flexible)
 
 let fresh_rigid_type_variable : subkind option -> datatypenode =
-  function subkind ->
-    incr type_variable_counter; `TypeVar ("_" ^ string_of_int (!type_variable_counter), subkind, `Rigid)
+  fun subkind ->
+    incr type_variable_counter;
+    `TypeVar ("_" ^ string_of_int (!type_variable_counter), subkind, `Rigid)
 
 let fresh_row_variable : subkind option -> row_var =
-  function subkind ->
-    incr type_variable_counter; `Open ("_" ^ string_of_int (!type_variable_counter), subkind, `Flexible)
+  fun subkind ->
+    incr type_variable_counter;
+    `Open ("_" ^ string_of_int (!type_variable_counter), subkind, `Flexible)
 
 let fresh_rigid_row_variable : subkind option -> row_var =
-  function subkind ->
-    incr type_variable_counter; `Open ("_" ^ string_of_int (!type_variable_counter), subkind, `Rigid)
+  fun subkind ->
+    incr type_variable_counter;
+    `Open ("_" ^ string_of_int (!type_variable_counter), subkind, `Rigid)
 
 let fresh_presence_variable : subkind option -> fieldspec =
-  function subkind ->
-    incr type_variable_counter; `Var ("_" ^ string_of_int (!type_variable_counter), subkind, `Flexible)
+  fun subkind ->
+    incr type_variable_counter;
+    `Var ("_" ^ string_of_int (!type_variable_counter), subkind, `Flexible)
 
 let fresh_rigid_presence_variable : subkind option -> fieldspec =
-  function subkind ->
-    incr type_variable_counter; `Var ("_" ^ string_of_int (!type_variable_counter), subkind, `Rigid)
+  fun subkind ->
+    incr type_variable_counter;
+    `Var ("_" ^ string_of_int (!type_variable_counter), subkind, `Rigid)
 
-let pos (start_pos, end_pos) : Sugartypes.position = start_pos, end_pos, None
+let pos (start_pos, end_pos) : Sugartypes.position = (start_pos, end_pos, None)
 
 let with_pos p = Sugartypes.with_pos (pos p)
 
 let ensure_match p (opening : string) (closing : string) = function
   | result when opening = closing -> result
-  | _ -> raise (ConcreteSyntaxError ("Closing tag '" ^ closing ^ "' does not match start tag '" ^ opening ^ "'.",
-                                     pos p))
+  | _ -> raise (ConcreteSyntaxError
+          ("Closing tag '" ^ closing ^ "' does not match start tag '" ^ opening
+           ^ "'.", pos p))
 
 let default_fixity = 9
 
@@ -108,32 +115,35 @@ let annotate sigpos (signame, datatype) dpos : _ -> binding =
 
 let primary_kind_of_string p =
   function
-  | "Type" -> `Type
-  | "Row" -> `Row
+  | "Type"     -> `Type
+  | "Row"      -> `Row
   | "Presence" -> `Presence
-  | pk -> raise (ConcreteSyntaxError ("Invalid primary kind: " ^ pk, pos p))
+  | pk         ->
+     raise (ConcreteSyntaxError ("Invalid primary kind: " ^ pk, pos p))
 
 let linearity_of_string p =
   function
   | "Any" -> `Any
   | "Unl" -> `Unl
-  | lin -> raise (ConcreteSyntaxError ("Invalid kind linearity: " ^ lin, pos p))
+  | lin   ->
+     raise (ConcreteSyntaxError ("Invalid kind linearity: " ^ lin, pos p))
 
 let restriction_of_string p =
   function
-  | "Any" -> `Any
-  | "Base" -> `Base
+  | "Any"     -> `Any
+  | "Base"    -> `Base
   | "Session" -> `Session
-  | rest -> raise (ConcreteSyntaxError ("Invalid kind restriction: " ^ rest, pos p))
+  | rest      ->
+     raise (ConcreteSyntaxError ("Invalid kind restriction: " ^ rest, pos p))
 
 let full_kind_of pos prim lin rest =
   let p = primary_kind_of_string pos prim in
-  let l = linearity_of_string pos lin in
-  let r = restriction_of_string pos rest in
-  p, Some (l, r)
+  let l = linearity_of_string    pos lin  in
+  let r = restriction_of_string  pos rest in
+  (p, Some (l, r))
 
 let full_subkind_of pos lin rest =
-  let l = linearity_of_string pos lin in
+  let l = linearity_of_string   pos lin  in
   let r = restriction_of_string pos rest in
   Some (l, r)
 
@@ -149,24 +159,24 @@ perhaps. *)
 let kind_of p =
   function
   (* primary kind abbreviation  *)
-  | "Type" -> `Type, None
-  | "Row" -> `Row, None
-  | "Presence" -> `Presence, None
+  | "Type"     -> (`Type, None)
+  | "Row"      -> (`Row, None)
+  | "Presence" -> (`Presence, None)
   (* subkind of type abbreviations *)
-  | "Any" -> `Type, Some (`Any, `Any)
-  | "Base" -> `Type, Some (`Unl, `Base)
-  | "Session" -> `Type, Some (`Any, `Session)
-  | "Eff"     -> `Row, Some (`Unl, `Effect)
-  | k -> raise (ConcreteSyntaxError ("Invalid kind: " ^ k, pos p))
+  | "Any"      -> (`Type, Some (`Any, `Any))
+  | "Base"     -> (`Type, Some (`Unl, `Base))
+  | "Session"  -> (`Type, Some (`Any, `Session))
+  | "Eff"      -> (`Row, Some (`Unl, `Effect))
+  | k          -> raise (ConcreteSyntaxError ("Invalid kind: " ^ k, pos p))
 
 let subkind_of p =
   function
   (* subkind abbreviations *)
-  | "Any" -> Some (`Any, `Any)
-  | "Base" -> Some (`Unl, `Base)
+  | "Any"     -> Some (`Any, `Any)
+  | "Base"    -> Some (`Unl, `Base)
   | "Session" -> Some (`Any, `Session)
-  | "Eff"  -> Some (`Unl, `Effect)
-  | sk -> raise (ConcreteSyntaxError ("Invalid subkind: " ^ sk, pos p))
+  | "Eff"     -> Some (`Unl, `Effect)
+  | sk        -> raise (ConcreteSyntaxError ("Invalid subkind: " ^ sk, pos p))
 
 let attach_kind (t, k) = (t, k, `Rigid)
 
@@ -175,20 +185,16 @@ let attach_subkind_helper update sk = update sk
 let attach_subkind (t, subkind) =
   let update sk =
     match t with
-    | `TypeVar (x, _, freedom) ->
-       `TypeVar (x, sk, freedom)
+    | `TypeVar (x, _, freedom) -> `TypeVar (x, sk, freedom)
     | _ -> assert false
-  in
-    attach_subkind_helper update subkind
+  in attach_subkind_helper update subkind
 
 let attach_row_subkind (r, subkind) =
   let update sk =
     match r with
-    | `Open (x, _, freedom) ->
-       `Open (x, sk, freedom)
+    | `Open (x, _, freedom) -> `Open (x, sk, freedom)
     | _ -> assert false
-  in
-    attach_subkind_helper update subkind
+  in attach_subkind_helper update subkind
 
 let row_with field (fields, row_var) = field::fields, row_var
 
@@ -212,7 +218,7 @@ let parseRegexFlags f =
               | 'g' -> `RegexGlobal
               | _ -> assert false) (asList f 0 [])
 
-let datatype d = d, None
+let datatype d = (d, None)
 
 let cp_unit p = with_pos p (`Unquote ([], with_pos p (`TupleLit [])))
 let present = `Present (with_dummy_pos `Unit)
@@ -552,8 +558,8 @@ parenthesized_thing:
 | LPAREN exp WITH labeled_exps RPAREN                          { with_pos $loc (`With ($2, $4))           }
 
 binop:
-| MINUS                                                        { `Minus }
-| MINUSDOT                                                     { `FloatMinus }
+| MINUS                                                        { `Minus          }
+| MINUSDOT                                                     { `FloatMinus     }
 | op                                                           { `Name ($1.node) }
 
 op:
@@ -607,15 +613,14 @@ exps:
 | separated_nonempty_list(COMMA, exp)                          { $1 }
 
 perhaps_exps:
-| separated_list(COMMA, exp)                                   { $1 }
+| loption(exps)                                                { $1 }
 
 unary_expression:
 | MINUS unary_expression                                       { with_pos $loc (`UnaryAppl (([], `Minus     ), $2)) }
 | MINUSDOT unary_expression                                    { with_pos $loc (`UnaryAppl (([], `FloatMinus), $2)) }
 | PREFIXOP unary_expression                                    { with_pos $loc (`UnaryAppl (([], `Name $1   ), $2)) }
 | postfix_expression | constructor_expression                  { $1 }
-| DOOP CONSTRUCTOR arg_spec                                    { with_pos $loc (`DoOperation ($2, $3, None)) }
-| DOOP CONSTRUCTOR                                             { with_pos $loc (`DoOperation ($2, [], None)) }
+| DOOP CONSTRUCTOR loption(arg_spec)                           { with_pos $loc (`DoOperation ($2, $3, None)) }
 
 
 infixr_9:
@@ -834,7 +839,7 @@ perhaps_generators:
 | separated_list(COMMA, generator)                             { $1 }
 
 generator:
-| list_generator                                               { `List $1 }
+| list_generator                                               { `List $1  }
 | table_generator                                              { `Table $1 }
 
 list_generator:
@@ -858,7 +863,7 @@ escape_expression:
 formlet_expression:
 | escape_expression                                            { $1 }
 | FORMLET xml YIELDS exp                                       { with_pos $loc (`Formlet ($2, $4)) }
-| PAGE xml                                                     { with_pos $loc (`Page $2) }
+| PAGE xml                                                     { with_pos $loc (`Page $2)          }
 
 table_expression:
 | formlet_expression                                           { $1 }
@@ -880,14 +885,14 @@ field_constraints:
 
 field_constraint:
 | READONLY                                                     { `Readonly }
-| DEFAULT                                                      { `Default }
+| DEFAULT                                                      { `Default  }
 
 perhaps_db_args:
 | atomic_expression?                                           { $1 }
 
 perhaps_db_driver:
-| atomic_expression perhaps_db_args                            { Some $1, $2 }
-| /* empty */                                                  { None, None }
+| atomic_expression perhaps_db_args                            { Some $1, $2   }
+| /* empty */                                                  { None   , None }
 
 database_expression:
 | table_expression                                             { $1 }
@@ -967,7 +972,7 @@ binding:
 | typedecl SEMICOLON | links_module | alien_block | links_open { $1 }
 
 bindings:
-| binding                                                      { [$1] }
+| binding                                                      { [$1]      }
 | bindings binding                                             { $1 @ [$2] }
 
 moduleblock:
@@ -1003,14 +1008,14 @@ datatype:
 
 arrow_prefix:
 | LBRACE RBRACE                                                { ([], `Closed) }
-| LBRACE efields RBRACE                                        { $2 }
+| LBRACE efields RBRACE                                        { $2            }
 
 straight_arrow_prefix:
-| arrow_prefix                                                 { $1 }
+| arrow_prefix                                                 { $1       }
 | MINUS nonrec_row_var | MINUS kinded_nonrec_row_var           { ([], $2) }
 
 squig_arrow_prefix:
-| hear_arrow_prefix | arrow_prefix                             { $1 }
+| hear_arrow_prefix | arrow_prefix                             { $1       }
 | TILDE nonrec_row_var | TILDE kinded_nonrec_row_var           { ([], $2) }
 
 hear_arrow_prefix:
@@ -1061,11 +1066,11 @@ forall_datatype:
 session_datatype:
 | BANG datatype DOT datatype                                   { `Output ($2, $4) }
 | QUESTION datatype DOT datatype                               { `Input  ($2, $4) }
-| LBRACKETPLUSBAR row BARPLUSRBRACKET                          { `Select $2 }
-| LBRACKETAMPBAR row BARAMPRBRACKET                            { `Choice $2 }
-| TILDE datatype                                               { `Dual $2 }
-| END                                                          { `End }
-| primary_datatype                                             { $1 }
+| LBRACKETPLUSBAR row BARPLUSRBRACKET                          { `Select $2       }
+| LBRACKETAMPBAR row BARAMPRBRACKET                            { `Choice $2       }
+| TILDE datatype                                               { `Dual $2         }
+| END                                                          { `End             }
+| primary_datatype                                             { $1               }
 
 parenthesized_datatypes:
 | LPAREN RPAREN                                                { [] }
@@ -1075,7 +1080,7 @@ parenthesized_datatypes:
 primary_datatype:
 | parenthesized_datatypes                                      { match $1 with
                                                                    | [] -> `Unit
-                                                                   | [{ node  ; _ }] -> node
+                                                                   | [{node;_}] -> node
                                                                    | ts  -> `Tuple ts }
 | LPAREN rfields RPAREN                                        { `Record $2 }
 | TABLEHANDLE
@@ -1097,10 +1102,10 @@ primary_datatype:
 | CONSTRUCTOR LPAREN type_arg_list RPAREN                      { `TypeApplication ($1, $3) }
 
 type_var:
-| VARIABLE                                                     { `TypeVar ($1, None, `Rigid) }
+| VARIABLE                                                     { `TypeVar ($1, None, `Rigid)    }
 | PERCENTVAR                                                   { `TypeVar ($1, None, `Flexible) }
 | UNDERSCORE                                                   { fresh_rigid_type_variable None }
-| PERCENT                                                      { fresh_type_variable None }
+| PERCENT                                                      { fresh_type_variable None       }
 
 kinded_type_var:
 | type_var subkind                                             { attach_subkind ($1, $2) }
@@ -1112,32 +1117,32 @@ type_arg_list:
    (TYPE, ROW, and PRESENCE are no longer tokens...)
 */
 type_arg:
-| datatype                                                     { `Type $1 }
-| TYPE LPAREN datatype RPAREN                                  { `Type $3 }
-| ROW LPAREN row RPAREN                                        { `Row $3 }
+| datatype                                                     { `Type $1     }
+| TYPE LPAREN datatype RPAREN                                  { `Type $3     }
+| ROW LPAREN row RPAREN                                        { `Row $3      }
 | PRESENCE LPAREN fieldspec RPAREN                             { `Presence $3 }
-| LBRACE row RBRACE                                            { `Row $2 }
+| LBRACE row RBRACE                                            { `Row $2      }
 
 vrow:
-| vfields                                                      { $1 }
-| /* empty */                                                  { [], `Closed }
+| vfields                                                      { $1            }
+| /* empty */                                                  { ([], `Closed) }
 
 datatypes:
 | separated_nonempty_list(COMMA, datatype)                     { $1 }
 
 row:
-| fields                                                       { $1 }
-| /* empty */                                                  { [], `Closed }
+| fields                                                       { $1            }
+| /* empty */                                                  { ([], `Closed) }
 
 fields:
-| field                                                        { [$1], `Closed }
-| soption(field) VBAR row_var                                  {  $1 , $3 }
-| soption(field) VBAR kinded_row_var                           {  $1 , $3 }
-| field COMMA fields                                           { $1 :: fst $3, snd $3 }
+| field                                                        { ([$1]       , `Closed) }
+| soption(field) VBAR row_var                                  { ( $1        , $3     ) }
+| soption(field) VBAR kinded_row_var                           { ( $1        , $3     ) }
+| field COMMA fields                                           { ( $1::fst $3, snd $3 ) }
 
 field:
-| field_label                                                  { $1, present }
-| field_label fieldspec                                        { $1, $2 }
+| field_label                                                  { ($1, present) }
+| field_label fieldspec                                        { ($1, $2) }
 
 field_label:
 | CONSTRUCTOR                                                  { $1 }
@@ -1146,40 +1151,40 @@ field_label:
 | UINTEGER                                                     { string_of_int $1 }
 
 rfields:
-| rfield                                                       { [$1], `Closed }
-| soption(rfield) VBAR row_var                                 {  $1 , $3 }
-| soption(rfield) VBAR kinded_row_var                          {  $1 , $3 }
-| rfield COMMA rfields                                         { $1 :: fst $3, snd $3 }
+| rfield                                                       { ([$1]       , `Closed) }
+| soption(rfield) VBAR row_var                                 { ( $1        , $3     ) }
+| soption(rfield) VBAR kinded_row_var                          { ( $1        , $3     ) }
+| rfield COMMA rfields                                         { ( $1::fst $3, snd $3 ) }
 
 rfield:
 /* The following sugar is tempting, but it leads to a conflict. Is
    the type (a,b,c) a record with fields a, b, c or a polymorphic tuple
    with type variables a, b, c?
 */
-| record_label fieldspec                                       { $1, $2 }
+| record_label fieldspec                                       { ($1, $2) }
 
 record_label:
 | field_label                                                  { $1 }
 
 vfields:
-| vfield                                                       { [$1], `Closed }
-| row_var                                                      { [], $1 }
-| kinded_row_var                                               { [], $1 }
-| vfield VBAR vfields                                          { $1 :: fst $3, snd $3 }
+| vfield                                                       { ([$1]      , `Closed) }
+| row_var                                                      { ([]        , $1     ) }
+| kinded_row_var                                               { ([]        , $1     ) }
+| vfield VBAR vfields                                          { ($1::fst $3, snd $3 ) }
 
 vfield:
-| CONSTRUCTOR                                                  { $1, present }
-| CONSTRUCTOR fieldspec                                        { $1, $2 }
+| CONSTRUCTOR                                                  { ($1, present) }
+| CONSTRUCTOR fieldspec                                        { ($1, $2)      }
 
 efields:
-| efield                                                       { [$1], `Closed }
-| soption(efield) VBAR nonrec_row_var                          {  $1 , $3 }
-| soption(efield) VBAR kinded_nonrec_row_var                   {  $1 , $3 }
-| efield COMMA efields                                         { $1 :: fst $3, snd $3 }
+| efield                                                       { ([$1]       , `Closed) }
+| soption(efield) VBAR nonrec_row_var                          { ( $1        , $3     ) }
+| soption(efield) VBAR kinded_nonrec_row_var                   { ( $1        , $3     ) }
+| efield COMMA efields                                         { ( $1::fst $3, snd $3 ) }
 
 efield:
-| effect_label                                                 { $1, present }
-| effect_label fieldspec                                       { $1, $2 }
+| effect_label                                                 { ($1, present) }
+| effect_label fieldspec                                       { ($1, $2)      }
 
 effect_label:
 | CONSTRUCTOR                                                  { $1 }
@@ -1196,7 +1201,7 @@ fieldspec:
 | LBRACE PERCENT RBRACE                                        { fresh_presence_variable None }
 
 nonrec_row_var:
-| VARIABLE                                                     { `Open ($1, None, `Rigid) }
+| VARIABLE                                                     { `Open ($1, None, `Rigid   ) }
 | PERCENTVAR                                                   { `Open ($1, None, `Flexible) }
 | UNDERSCORE                                                   { fresh_rigid_row_variable None }
 | PERCENT                                                      { fresh_row_variable None }
@@ -1252,58 +1257,58 @@ regex_pattern_alternate:
 | regex_pattern_sequence ALTERNATE regex_pattern_alternate     { `Alternate (`Seq $1, $3) }
 
 regex_pattern_sequence:
-| regex_pattern+                                            { $1 }
+| regex_pattern+                                               { $1 }
 
 /*
  * Pattern grammar
  */
 pattern:
-| typed_pattern                                             { $1 }
-| typed_pattern COLON primary_datatype                      { with_pos $loc (`HasType ($1, datatype (with_pos $loc($3) $3))) }
+| typed_pattern                                                { $1 }
+| typed_pattern COLON primary_datatype                         { with_pos $loc (`HasType ($1, datatype (with_pos $loc($3) $3))) }
 
 typed_pattern:
-| cons_pattern                                              { $1 }
-| cons_pattern AS var                                       { with_pos $loc (`As (make_untyped_binder $3, $1)) }
+| cons_pattern                                                 { $1 }
+| cons_pattern AS var                                          { with_pos $loc (`As (make_untyped_binder $3, $1)) }
 
 cons_pattern:
-| constructor_pattern                                       { $1 }
-| constructor_pattern COLONCOLON cons_pattern               { with_pos $loc (`Cons ($1, $3)) }
+| constructor_pattern                                          { $1 }
+| constructor_pattern COLONCOLON cons_pattern                  { with_pos $loc (`Cons ($1, $3)) }
 
 constructor_pattern:
-| negative_pattern                                          { $1 }
-| CONSTRUCTOR parenthesized_pattern?                        { with_pos $loc (`Variant ($1, $2)) }
+| negative_pattern                                             { $1 }
+| CONSTRUCTOR parenthesized_pattern?                           { with_pos $loc (`Variant ($1, $2)) }
 
 constructors:
-| separated_nonempty_list(COMMA, CONSTRUCTOR)               { $1 }
+| separated_nonempty_list(COMMA, CONSTRUCTOR)                  { $1 }
 
 negative_pattern:
-| primary_pattern                                           { $1 }
-| MINUS CONSTRUCTOR                                         { with_pos $loc (`Negative [$2]) }
-| MINUS LPAREN constructors RPAREN                          { with_pos $loc (`Negative $3) }
+| primary_pattern                                              { $1 }
+| MINUS CONSTRUCTOR                                            { with_pos $loc (`Negative [$2]) }
+| MINUS LPAREN constructors RPAREN                             { with_pos $loc (`Negative $3)   }
 
 parenthesized_pattern:
-| LPAREN RPAREN                                             { with_pos $loc (`Tuple []) }
-| LPAREN pattern RPAREN                                     { $2 }
-| LPAREN pattern COMMA patterns RPAREN                      { with_pos $loc (`Tuple ($2 :: $4)) }
-| LPAREN labeled_patterns preceded(VBAR, pattern)? RPAREN   { with_pos $loc (`Record ($2, $3)) }
+| LPAREN RPAREN                                                { with_pos $loc (`Tuple []) }
+| LPAREN pattern RPAREN                                        { $2 }
+| LPAREN pattern COMMA patterns RPAREN                         { with_pos $loc (`Tuple ($2 :: $4)) }
+| LPAREN labeled_patterns preceded(VBAR, pattern)? RPAREN      { with_pos $loc (`Record ($2, $3)) }
 
 primary_pattern:
-| VARIABLE                                                  { with_pos $loc (`Variable (make_untyped_binder (with_pos $loc $1))) }
-| UNDERSCORE                                                { with_pos $loc `Any }
-| constant                                                  { with_pos $loc (`Constant $1) }
-| LBRACKET RBRACKET                                         { with_pos $loc `Nil }
-| LBRACKET patterns RBRACKET                                { with_pos $loc (`List $2) }
-| parenthesized_pattern                                     { $1 }
+| VARIABLE                                                     { with_pos $loc (`Variable (make_untyped_binder (with_pos $loc $1))) }
+| UNDERSCORE                                                   { with_pos $loc `Any }
+| constant                                                     { with_pos $loc (`Constant $1) }
+| LBRACKET RBRACKET                                            { with_pos $loc `Nil }
+| LBRACKET patterns RBRACKET                                   { with_pos $loc (`List $2) }
+| parenthesized_pattern                                        { $1 }
 
 patterns:
-| separated_nonempty_list(COMMA, pattern)                   { $1 }
+| separated_nonempty_list(COMMA, pattern)                      { $1 }
 
 labeled_patterns:
 | separated_nonempty_list(COMMA,
-   separated_pair(record_label, EQ,  pattern))              { $1 }
+   separated_pair(record_label, EQ,  pattern))                 { $1 }
 
 multi_args:
-| LPAREN separated_list(COMMA, pattern) RPAREN              { $2 }
+| LPAREN separated_list(COMMA, pattern) RPAREN                 { $2 }
 
 arg_lists:
-| multi_args+                                               { $1 }
+| multi_args+                                                  { $1 }


### PR DESCRIPTION
Addresses #426.

Below is a parser refactoring that I have been working on for the past week or so. I mostly tried to compactify the rules by relying on Menhir combinators. So for example instead of productions like:

```
foos:
| foo      { $1       }
| foo foos { $1 :: $2 }
```

we now have:

```
foos:
| foo+      { $1 }
```

As a result `parser.mly` is now about 100 lines shorter and about 13% smaller in terms of file size in bytes. This is as far as I was able to go without altering the structure of Links AST and touching further stages of compilation pipeline. More improvements are possible if we did so, but I personally don't yet feel competent enough to do this. A good example of a possible improvement are the three production rules for `INSERT` already discussed in https://github.com/links-lang/links/issues/426#issuecomment-442583867:

```
| INSERT exp VALUES LBRACKET LPAREN labeled_exps RPAREN RBRACKET
  { with_pos $loc (`DBInsert ($2, labels $6,
     with_pos $loc($6) (`ListLit ([with_pos $loc($6) (`RecordLit ($6, None))], None)),
    None)) }

| INSERT exp VALUES LBRACKET LPAREN RPAREN RBRACKET RETURNING VARIABLE
  { with_pos $loc (`DBInsert ($2, [],
     with_pos $loc (`ListLit ([with_pos $loc (`RecordLit ([], None))], None)),
    Some (with_pos $loc($9) (`Constant (`String $9))))) }

| INSERT exp VALUES LBRACKET LPAREN labeled_exps RPAREN RBRACKET RETURNING VARIABLE
  { with_pos $loc (`DBInsert ($2, labels $6,
     with_pos $loc($6) (`ListLit ([with_pos $loc($6) (`RecordLit ($6, None))], None)),
    Some (with_pos $loc (`Constant (`String $10))))) }
```

These can be collapsed into a single rule:

```
| INSERT exp VALUES LBRACKET LPAREN loption(labeled_exps) RPAREN RBRACKET
         preceded(RETURNING, VARIABLE)?
  { with_pos $loc (`DBInsert ($2, labels $6,
     with_pos $loc($6) (`ListLit ([with_pos $loc($6) (`RecordLit ($6, None))], None)),
    OptionUtils.opt_map (fun v -> with_pos $loc (`Constant (`String v))) $9)) }
```
But this requries that later stages of compilation pipeline catch a case where `labeled_exps` is an empty list and there is no `RETURNING VARIABLE`.

There is one more thing I am tempted to do, but I first need to know what others think. Currently `parser.mly` is formatted in such a way that productions are placed on the left and semantic actions are placed in the same line on the right, starting in column 63. This leads to extremely long lines (as much as 140 columns). I am often working with two source files opened side by side, but with `parser.mly` formatted the way it is now this is impossible. Similalrly, I suspect many of you will experience problems viewing changes in this PR, because lines are too long to be displayed side by side and they need to be wrapped, which makes viewing difficult. I would like to reformat `parser.mly` so that semantic actions are placed below productions whenever necessary. An example of this is above - the three INSERT rules are reformatted using this style for the purpose of this comment. In the source code they currently look like this:

```
| INSERT exp VALUES
  LBRACKET LPAREN labeled_exps RPAREN RBRACKET                 { with_pos $loc (`DBInsert ($2,
                                                                          labels $6,
                                                                          with_pos $loc($6)
                                                                                   (`ListLit ([with_pos $loc($6)
                                                                                                        (`RecordLit ($6, None))], None)),
                                                                          None)) }
| INSERT exp VALUES
  LBRACKET LPAREN RPAREN RBRACKET
  RETURNING VARIABLE                                           { with_pos $loc (`DBInsert ($2,
                                                                          [],
                                                                          (with_pos $loc (`ListLit ([with_pos $loc (`RecordLit ([], None))],
                                                                                                    None))),
                                                                          Some (with_pos $loc($9) (`Constant (`String $9))))) }
| INSERT exp VALUES
  LBRACKET LPAREN labeled_exps RPAREN RBRACKET
  RETURNING VARIABLE                                           { with_pos $loc (`DBInsert ($2,
                                                                          labels $6,
                                                                          (with_pos $loc($6) (`ListLit ([with_pos $loc($6)
                                                                                                                  (`RecordLit ($6, None))],
                                                                                                        None))),
                                                                          Some (with_pos $loc (`Constant (`String $10))))) }

```
which, I think, is horrible to read.  Are there any strong opinions for or against such reformatting?

Finally, there is this note in `parser.mly`:

```
/* FIXME:
 *
 * recursive row vars shouldn't be restricted to vfields.
 */
row_var:
| nonrec_row_var                                               { $1 }
| LPAREN MU VARIABLE DOT vfields RPAREN                        { `Recursive ($3, $5) }
```

What should the other allowed productions be? We can now parameterize production rules so this should be easy to fix.

In general, it would be nice if these kind of TODO/FIXME notes were avoided and appropriate tickets with informative description be created instead. (I am guessing many such notes come from times when there was no bugtracker?) I believe this would greatly increase the chances that such TODOs ever get addressed.