### PR TITLE
[WIP]: hacky fix to issue225

### DIFF
--- a/core/parser.mly
+++ b/core/parser.mly
@@ -931,18 +931,24 @@ forall_datatype:
      Parenthesised versions take priority over non-parenthesised versions.
 */
 session_datatype:
-| BANG datatype DOT datatype                                   { `Output ($2, $4) }
-| QUESTION datatype DOT datatype                               { `Input  ($2, $4) }
+| BANG primary_datatype_loc DOT datatype                                   { `Output ($2, $4) }
+| QUESTION primary_datatype_loc DOT datatype                               { `Input  ($2, $4) }
 | LBRACKETPLUSBAR row BARPLUSRBRACKET                          { `Select $2       }
 | LBRACKETAMPBAR row BARAMPRBRACKET                            { `Choice $2       }
 | TILDE datatype                                               { `Dual $2         }
 | END                                                          { `End             }
-| primary_datatype                                             { $1               }
+| qualified_or_primary_datatype                                { $1               }
 
 parenthesized_datatypes:
 | LPAREN RPAREN                                                { [] }
-| LPAREN qualified_type_name RPAREN                            { [with_pos $loc (`QualifiedTypeApplication ($2, []))] }
+/*| LPAREN qualified_type_name RPAREN                            { [with_pos $loc (`QualifiedTypeApplication ($2, []))] }*/
 | LPAREN datatypes RPAREN                                      { $2 }
+
+qualified_or_primary_datatype:
+| LPAREN qualified_type_name RPAREN                            { `QualifiedTypeApplication ($2, []) }
+
+primary_datatype_loc:
+primary_datatype                                           { with_pos $loc $1 }
 
 primary_datatype:
 | parenthesized_datatypes                                      { match $1 with

--- a/core/parser.mly
+++ b/core/parser.mly
@@ -930,7 +930,7 @@ forall_datatype:
 
      Parenthesised versions take priority over non-parenthesised versions.
 
-   jcheney: Modified grammar to allow unparenthesized qualified type names
+   24.1.19: Modified grammar to allow unparenthesized qualified type names
    in most places, but specifically forbid in ? . or ! .
    This also requires moving the TILDE production into primary_datatype
    since otherwise, ? ~M.x . y is ambiguous.
@@ -938,8 +938,8 @@ forall_datatype:
    among several nonterminals.
 */
 session_datatype:
-| BANG primary_datatype_loc DOT datatype                       { `Output ($2, $4) }
-| QUESTION primary_datatype_loc DOT datatype                   { `Input  ($2, $4) }
+| BANG primary_datatype_pos DOT datatype                       { `Output ($2, $4) }
+| QUESTION primary_datatype_pos DOT datatype                   { `Input  ($2, $4) }
 | LBRACKETPLUSBAR row BARPLUSRBRACKET                          { `Select $2       }
 | LBRACKETAMPBAR row BARAMPRBRACKET                            { `Choice $2       }
 | END                                                          { `End             }
@@ -950,11 +950,11 @@ parenthesized_datatypes:
 | LPAREN RPAREN                                                { [] }
 | LPAREN datatypes RPAREN                                      { $2 }
 
-primary_datatype_loc:
+primary_datatype_pos:
 | primary_datatype                                             { with_pos $loc $1 }
 
 primary_datatype:
-| TILDE primary_datatype_loc                                   { `Dual $2 }
+| TILDE primary_datatype_pos                                   { `Dual $2 }
 | parenthesized_datatypes                                      { match $1 with
                                                                    | [] -> `Unit
                                                                    | [{node;_}] -> node

--- a/core/parser.mly
+++ b/core/parser.mly
@@ -931,7 +931,7 @@ forall_datatype:
      Parenthesised versions take priority over non-parenthesised versions.
 
    jcheney: Modified grammar to allow unparenthesized qualified type names
-   in most places, but specifically forbid in ? . or ! . 
+   in most places, but specifically forbid in ? . or ! .
    This also requires moving the TILDE production into primary_datatype
    since otherwise, ? ~M.x . y is ambiguous.
    This is not ideal since it spreads the session-related constructs

--- a/core/parser.mly
+++ b/core/parser.mly
@@ -935,7 +935,6 @@ session_datatype:
 | QUESTION primary_datatype_loc DOT datatype                               { `Input  ($2, $4) }
 | LBRACKETPLUSBAR row BARPLUSRBRACKET                          { `Select $2       }
 | LBRACKETAMPBAR row BARAMPRBRACKET                            { `Choice $2       }
-| TILDE datatype                                               { `Dual $2         }
 | END                                                          { `End             }
 | qualified_or_primary_datatype                                { $1               }
 
@@ -945,12 +944,14 @@ parenthesized_datatypes:
 | LPAREN datatypes RPAREN                                      { $2 }
 
 qualified_or_primary_datatype:
-| LPAREN qualified_type_name RPAREN                            { `QualifiedTypeApplication ($2, []) }
+| qualified_type_name                                          { `QualifiedTypeApplication ($1, []) }
+| primary_datatype                                             { $1 }
 
 primary_datatype_loc:
-primary_datatype                                           { with_pos $loc $1 }
+| primary_datatype                                             { with_pos $loc $1 }
 
 primary_datatype:
