### PR TITLE
Use smart constructors in desugar* modules

### DIFF
--- a/core/desugarAlienBlocks.ml
+++ b/core/desugarAlienBlocks.ml
@@ -12,6 +12,7 @@
 
 open Utility
 open Sugartypes
+open SugarConstructors.Make
 
 let rec flatten_simple = fun () ->
 object(self)
@@ -39,14 +40,13 @@ object(self)
     | {node=`AlienBlock (lang, lib, decls); _} ->
         self#list (fun o ((bnd, dt)) ->
           let name = name_of_binder bnd in
-          let pos = bnd.pos in
-          o#add_binding (with_pos pos (`Foreign (bnd, name, lang, lib, dt)))) decls
-    | {node=`Module (name, bindings); pos} ->
+          o#add_binding (with_dummy_pos (`Foreign (bnd, name, lang, lib, dt)))) decls
+    | {node=`Module (name, bindings); _} ->
         let flattened_bindings =
           List.concat (
             List.map (fun b -> ((flatten_bindings ())#binding b)#get_bindings) bindings
           ) in
-        self#add_binding (with_pos pos (`Module (name, flattened_bindings)))
+        self#add_binding (with_dummy_pos (`Module (name, flattened_bindings)))
     | b -> self#add_binding ((flatten_simple ())#binding b)
 
   method! program = function

--- a/core/desugarCP.ml
+++ b/core/desugarCP.ml
@@ -1,7 +1,18 @@
 open Utility
 open Sugartypes
+open SugarConstructors.Make
 
 module TyEnv = Env.String
