### PR TITLE
Whitelist for whitespace check (Fixes #464)

### DIFF
--- a/tools/rule-check
+++ b/tools/rule-check
@@ -1,4 +1,4 @@
-#!/usr/bin/env bash
+#!/bin/bash
 #
 # Runs a series of scripts that each check whether some code invariant
 # is respected.

--- a/tools/rule-check
+++ b/tools/rule-check
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Runs a series of scripts that each check whether some code invariant
 # is respected.

--- a/tools/rules/trailing_whitespace
+++ b/tools/rules/trailing_whitespace
@@ -1,4 +1,4 @@
-#!/usr/bin/env bash
+#!/bin/bash
 #
 # Checks whether source files contain trailing script.
 #
@@ -17,25 +17,21 @@ DIRS=("core" "bin" "tests" "examples")
 # Counter to keep track of number of files with trailing white space.
 ERRORS=0
 
+
+PATTERNS=("*.ml" "*.mli" "*.mly" "*.mll" "*.py" "*.pl" "*.html" "*.js"\
+          "*.txt" "*.links" "*.css" "*.sh" "*.el" "*.vim" "*.opam"\
+          "dune-project" "dune")
+
+# https://stackoverflow.com/questions/1527049/how-can-i-join-elements-of-an-array-in-bash
+SEP=" -o -name "
+FIND_STR="$( printf "${SEP}\"%s\"" "${PATTERNS[@]}" )"
+FIND_STR="${FIND_STR:${#SEP}}"
+FIND_STR="-name $FIND_STR"
+echo ${FIND_STR}
+
 for dir in ${DIRS[@]}; do
-    for file in $(find "$dir" -type f \
-        \( -name "*.ml" -o \
-           -name "*.mli" -o \
-           -name "*.mly" -o \
-           -name "*.mll" -o \
-           -name "*.py" -o \
-           -name "*.pl" -o \
-           -name "*.html" -o \
-           -name "*.js" -o \
-           -name "*.txt" -o \
-           -name "*.links" -o \
-           -name "*.css" -o \
-           -name "*.sh" -o \
-           -name "*.el" -o \
-           -name "*.vim" -o \
-           -name "*.opam" -o \
-           -name "dune-project" -o \
-           -name "dune" \) -exec egrep -l " +$" {} \;); do
+    for file in $(eval "find \""$dir"\" -type f \( ${FIND_STR} \) \
+      -exec egrep -l \" +$\" {} \;"); do
           echo -n "$file"
           if [[ $STRIP -eq 1 ]]; then
               echo -n "..."

--- a/tools/rules/trailing_whitespace
+++ b/tools/rules/trailing_whitespace
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Checks whether source files contain trailing script.
 #

--- a/tools/rules/trailing_whitespace
+++ b/tools/rules/trailing_whitespace
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 #
-# Checks whether source files contain trailing script.
+# Checks whether any textual files contain trailing whitespace.
 #
 # By passing the argument "strip" the script attempts to automatically
 # strip trailing white space.

--- a/tools/rules/trailing_whitespace
+++ b/tools/rules/trailing_whitespace
@@ -18,21 +18,38 @@ DIRS=("core" "bin" "tests" "examples")
 ERRORS=0
 
 for dir in ${DIRS[@]}; do
-    for file in $(find "$dir"  -type f -not -name "*.pdf" -exec egrep -l " +$" {} \;); do
-        echo -n "$file"
-        if [[ $STRIP -eq 1 ]]; then
-            echo -n "..."
-            sed -i 's/[ \t]*$//' $file
-            if [[ $? -eq 0 ]]; then
-                echo " CLEANED."
-            else
-                echo " FAILED."
-                ERRORS=$((ERRORS+1))
-            fi
-        else
-            echo ""
-            ERRORS=$((ERRORS+1))
-        fi
+    for file in $(find "$dir" -type f \
+        \( -name "*.ml" -o \
+           -name "*.mli" -o \
+           -name "*.mly" -o \
+           -name "*.mll" -o \
+           -name "*.py" -o \
+           -name "*.pl" -o \
+           -name "*.html" -o \
+           -name "*.js" -o \
+           -name "*.txt" -o \
+           -name "*.links" -o \
+           -name "*.css" -o \
+           -name "*.sh" -o \
+           -name "*.el" -o \
+           -name "*.vim" -o \
+           -name "*.opam" -o \
+           -name "dune-project" -o \
+           -name "dune" \) -exec egrep -l " +$" {} \;); do
+          echo -n "$file"
+          if [[ $STRIP -eq 1 ]]; then
+              echo -n "..."
+              sed -i 's/[ \t]*$//' $file
+              if [[ $? -eq 0 ]]; then
+                  echo " CLEANED."
+              else
+                  echo " FAILED."
+                  ERRORS=$((ERRORS+1))
+              fi
+          else
+              echo ""
+              ERRORS=$((ERRORS+1))
+          fi
     done
 done
 


### PR DESCRIPTION
This PR only checks textual files defined in a whitelist, as opposed to all files except PDFs, for trailing whitespace.

Note that due to syntactically-significant trailing whitespace in Markdown files (as identified by @dhil),`md` files are excluded from this check.

Also, I toyed with the idea of storing the whitelist in an array, but decided against this as it wasn't pleasant to programmatically build up the `find` command, and the alternative was to run the `find` command `m * n` times, where `m` is the number of directories and `n` is the number of extensions.