+| TILDE primary_datatype_loc                                   { `Dual $2 }
 | parenthesized_datatypes                                      { match $1 with
                                                                    | [] -> `Unit
                                                                    | [{node;_}] -> node

--- a/core/parser.mly
+++ b/core/parser.mly
@@ -938,8 +938,8 @@ forall_datatype:
    among several nonterminals.
 */
 session_datatype:
-| BANG primary_datatype_loc DOT datatype                                   { `Output ($2, $4) }
-| QUESTION primary_datatype_loc DOT datatype                               { `Input  ($2, $4) }
+| BANG primary_datatype_loc DOT datatype                       { `Output ($2, $4) }
+| QUESTION primary_datatype_loc DOT datatype                   { `Input  ($2, $4) }
 | LBRACKETPLUSBAR row BARPLUSRBRACKET                          { `Select $2       }
 | LBRACKETAMPBAR row BARAMPRBRACKET                            { `Choice $2       }
 | END                                                          { `End             }

--- a/core/parser.mly
+++ b/core/parser.mly
@@ -929,6 +929,13 @@ forall_datatype:
      S = !(ModuleA.ModuleB.Type).S
 
      Parenthesised versions take priority over non-parenthesised versions.
+
+   jcheney: Modified grammar to allow unparenthesized qualified type names
+   in most places, but specifically forbid in ? . or ! . 
+   This also requires moving the TILDE production into primary_datatype
+   since otherwise, ? ~M.x . y is ambiguous.
+   This is not ideal since it spreads the session-related constructs
+   among several nonterminals.
 */
 session_datatype:
 | BANG primary_datatype_loc DOT datatype                                   { `Output ($2, $4) }
@@ -936,16 +943,12 @@ session_datatype:
 | LBRACKETPLUSBAR row BARPLUSRBRACKET                          { `Select $2       }
 | LBRACKETAMPBAR row BARAMPRBRACKET                            { `Choice $2       }
 | END                                                          { `End             }
-| qualified_or_primary_datatype                                { $1               }
+| primary_datatype                                             { $1               }
+| qualified_type_name                                          { `QualifiedTypeApplication ($1, []) }
 
 parenthesized_datatypes:
 | LPAREN RPAREN                                                { [] }
-/*| LPAREN qualified_type_name RPAREN                            { [with_pos $loc (`QualifiedTypeApplication ($2, []))] }*/
 | LPAREN datatypes RPAREN                                      { $2 }
-
-qualified_or_primary_datatype:
-| qualified_type_name                                          { `QualifiedTypeApplication ($1, []) }
-| primary_datatype                                             { $1 }
 
 primary_datatype_loc:
 | primary_datatype                                             { with_pos $loc $1 }

--- a/core/parser.mly
+++ b/core/parser.mly
@@ -1139,7 +1139,7 @@ regex_pattern_sequence:
  */
 pattern:
 | typed_pattern                                                { $1 }
-| typed_pattern COLON primary_datatype                         { with_pos $loc (`HasType ($1, datatype (with_pos $loc($3) $3))) }
+| typed_pattern COLON primary_datatype_pos                         { with_pos $loc (`HasType ($1, datatype $3)) }
 
 typed_pattern:
 | cons_pattern                                                 { $1 }

--- a/tests/modules.tests
+++ b/tests/modules.tests
@@ -125,3 +125,9 @@ filemode : args
 args : -m --path=tests/modules
 stderr : ./tests/modules/constructor-test-bad.links:5: Unbound type constructor DT
 exit : 1
+
+Qualified names allowed without parentheses
+./tests/modules/qualified-type-names.links
+filemode : args
+args : -m --path=tests/modules
+stdout : () : ()

--- a/tests/modules/qualified-type-names.links
+++ b/tests/modules/qualified-type-names.links
@@ -1,0 +1,10 @@
+module One {
+  typename One = Int;
+}
+
+typename Two = One.One;
+
+sig foo : (One.One) ~> One.One
+fun foo (a) {
+  a
+}


### PR DESCRIPTION
This is an attempt to fix #225 while allowing reuse of `.` for session types and qualified types.  It is hacky and wrong, but passes all of the existing tests.

Explanation:
1. Create `primary_datatype_loc` nonterminal for primary_datatypes annotated with their location (so that their semantic actions have the same type as `datatype`)
2. Remove `qualified_type_name` from `parenthesized_datatypes` and make a new nonterminal `qualified_or_primary_datatype` that allows either a non-parenthesized `primary_datatype` or a `qualified_or_primary_datatype`.
3. Move `TILDE datatype` from `session_type` to `primary_datatype` and restrict the second component to be `primary_datatype_loc`. 

The third change was the one I was least pleased about but seems necessary to parse existing type expressions using `TILDE` conventionally on variables, such as

```
# examples/sessions/forkbomb.links
mu a.!~a.a
``` 

Restricting what goes after the datatype is necessary so that a `session_type` cannot end with a tilde'd qualified type.  That is, you still have to write 
```
~(M.x)
```
but that is what we would have had to write before this change.

TODO:
- [x] Add tests from #225 to confirm this solves original problem
- [x] Discuss alternatives / clean up hacked grammar
- [x] Remove commented-out line and add comment documenting the reason(s) for this change