+
+let accept_str    = "accept"
+let close_str     = "close"
+let link_sync_str = "linkSync"
+let new_str       = "new"
+let receive_str   = "receive"
+let request_str   = "request"
+let send_str      = "send"
+let wait_str      = "wait"
+let wild_str      = "wild"
 
 class desugar_cp env =
 object (o : 'self_type)
@@ -9,58 +20,46 @@ object (o : 'self_type)
 
   method! phrasenode = function
     | `CP p ->
-       let rec desugar_cp = fun o {node = p; pos} ->
-         let add_pos x = with_pos pos x in
+       let rec desugar_cp = fun o {node = p; _} ->
          match p with
          | `Unquote (bs, e) ->
             let envs = o#backup_envs in
             let (o, bs) = TransformSugar.listu o (fun o -> o#binding) bs in
             let (o, e, t) = o#phrase e in
             let o = o#restore_envs envs in
-            o, `Block (bs, e), t
+            o, block_node (bs, e), t
          | `Grab ((c, _), None, p) ->
             let (o, e, t) = desugar_cp o p in
-            o, `Block
-                ([add_pos (`Val (add_pos `Any, ([],
-                                      add_pos (`FnAppl (add_pos (`Var "wait"),
-                                                       [add_pos (`Var c)]))),
-                                      `Unknown, None))],
-                 add_pos e), t
+            o, block_node
+                ([val_binding (any_pat dp) (fn_appl_var wait_str c)],
+                 with_dummy_pos e), t
          | `Grab ((c, Some (`Input (_a, s), grab_tyargs)), Some {node=x, Some u; _}, p) -> (* FYI: a = u *)
             let envs = o#backup_envs in
-            let venv = TyEnv.bind (TyEnv.bind (o#get_var_env ())
-                                              (x, u))
+            let venv = TyEnv.bind (TyEnv.bind (o#get_var_env ()) (x, u))
                                   (c, s) in
             let o = {< var_env = venv >} in
             let (o, e, t) = desugar_cp o p in
             let o = o#restore_envs envs in
-            o, `Block
-                ([add_pos (`Val (add_pos (`Record ([("1", add_pos (`Variable (make_binder x u pos)));
-                                                    ("2", add_pos (`Variable (make_binder c s pos)))], None)),
-                                 ([], add_pos (`FnAppl (add_pos (Sugartypes.tappl (`Var "receive", grab_tyargs)),
-                                                        [add_pos (`Var c)]))),
-                                 `Unknown, None))],
-                 add_pos e), t
+            o, block_node
+                ([val_binding (with_dummy_pos (`Record ([("1", variable_pat ~ty:u x);
+                                                         ("2", variable_pat ~ty:s c)], None)))
+                               (fn_appl receive_str grab_tyargs [var c])],
+                 with_dummy_pos e), t
          | `Give ((c, _), None, p) ->
             let (o, e, t) = desugar_cp o p in
-            o, `Block
-                ([add_pos (`Val (add_pos `Any,
-                                 ([], add_pos (`FnAppl (add_pos (`Var "close"),
-                                                        [add_pos (`Var c)]))),
-                                 `Unknown, None))],
-                 add_pos e), t
+            o, block_node
+                ([val_binding (any_pat dp) (fn_appl_var close_str c)],
+                 with_dummy_pos e), t
          | `Give ((c, Some (`Output (_t, s), give_tyargs)), Some e, p) ->
             let envs = o#backup_envs in
             let o = {< var_env = TyEnv.bind (o#get_var_env ()) (c, s) >} in
             let (o, e, _typ) = o#phrase e in
             let (o, p, t) = desugar_cp o p in
             let o = o#restore_envs envs in
-            o, `Block
-                ([add_pos (`Val (add_pos (`Variable (make_binder c s pos)),
-                                 ([], add_pos (`FnAppl (add_pos (Sugartypes.tappl (`Var "send", give_tyargs)),
-                                                        [e; add_pos (`Var c)]))),
-                                 `Unknown, None))],
-                 add_pos p), t
+            o, block_node
+                ([val_binding (variable_pat ~ty:s c)
+                              (fn_appl send_str give_tyargs [e; var c])],
+                 with_dummy_pos p), t
          | `GiveNothing ({node=c, Some t; _}) ->
             o, `Var c, t
          | `Select ({node=c, Some s; _}, label, p) ->
@@ -68,51 +67,47 @@ object (o : 'self_type)
             let o = {< var_env = TyEnv.bind (o#get_var_env ()) (c, TypeUtils.select_type label s) >} in
             let (o, p, t) = desugar_cp o p in
             let o = o#restore_envs envs in
-            o, `Block
-                ([add_pos (`Val (add_pos (`Variable (make_binder c (TypeUtils.select_type label s) pos)),
-                                 ([], add_pos (`Select (label, (add_pos (`Var c))))),
-                                 `Unknown, None))],
-                 add_pos p), t
+            o, block_node
+                ([val_binding (variable_pat ~ty:(TypeUtils.select_type label s) c)
+                               (with_dummy_pos (`Select (label, var c)))],
+                 with_dummy_pos p), t
          | `Offer ({node=c, Some s; _}, cases) ->
             let desugar_branch (label, p) (o, cases) =
               let envs = o#backup_envs in
               let o = {< var_env = TyEnv.bind (o#get_var_env ()) (c, TypeUtils.choice_at label s) >} in
               let (o, p, t) = desugar_cp o p in
-              let pat : pattern = add_pos (`Variant (label, Some (add_pos (`Variable (make_binder c (TypeUtils.choice_at label s) pos))))) in
-              o#restore_envs envs, ((pat, add_pos p), t) :: cases in
+              let pat : pattern = with_dummy_pos (`Variant (label,
+                      Some (variable_pat ~ty:(TypeUtils.choice_at label s) c))) in
+              o#restore_envs envs, ((pat, with_dummy_pos p), t) :: cases in
             let (o, cases) = List.fold_right desugar_branch cases (o, []) in
             (match List.split cases with
                 | (_, []) -> assert false (* Case list cannot be empty *)
                 | (cases, t :: _ts) ->
-                    o, `Offer (add_pos (`Var c),
-                               cases,
-                               Some t), t)
+                    o, `Offer (var c, cases, Some t), t)
          | `Link ({node=c, Some ct; _}, {node=d, Some _; _}) ->
-            o, `FnAppl (add_pos (Sugartypes.tappl (`Var "linkSync", [`Type ct; `Row o#lookup_effects])),
-                        [add_pos (`Var c); add_pos (`Var d)]), Types.make_endbang_type
+            o, fn_appl_node link_sync_str [`Type ct; `Row o#lookup_effects]
+                            [var c; var d],
+            Types.make_endbang_type
          | `Comp ({node=c, Some s; _}, left, right) ->
             let envs = o#backup_envs in
             let (o, left, _typ) = desugar_cp {< var_env = TyEnv.bind (o#get_var_env ()) (c, s) >} left in
             let (o, right, t) = desugar_cp {< var_env = TyEnv.bind (o#get_var_env ()) (c, Types.dual_type s) >} right in
             let o = o#restore_envs envs in
-            let left_block = add_pos (`Spawn (`Angel, `NoSpawnLocation, add_pos (`Block (
-                                     [ add_pos (`Val (add_pos (`Variable (make_binder c s pos)),
-                                                      ([], add_pos (`FnAppl (add_pos (`Var "accept"), [add_pos (`Var c)]))),
-                                                      `Unknown, None));
-                                       add_pos (`Val (add_pos (`Variable (make_binder c Types.make_endbang_type pos)),
-                                                      ([], add_pos left), `Unknown, None))],
-                                       add_pos (`FnAppl (add_pos (`Var "close"), [add_pos (`Var c)])))),
-                                              Some (Types.make_singleton_closed_row ("wild", `Present Types.unit_type)))) in
+            let left_block =
+                spawn `Angel `NoSpawnLocation (block (
+                    [ val_binding (variable_pat ~ty:s c) (fn_appl_var accept_str c);
+                      val_binding (variable_pat ~ty:Types.make_endbang_type c)
+                                  (with_dummy_pos left)],
+                    fn_appl_var close_str c))
+                      ~row:(Types.make_singleton_closed_row (wild_str, `Present Types.unit_type)) in
             let o = o#restore_envs envs in
-            o, `Block
-                  ([add_pos (`Val (add_pos (`Variable (make_binder c (`Application (Types.access_point, [`Type s])) pos)),
-                                   ([], add_pos (`FnAppl (add_pos (`Var "new"), []))),
-                                   `Unknown, None));
-                    add_pos (`Val (add_pos `Any, ([], left_block), `Unknown, None));
-                    add_pos (`Val (add_pos (`Variable (make_binder c (Types.dual_type s) pos)),
-                                   ([], add_pos (`FnAppl (add_pos (`Var "request"), [add_pos (`Var c)]))),
-                                   `Unknown, None))],
-                   add_pos right), t
+            o, block_node
+                  ([val_binding (variable_pat ~ty:(`Application (Types.access_point, [`Type s])) c)
+                                (fn_appl new_str [] []);
+                    val_binding (any_pat dp) left_block;
+                    val_binding (variable_pat ~ty:(Types.dual_type s) c)
+                                (fn_appl_var request_str c)],
+                   with_dummy_pos right), t
          | _ -> assert false in
        desugar_cp o p
     | e -> super#phrasenode e

--- a/core/desugarFormlets.ml
+++ b/core/desugarFormlets.ml
@@ -1,5 +1,6 @@
 open Utility
 open Sugartypes
+open SugarConstructors.Make
 
 let rec is_raw phrase =
   match phrase.node with
@@ -16,6 +17,12 @@ let tt =
     | [t] -> t
     | ts -> Types.make_tuple_type ts
 
+let xml_str           = "xml"
+let string_to_xml_str = "stringToXml"
+let pure_str          = "pure"
+let plug_str          = "plug"
+let atatat_str        = "@@@"
+
 class desugar_formlets env =
 object (o : 'self_type)
   inherit (TransformSugar.transform env) as super
@@ -28,18 +35,17 @@ object (o : 'self_type)
   *)
   method formlet_patterns : Sugartypes.phrase -> (Sugartypes.pattern list * Sugartypes.phrase list * Types.datatype list) =
     fun ph ->
-      let dp = Sugartypes.dummy_position in
       match ph.node with
         | _ when is_raw ph ->
-            [with_dummy_pos (`Tuple [])], [with_dummy_pos (`TupleLit [])], [Types.unit_type]
+            [tuple_pat []], [tuple []], [Types.unit_type]
         | `FormBinding (f, p) ->
             let (_o, _f, ft) = o#phrase f in
             let t = Types.fresh_type_variable (`Any, `Any) in
             let () =
               Unify.datatypes
                 (ft, Instantiate.alias "Formlet" [`Type t] tycon_env) in
-            let var = Utility.gensym ~prefix:"_formlet_" () in
-            let (xb, x) = (make_binder var t dp), (with_dummy_pos (`Var var)) in
+            let name = Utility.gensym ~prefix:"_formlet_" () in
+            let (xb, x) = (binder name ~ty:t, var name) in
               [with_dummy_pos (`As (xb, p))], [x], [t]
         | `Xml (_, _, _, [node]) ->
             o#formlet_patterns node
@@ -51,7 +57,7 @@ object (o : 'self_type)
                      match ps', vs', ts' with
                        | [p], [v], [t] -> p::ps, v::vs, t::ts
                        | _ ->
-                           with_dummy_pos (`Tuple ps')::ps, (with_dummy_pos (`TupleLit vs'))::vs, (Types.make_tuple_type ts')::ts)
+                           (tuple_pat ps')::ps, (tuple vs')::vs, (Types.make_tuple_type ts')::ts)
                 ([], [], []) contents
             in
               List.rev ps, List.rev vs, List.rev ts
@@ -61,31 +67,22 @@ object (o : 'self_type)
   (* desugar a formlet body (the ^o transformation) *)
   method private formlet_body_node : Sugartypes.phrasenode -> ('self_type * Sugartypes.phrasenode * Types.datatype) =
     fun e ->
-      let dp = Sugartypes.dummy_position in
         match e with
           | `TextNode s ->
               let e =
-                `FnAppl
-                  (with_dummy_pos (`TAppl (with_dummy_pos (`Var "xml"), [`Row (o#lookup_effects)])),
-                   [with_dummy_pos (`FnAppl
-                    (with_dummy_pos (`TAppl (with_dummy_pos (`Var "stringToXml"), [`Row (o#lookup_effects)])),
-                     [with_dummy_pos (`Constant (`String s))]))])
-              in
-                (o, e, Types.xml_type)
+                fn_appl_node xml_str [`Row (o#lookup_effects)]
+                  [fn_appl string_to_xml_str [`Row (o#lookup_effects)]
+                     [constant_str s]]
+              in (o, e, Types.xml_type)
           | `Block (bs, e) ->
               let (o, e, _) =
                 o#phrasenode
-                  (`Block
-                     (bs,
-                      with_dummy_pos
-                        (`FnAppl
-                         (with_dummy_pos (`TAppl (with_dummy_pos (`Var "xml"), [`Row (o#lookup_effects)])),
-                          [e]))))
-              in
-                (o, e, Types.xml_type)
+                  (block_node
+                     (bs, (fn_appl xml_str [`Row (o#lookup_effects)] [e])))
+              in (o, e, Types.xml_type)
           | `FormBinding (f, _) ->
-              let (o, {node=f; _}, ft) = o#phrase f in
-                (o, f, ft)
+              let (o, {node=f; _}, ft) = o#phrase f
+              in (o, f, ft)
           | `Xml ("#", [], None, contents) ->
               (* pure (fun ps -> vs) <*> e1 <*> ... <*> ek *)
               let pss, vs, ts =
@@ -100,7 +97,7 @@ object (o : 'self_type)
                                *)
                                [p]::pss, v::vs, t::ts
                            | _ ->
-                               [with_dummy_pos (`Tuple ps')]::pss, with_dummy_pos (`TupleLit vs')::vs, (Types.make_tuple_type ts')::ts)
+                               [(tuple_pat ps')]::pss, tuple vs'::vs, (Types.make_tuple_type ts')::ts)
                     ([], [], []) contents
                 in
                   List.rev pss, List.rev vs, List.rev ts in
@@ -116,30 +113,24 @@ object (o : 'self_type)
                     | [] ->
                         let (o, e, _) =
                           super#phrasenode (`Xml ("#", [], None, contents))
-                        in
-                          (o,
-                           (`FnAppl
-                              (with_dummy_pos (`TAppl (with_dummy_pos (`Var "xml"), [`Row (o#lookup_effects)])), [with_dummy_pos e])),
-                           Types.xml_type)
+                        in (o, fn_appl_node xml_str [`Row (o#lookup_effects)]
+                                            [with_dummy_pos e],
+                            Types.xml_type)
                     | _ ->
                         let (o, es, _) = TransformSugar.list o (fun o -> o#formlet_body) contents in
                         let mb = `Row (o#lookup_effects) in
                         let base : phrase =
-                          with_dummy_pos
-                            (`FnAppl
-                             (with_dummy_pos (`TAppl (with_dummy_pos (`Var "pure"), [`Type ft; mb])),
-                              [with_dummy_pos (`FunLit (Some (List.rev args), `Unl,
-                                                       (List.rev pss, with_dummy_pos (`TupleLit vs)), `Unknown))])) in
+                          fn_appl pure_str [`Type ft; mb]
+                            [fun_lit ~args:(List.rev args) `Unl (List.rev pss)
+                                     (tuple vs)] in
                         let p, et =
                           List.fold_right
                             (fun arg (base, ft) ->
                                let arg_type = List.hd (TypeUtils.arg_types ft) in
                                let ft = TypeUtils.return_type ft in
                                let base : phrase =
-                                 with_dummy_pos (`FnAppl
-                                  (with_dummy_pos (`TAppl
-                                   (with_dummy_pos (`Var "@@@"), [`Type arg_type; `Type ft; mb])),
-                                   [arg; base]))
+                                 fn_appl atatat_str [`Type arg_type; `Type ft; mb]
+                                         [arg; base]
                                in base, ft)
                             es (base, ft)
                         in
@@ -150,19 +141,14 @@ object (o : 'self_type)
               let (o, attrexp, _) = TransformSugar.option o (fun o -> o#phrase) attrexp in
               let eff = o#lookup_effects in
               let context : phrase =
-                let var = Utility.gensym ~prefix:"_formlet_" () in
-                let (xb, x) = (make_binder var (Types.xml_type) dp), (with_dummy_pos (`Var var)) in
-                  with_dummy_pos
-                    (`FunLit (Some [Types.make_tuple_type [Types.xml_type], eff],
-                            `Unl,
-                            ([[with_dummy_pos (`Variable xb)]],
-                               with_dummy_pos (`Xml (tag, attrs, attrexp, [with_dummy_pos (`Block ([], x))]))), `Unknown)) in
-              let (o, e, t) = o#formlet_body (with_dummy_pos (`Xml ("#", [], None, contents))) in
-                (o,
-                 `FnAppl
-                   (with_dummy_pos (`TAppl (with_dummy_pos (`Var "plug"), [`Type t; `Row eff])),
-                    [context; e]),
-                 t)
+                let name = Utility.gensym ~prefix:"_formlet_" () in
+                fun_lit ~args:[Types.make_tuple_type [Types.xml_type], eff]
+                        `Unl
+                        [[variable_pat ~ty:(Types.xml_type) name]]
+                        (xml tag attrs attrexp [block ([], var name)]) in
+              let (o, e, t) = o#formlet_body (xml "#" [] None contents) in
+                (o, fn_appl_node plug_str [`Type t; `Row eff]
+                      [context; e], t)
           | _ -> assert false
 
   method formlet_body : Sugartypes.phrase -> ('self_type * Sugartypes.phrase * Types.datatype) =
@@ -182,17 +168,17 @@ object (o : 'self_type)
         let pss =
           match ps with
             | [p] -> [[p]]
-            | _ -> [[with_dummy_pos (`Tuple ps)]] in
+            | _ -> [[tuple_pat ps]] in
 
         let arg_type = Types.make_tuple_type ts in
         let mb = `Row (o#lookup_effects) in
 
         let e =
-          `FnAppl
-            (with_dummy_pos (`TAppl (with_dummy_pos (`Var "@@@"), [`Type arg_type; `Type yields_type; mb])),
-             [body; with_dummy_pos (`FnAppl (with_dummy_pos (`TAppl (with_dummy_pos (`Var "pure"),
-                    [`Type (`Function (Types.make_tuple_type [arg_type], empty_eff, yields_type)); mb])),
-                      [with_dummy_pos (`FunLit (Some [Types.make_tuple_type [arg_type], empty_eff], `Unl, (pss, yields), `Unknown))]))])
+          fn_appl_node atatat_str
+             [`Type arg_type; `Type yields_type; mb]
+             [body; fn_appl pure_str
+                    [`Type (`Function (Types.make_tuple_type [arg_type], empty_eff, yields_type)); mb]
+                    [fun_lit ~args:[Types.make_tuple_type [arg_type], empty_eff] `Unl pss yields]]
         in
           (o, e, Instantiate.alias "Formlet" [`Type yields_type] tycon_env)
     | e -> super#phrasenode e

--- a/core/desugarHandlers.ml
+++ b/core/desugarHandlers.ml
@@ -1,5 +1,6 @@
 open Utility
 open Sugartypes
+open SugarConstructors.Make
 
 (*
 
@@ -42,7 +43,7 @@ let rec names : pattern -> string list
 let resolve_name_conflicts : pattern -> stringset -> pattern
   = fun pat conflicts ->
     let rec hide_names : pattern -> pattern
-      = fun pat -> with_pos pat.pos
+      = fun pat -> with_dummy_pos
          begin
           match pat.node with
           | `Variant (label, pat_opt)    -> `Variant (label, opt_map hide_names pat_opt)
@@ -83,9 +84,6 @@ let resolve_name_conflicts : pattern -> stringset -> pattern
 *)
 let parameterize : (pattern * phrase) list -> pattern list list option -> (pattern * phrase) list
   = fun cases params ->
-  let wrap_fun params body =
-    with_dummy_pos (`FunLit (None, `Unl, (params, body), `Unknown))
-  in
   match params with
     None
   | Some [] -> cases
@@ -97,16 +95,16 @@ let parameterize : (pattern * phrase) list -> pattern list list option -> (patte
          StringSet.inter (StringSet.from_list pat_names) (StringSet.from_list param_names)
        in
        let params = List.map (List.map (fun p -> resolve_name_conflicts p name_conflicts)) params in
-       (pat, wrap_fun params body)
+       (pat, fun_lit `Unl params body)
      ) cases
 
 
 (* This function assigns fresh names to `Any (_) *)
 let rec deanonymize : pattern -> pattern
-  = fun pat -> with_pos pat.pos
+  = fun pat -> with_dummy_pos
      begin
       match pat.node with
-        `Any                         -> `Variable (make_untyped_binder (with_dummy_pos (Utility.gensym ~prefix:"dsh" ())))
+        `Any                         -> `Variable (binder (Utility.gensym ~prefix:"dsh" ()))
       | `Nil                         -> `Nil
       | `Cons (p, p')                -> `Cons (deanonymize p, deanonymize p')
       | `List ps                     -> `List (List.map deanonymize ps)
@@ -123,22 +121,23 @@ let rec deanonymize : pattern -> pattern
 
 (* This function translates a pattern into a phrase. It assumes that the given pattern has been deanonymised. *)
 let rec phrase_of_pattern : pattern -> phrase
-  = fun pat -> with_pos pat.pos
+  = fun pat ->
      begin
       match pat.node with
         `Any                         -> assert false (* can never happen after the fresh name generation pass *)
-      | `Nil                         -> `ListLit ([], None)
-      | `Cons (hd, tl)               -> `InfixAppl (([], `Cons), phrase_of_pattern hd, phrase_of_pattern tl) (* x :: xs => (phrase_of_pattern x) :: (phrase_of_pattern xs) *)
-      | `List ps                     -> `ListLit (List.map phrase_of_pattern ps, None)
+      | `Nil                         -> list []
+      | `Cons (hd, tl)               -> infix_appl' (phrase_of_pattern hd) `Cons (phrase_of_pattern tl)
+      | `List ps                     -> list (List.map phrase_of_pattern ps)
       | `Effect _                    -> assert false
-      | `Variant (name, pat_opt)     -> `ConstructorLit (name, opt_map phrase_of_pattern pat_opt, None)
-      | `Negative _                 -> failwith "desugarHandlers.ml: phrase_of_pattern case for `Negative not yet implemented!"
-      | `Record (name_pats, pat_opt) -> `RecordLit (List.map (fun (n,p) -> (n, phrase_of_pattern p)) name_pats, opt_map phrase_of_pattern pat_opt)
-      | `Tuple ps                    -> `TupleLit (List.map phrase_of_pattern ps)
-      | `Constant c                  -> `Constant c
-      | `Variable b                  -> `Var (name_of_binder b)
-      | `As (b,_)                    -> `Var (name_of_binder b)
-      | `HasType (p,t)               -> `TypeAnnotation (phrase_of_pattern p, t)
+      | `Variant (name, pat_opt)     -> constructor name ?body:(opt_map phrase_of_pattern pat_opt)
+      | `Negative _                  -> failwith "desugarHandlers.ml: phrase_of_pattern case for `Negative not yet implemented!"
+      | `Record (name_pats, pat_opt) -> record (List.map (fun (n,p) -> (n, phrase_of_pattern p)) name_pats)
+                                               ?exp:(opt_map phrase_of_pattern pat_opt)
+      | `Tuple ps                    -> tuple (List.map phrase_of_pattern ps)
+      | `Constant c                  -> constant c
+      | `Variable b                  -> var (name_of_binder b)
+      | `As (b,_)                    -> var (name_of_binder b)
+      | `HasType (p,t)               -> with_dummy_pos (`TypeAnnotation (phrase_of_pattern p, t))
      end
 
 (* This function applies the list of parameters to the generated handle. *)
@@ -160,20 +159,18 @@ let split_handler_cases : (pattern * phrase) list -> (pattern * phrase) list * (
     match ret with
     | [] ->
        let x = "x" in
-       let xb = make_untyped_binder (with_dummy_pos x) in
-       let id = (with_dummy_pos (`Variable xb), (with_dummy_pos (`Var x))) in
+       let id = (variable_pat x, var x) in
        ([id], List.rev ops)
     | _ ->
        (List.rev ret, List.rev ops)
 
 let funlit_of_handlerlit : Sugartypes.handlerlit -> Sugartypes.funlit
   = fun (depth, m, cases, params) ->
-    let pos = m.pos in
     let m    = deanonymize m in
-    let comp = with_pos pos (`FnAppl (phrase_of_pattern m, [])) in
+    let comp = with_dummy_pos (`FnAppl (phrase_of_pattern m, [])) in
     let cases = parameterize cases params in
     let hndlr = SugarConstructors.Make.untyped_handler comp cases depth in
-    let handle = with_pos pos (`Block ([], (with_pos pos (`Handle hndlr)))) in
+    let handle = block ([], (with_dummy_pos (`Handle hndlr))) in
     let params = opt_map (List.map (List.map deanonymize)) params in
     let body  =
       match params with
@@ -188,16 +185,15 @@ let funlit_of_handlerlit : Sugartypes.handlerlit -> Sugartypes.funlit
         Some params -> params @ ([m] :: fnparams)
       | None -> [m] :: fnparams
     in
-    let fnlit = (fnparams, body) in
-    fnlit
+    (fnparams, body)
 
 let desugar_handlers_early =
 object
   inherit SugarTraversals.map as super
   method! phrasenode = function
     | `HandlerLit hnlit ->
-       let fnlit = funlit_of_handlerlit hnlit in
-       let funlit : Sugartypes.phrasenode = `FunLit (None, `Unl, fnlit, `Unknown) in
+       let (fnparams, body) = funlit_of_handlerlit hnlit in
+       let funlit : Sugartypes.phrasenode = (fun_lit `Unl fnparams body).node in
        super#phrasenode funlit
     | e -> super#phrasenode e
 
@@ -205,13 +201,13 @@ object
     match node with
     | `Handle h ->
        let (val_cases, eff_cases) = split_handler_cases h.sh_effect_cases in
-       with_pos pos (`Handle { h with sh_effect_cases = eff_cases;
-                                      sh_value_cases  = val_cases })
+       with_dummy_pos (`Handle { h with sh_effect_cases = eff_cases;
+                                        sh_value_cases  = val_cases })
     | _ -> super#phrase {node; pos}
 
   method! bindingnode = function
     | `Handler (binder, hnlit, annotation) ->
        let fnlit  = funlit_of_handlerlit hnlit in
-       `Fun (binder, `Unl, ([], fnlit), `Unknown, annotation)
+       (fun_binding' ?annotation binder fnlit).node
     | b -> super#bindingnode b
 end

--- a/core/desugarProcesses.ml
+++ b/core/desugarProcesses.ml
@@ -1,5 +1,6 @@
 open Utility
 open Sugartypes
+open SugarConstructors.Make
 
 (*
    spawn {e}
@@ -28,9 +29,8 @@ object (o : 'self_type)
         let o = o#with_effects outer_eff in
 
         let e : phrasenode =
-          `FnAppl
-            (with_dummy_pos (`TAppl (with_dummy_pos (`Var "spawnWait"), [`Row inner_eff; `Type body_type; `Row outer_eff])),
-             [with_dummy_pos (`FunLit (Some [(Types.make_tuple_type [], inner_eff)], `Unl, ([[]], body), `Unknown))])
+          fn_appl_node "spawnWait" [`Row inner_eff; `Type body_type; `Row outer_eff]
+            [fun_lit ~args:[(Types.make_tuple_type [], inner_eff)] `Unl [[]] body]
         in
           (o, e, body_type)
     | `Spawn (k, spawn_loc, body, Some inner_eff) ->
@@ -47,10 +47,8 @@ object (o : 'self_type)
         let spawn_loc_phr =
           match spawn_loc with
             | `ExplicitSpawnLocation phr -> phr
-            | `SpawnClient -> with_dummy_pos (`FnAppl (with_dummy_pos (`Var "there"),
-                                                      [with_dummy_pos (`TupleLit [])]))
-            | `NoSpawnLocation -> with_dummy_pos (`FnAppl (with_dummy_pos (`Var "here"),
-                                                          [with_dummy_pos (`TupleLit [])])) in
+            | `SpawnClient -> fn_appl "there" [] [tuple []]
+            | `NoSpawnLocation -> fn_appl "here" [] [tuple []] in
 
         let spawn_fun =
           match k with
@@ -63,12 +61,9 @@ object (o : 'self_type)
          * corresponded to the spawn type. *)
 
         let e : phrasenode =
-          `FnAppl
-            (with_dummy_pos (`TAppl (with_dummy_pos (`Var spawn_fun),
-                                     [`Row inner_eff; `Type body_type; `Row outer_eff])),
-             [with_dummy_pos (`FunLit (Some [(Types.make_tuple_type [], inner_eff)],
-                                       `Unl, ([[]], body), `Unknown));
-              spawn_loc_phr])
+          fn_appl_node spawn_fun [`Row inner_eff; `Type body_type; `Row outer_eff]
+             [fun_lit ~args:[(Types.make_tuple_type [], inner_eff)] `Unl [[]] body;
+              spawn_loc_phr]
         in
           (o, e, process_type)
     | `Receive (cases, Some t) ->
@@ -78,10 +73,7 @@ object (o : 'self_type)
             match StringMap.find "hear" fields with
               | (`Present mbt) ->
                   o#phrasenode
-                    (`Switch (with_dummy_pos
-                     (`FnAppl (with_dummy_pos
-                      (`TAppl (with_dummy_pos (`Var "recv"), [`Type mbt; `Row other_effects])),
-                               [])),
+                    (`Switch (fn_appl "recv" [`Type mbt; `Row other_effects] [],
                               cases,
                               Some t))
               | _ -> assert false

--- a/core/desugarRegexes.ml
+++ b/core/desugarRegexes.ml
@@ -1,64 +1,67 @@
 open Sugartypes
+open SugarConstructors.Make
 
-let desugar_repeat regex_type : Regex.repeat -> phrasenode = function
-  | Regex.Star      -> `ConstructorLit ("Star"     , None, Some regex_type)
-  | Regex.Plus      -> `ConstructorLit ("Plus"     , None, Some regex_type)
-  | Regex.Question  -> `ConstructorLit ("Question" , None, Some regex_type)
+(* String constants used in regular expressions.  These should probably be
+   reused in linksregexes.ml *)
+let range_str        = "Range"
+let simply_str       = "Simply"
+let quote_str        = "Quote"
+let any_str          = "Any"
+let start_anchor_str = "StartAnchor"
+let end_anchor_str   = "EndAnchor"
+let seq_str          = "Seq"
+let alternative_str  = "Alternate"
+let group_str        = "Group"
+let repeat_str       = "Repeat"
+let replace_str      = "Replace"
+let star_str         = "Star"
+let plus_str         = "Plus"
+let question_str     = "Question"
 
-let desugar_regex phrase regex_type pos : regex -> phrasenode =
+let desugar_regex phrase regex_type regex : phrase =
   (* Desugar a regex, making sure that only variables are embedded
      within.  Any expressions that are spliced into the regex must be
      let-bound beforehand.  *)
+  let constructor' ?body name = constructor name ?body ~ty:regex_type in
+  let desugar_repeat : Regex.repeat -> phrase = function
+    | Regex.Star      -> constructor' star_str
+    | Regex.Plus      -> constructor' plus_str
+    | Regex.Question  -> constructor' question_str in
   let exprs = ref [] in
   let expr e =
     let (_, e, t) = phrase e in
     let v = Utility.gensym ~prefix:"_regex_" () in
       begin
         exprs := (v, e, t) :: !exprs;
-        with_pos pos (`Var v)
+        var v
       end in
-  let rec aux : regex -> phrasenode =
+  let rec aux : regex -> phrase =
     function
-      | `Range (f, t)       -> `ConstructorLit ("Range",
-                                 Some (with_pos pos (`TupleLit [with_pos pos (`Constant (`Char f));
-                                                                with_pos pos (`Constant (`Char t))])),
-                                 Some regex_type)
-      | `Simply s           -> `ConstructorLit ("Simply", Some (with_pos pos (`Constant (`String s))), Some regex_type)
-      | `Quote s            -> `ConstructorLit ("Quote", Some (with_pos pos (aux s)), Some regex_type)
-      | `Any                -> `ConstructorLit ("Any", None, Some regex_type)
-      | `StartAnchor        -> `ConstructorLit ("StartAnchor", None, Some regex_type)
-      | `EndAnchor          -> `ConstructorLit ("EndAnchor", None, Some regex_type)
-      | `Seq rs             -> `ConstructorLit ("Seq", Some (with_pos pos (`ListLit (List.map (fun s -> with_pos pos (aux s)) rs,
-                                                                                     Some (Types.make_list_type regex_type)))),
-                                                Some regex_type)
-      | `Alternate (r1, r2) -> `ConstructorLit ("Alternate",
-                                 Some (with_pos pos (`TupleLit [ with_pos pos (aux r1)
-                                                               ; with_pos pos (aux r2)])),
-                                 Some regex_type)
-      | `Group s            -> `ConstructorLit ("Group", Some (with_pos pos (aux s)), Some regex_type)
-      | `Repeat (rep, r)    -> `ConstructorLit ("Repeat",
-                                 Some (with_pos pos (`TupleLit [with_pos pos (desugar_repeat regex_type rep);
-                                                                with_pos pos (aux r)])),
-                                 Some regex_type)
-      | `Splice e           -> `ConstructorLit ("Quote",
-                                 Some (with_pos pos (`ConstructorLit ("Simply", Some (expr e), Some regex_type))),
-                                 Some regex_type)
-      | `Replace (re, (`Literal tmpl)) -> `ConstructorLit("Replace",
-                                 Some (with_pos pos (`TupleLit ([with_pos pos (aux re);
-                                                                 with_pos pos (`Constant (`String tmpl))]))),
-                                 Some regex_type)
-      | `Replace (re, (`Splice e)) -> `ConstructorLit("Replace",
-                                 Some (with_pos pos (`TupleLit ([with_pos pos (aux re); expr e]))),
-                                 Some regex_type)
-  in fun e ->
-     let e = aux e in
-     `Block (List.map (fun (v, e1, t) ->
-                 (with_pos pos (`Val (with_pos pos (`Variable (make_binder v t pos)), ([], e1), `Unknown, None))))
-               !exprs,
-             with_pos pos e)
-
-let appl pos name tyargs args =
-  with_pos pos (`FnAppl (with_pos pos (tappl (`Var name, tyargs)), args))
+      | `Range (f, t) ->
+         constructor' ~body:(tuple [constant_char f; constant_char t]) range_str
+      | `Simply s           -> constructor' simply_str ~body:(constant_str s)
+      | `Quote s            -> constructor' quote_str  ~body:(aux s)
+      | `Any                -> constructor' any_str
+      | `StartAnchor        -> constructor' start_anchor_str
+      | `EndAnchor          -> constructor' end_anchor_str
+      | `Seq rs             ->
+         constructor' seq_str ~body:(list ~ty:(Types.make_list_type regex_type)
+                                          (List.map (fun s -> aux s) rs))
+      | `Alternate (r1, r2) ->
+         constructor' alternative_str ~body:(tuple [aux r1; aux r2])
+      | `Group s ->
+         constructor' group_str ~body:(aux s)
+      | `Repeat (rep, r) ->
+         constructor' repeat_str ~body:(tuple [desugar_repeat rep; aux r])
+      | `Splice e ->
+         constructor' quote_str ~body:(constructor' ~body:(expr e) simply_str)
+      | `Replace (re, (`Literal tmpl)) ->
+         constructor' replace_str ~body:(tuple [aux re; constant_str tmpl])
+      | `Replace (re, (`Splice e)) ->
+         constructor' replace_str ~body:(tuple [aux re; expr e])
+  in block (List.map (fun (v, e1, t) ->
+                val_binding (variable_pat ~ty:t v) e1) !exprs,
+            aux regex)
 
 let desugar_regexes env =
 object(self)
@@ -73,8 +76,8 @@ object(self)
           if List.exists ((=)`RegexNative) flags
           then "sntilde"
           else "stilde" in
-          self#phrase (appl pos libfn tyargs
-                            [e1; {node=desugar_regex self#phrase regex_type pos r; pos}])
+          self#phrase (fn_appl libfn tyargs
+                            [e1; desugar_regex self#phrase regex_type r])
     | `InfixAppl ((tyargs, `RegexMatch flags), e1, {node=`Regex r; _}) ->
         let nativep = List.exists ((=) `RegexNative) flags
         and listp   = List.exists ((=) `RegexList)   flags in
@@ -83,8 +86,8 @@ object(self)
           | true, false  -> "ltilde"
           | false, false -> "tilde"
           | false, true  -> "ntilde" in
-          self#phrase (appl pos libfn tyargs
-                            [e1; {node=desugar_regex self#phrase regex_type pos r; pos}])
+          self#phrase (fn_appl libfn tyargs
+                            [e1; desugar_regex self#phrase regex_type r])
     | `InfixAppl ((_tyargs, `RegexMatch _), _, _) ->
         raise (Errors.SugarError (pos, "Internal error: unexpected rhs of regex operator"))
     | _ -> super#phrase ph

--- a/core/sugarConstructors.mli
+++ b/core/sugarConstructors.mli
@@ -6,8 +6,5 @@ module type SugarConstructorsSig = SugarConstructorsIntf.SugarConstructorsSig
 module SugarConstructors (Position : Pos)
        : (SugarConstructorsSig with type t := Position.t)
 
-(* Modules for making nodes using various types of positions. *)
-module Make : (SugarConstructorsSig
-               with type t := (SourceCode.lexpos * SourceCode.lexpos *
-                               SourceCode.source_code option))
-module DummyMake : (SugarConstructorsSig with type t := unit)
+(* Module for making nodes using Sugartypes positions. *)
+module Make : (SugarConstructorsSig with type t := unit)

--- a/core/sugartypes.ml
+++ b/core/sugartypes.ml
@@ -26,8 +26,6 @@ let name_of_binder     {node=(n,_ );_} = n
 let type_of_binder     {node=(_,ty);_} = ty
 let type_of_binder_exn {node=(_,ty);_} =
   OptionUtils.val_of ty (* raises exception when ty = None *)
-let make_binder         n ty pos                 = with_pos pos (n   , Some ty)
-let make_untyped_binder {node;pos}               = with_pos pos (node, None   )
 let set_binder_name   {node=(_   ,ty); pos} name = with_pos pos (name, ty     )
 let set_binder_type   {node=(name,_ ); pos} ty   = with_pos pos (name, Some ty)
 let erase_binder_type {node=(name,_ ); pos}      = with_pos pos (name, None   )


### PR DESCRIPTION
This is a refactoring of desugar* modules in an attempt to cut down on clutter by using smart constructors. It addresses #421 and #423. 

For example, code that previously looked like this:

```OCaml
with_pos (`FnAppl
(with_pos (`TAppl (with_pos (`Var "plugP") pos, [`Row (o#lookup_effects)])) pos,
 [with_pos (`FunLit
             (Some ([Types.make_tuple_type [Types.xml_type], o#lookup_effects]),
              `Unl,
              ([[with_pos (`Variable (make_binder x Types.xml_type pos)) pos]],
               with_pos (`Xml (name, attrs, dynattrs,
                               [with_pos (`Block ([], with_pos (`Var x) pos)) pos])) pos), `Unknown)) pos;
  desugar_nodes pos children])) pos
```
now looks like this:
```OCaml
fn_appl "plugP" [`Row (o#lookup_effects)]
   [fun_lit ~args:[Types.make_tuple_type [Types.xml_type], o#lookup_effects]
            `Unl [[variable_pat ~ty:Types.xml_type x]]
            (xml name attrs dynattrs [block ([], var x)]);
    desugar_nodes children]
```

One important design decision is handling of locations in desugar modules. I assumed that since locations are meant to correspond to source code tokens they can only be meaningfully constructed by the parser. Therefore the `SugarConstructors.Make` module allows to attach only dummy positions to nodes:

```OCaml
module SugartypesPosition : Pos with type t = unit = struct
  type t = unit
  let pos ()           = Sugartypes.dummy_position
  let with_pos () node = Sugartypes.with_pos Sugartypes.dummy_position node
  let dp               = ()
end
```
This module is meant to be used everywhere except for the parser, which implements its own `Pos` module. To make things easier, all smart constructors have an optional position argument with a default dummy position.

A separate thing that caught my attention during refactoring is the usage of string constants. It seems to me that in some places we rely on string typing, which is something we should probably avoid. For now in some modules I have turned string constants into let-bound identifiers. Not sure if it was worth the effort though.