### PR TITLE
Make the `End` session type linear

### DIFF
--- a/core/desugarCP.ml
+++ b/core/desugarCP.ml
@@ -5,7 +5,7 @@ open SugarConstructors.Make
 module TyEnv = Env.String
 
 let accept_str    = "accept"
-let close_str     = "close"
+let close_str     = "closeBang"
 let link_sync_str = "linkSync"
 let new_str       = "new"
 let receive_str   = "receive"

--- a/core/evalir.ml
+++ b/core/evalir.ml
@@ -483,6 +483,9 @@ struct
     | `PrimitiveFunction ("cancel", _), [chan] ->
         Session.cancel (Value.unbox_channel chan) >>= fun _ ->
         apply_cont cont env (`Record [])
+    | `PrimitiveFunction ("close", _), [chan] ->
+        Session.close (Value.unbox_channel chan);
+        apply_cont cont env (`Record [])
     (* end of session stuff *)
     | `PrimitiveFunction ("unsafeAddRoute", _), [pathv; handler; error_handler] ->
        let path = Value.unbox_string pathv in

--- a/core/lib.ml
+++ b/core/lib.ml
@@ -449,6 +449,11 @@ let env : (string * (located_primitive * Types.datatype * pure)) list = [
    datatype "forall s::Type(Any, Session).(s) ~> ()",
    IMPURE);
 
+  "close",
+  (`PFun (fun _ -> assert false),
+   datatype "(End) ~> ()",
+   IMPURE);
+
   (* Lists and collections *)
   "Nil",
   (`List [],

--- a/core/proc.mli
+++ b/core/proc.mli
@@ -163,6 +163,8 @@ sig
 
   val get_buffer : channel_id -> (Value.t list) option
 
+  val close : chan -> unit
+
 end
 
 module rec Websockets : WEBSOCKETS

--- a/core/types.ml
+++ b/core/types.ml
@@ -720,7 +720,7 @@ let rec type_can_be_unl : var_set * var_set -> typ -> bool =
     | `MetaTypeVar point -> point_can_be_unl type_can_be_unl vars point
     | `ForAll (qs, t) -> type_can_be_unl (rec_vars, add_quantified_vars !qs quant_vars) t
     | `Dual s -> type_can_be_unl vars s
-    | `End -> true
+    | `End -> false
     | #session_type -> false
 and field_can_be_unl vars =
   function

--- a/examples/distribution/clientToClientDeleg.links
+++ b/examples/distribution/clientToClientDeleg.links
@@ -5,9 +5,9 @@ module Client1 {
 
   fun go(ap) {
     debug("Got send end of delegation channel");
-    var recvEnd = fork(fun(s) { var s = send(2, send(1, s)); sleep(2000); ignore(send(3, s)) });
+    var recvEnd = fork(fun(s) { var s = send(2, send(1, s)); sleep(2000); close(send(3, s)) });
     var delegSess = request(ap);
-    var _ = send(recvEnd, delegSess);
+    close(send(recvEnd, delegSess));
     debug("Delegated receive end of session to server")
   }
 
@@ -24,13 +24,15 @@ module Client2 {
   fun go(ap) {
     var delegS = accept(ap);
     debug("Got receive end of delegation channel");
-    var (s, _) = receive(delegS);
+    var (s, t) = receive(delegS);
+    close(t);
     debug("Got delegated channel");
     var (x1, s) = receive(s);
     debug (intToString(x1));
     var (x2, s) = receive(s);
     debug (intToString(x2));
     var (x3, s) = receive(s);
+    close(s);
     debug (intToString(x3));
     go(ap)
   }

--- a/examples/distribution/clientToServerDeleg.links
+++ b/examples/distribution/clientToServerDeleg.links
@@ -5,9 +5,9 @@ module Client {
 
   fun go(ap) {
     debug("Got send end of delegation channel");
-    var recvEnd = fork(fun(s) {  ignore(send(3, send(2, send(1, s)))) });
+    var recvEnd = fork(fun(s) {  close(send(3, send(2, send(1, s)))) });
     var delegSess = request(ap);
-    var _ = send(recvEnd, delegSess);
+    var _ = close(send(recvEnd, delegSess));
     debug("Delegated receive end of session to server")
   }
 
@@ -24,13 +24,15 @@ module Server {
   fun go(ap) {
     var delegS = accept(ap);
     debug("Got receive end of delegation channel");
-    var (s, _) = receive(delegS);
+    var (s, t) = receive(delegS);
+    close(t);
     debug("Got delegated channel");
     var (x1, s) = receive(s);
     debug (intToString(x1));
     var (x2, s) = receive(s);
     debug (intToString(x2));
     var (x3, s) = receive(s);
+    close(s);
     debug (intToString(x3));
     go(ap)
   }

--- a/examples/sessions/Elvina/Bookshop_1.links
+++ b/examples/sessions/Elvina/Bookshop_1.links
@@ -16,7 +16,7 @@ fun waitForClient(s) client
 			appendChildren(stringToXml(", card number received: " ^^ intToString(card)), getNodeById("items"));
 			var (address, s) = receive(s);
 			appendChildren(stringToXml(", address received: " ^^ address), getNodeById("items"));
-			()
+			close(s)
 	}
 }
 
@@ -24,8 +24,8 @@ sig orderBooks : (ShopSelect) ~> ()
 fun orderBooks(c) client
 {
 	var c = send("Alice in Wonderland", select Add c);
-	var _ = send("Summerhall Square", send(8753, select Checkout c));
-	()
+	var c = send("Summerhall Square", send(8753, select Checkout c));
+	close(c)
 }
 
 sig main : () ~> ()

--- a/examples/sessions/Elvina/Bookshop_2.links
+++ b/examples/sessions/Elvina/Bookshop_2.links
@@ -21,7 +21,7 @@ fun waitForClient(s) client
 			appendChildren(stringToXml("card number received: " ^^ intToString(card)), getNodeById("items"));
 			var (address, s) = receive(s);
 			appendChildren(stringToXml(", address received: " ^^ address), getNodeById("items"));
-			()
+			close(s)
 	}
 }
 
@@ -29,8 +29,7 @@ sig waitForSon : (SonSelect) ~> ()
 fun waitForSon(c) client
 {
 	offer(c) {
-		case Choice(c) -> var c = send("Children's Book", c);
-				  ()
+		case Choice(c) -> close(send("Children's Book", c));
 	}
 }
 
@@ -38,6 +37,7 @@ sig getSonBook : (SonOffer) ~> (String)
 fun getSonBook(s) client
 {
 	var (choice, s) = receive(select Choice s);
+  close(s);
 	choice
 }
 
@@ -52,8 +52,7 @@ fun orderBooks(c) client
 
 	# Add son's choice.
 	var c = send(choice, select Add c);
-	var _ = send("Summerhall Square", send(8753, select Checkout c));
-    ()
+	close(send("Summerhall Square", send(8753, select Checkout c)))
 }
 
 sig main : () ~> ()

--- a/examples/sessions/Elvina/Bookshop_3.links
+++ b/examples/sessions/Elvina/Bookshop_3.links
@@ -55,8 +55,7 @@ case Checkout(s) ->
 	var (addressFull, s) = shipper(s);	# Contact shipper, send it the channel to receive address.
 
 	var summary = summariseOrder(card, addressFull, orderedProducts, removedProducts);
-	var _ = send(summary, s);
-	()
+	close(send(summary, s));
 	}
 }
 
@@ -115,8 +114,7 @@ sig waitForSon : (SonSelect) ~> ()
 fun waitForSon(c) client
 {
 	offer(c) {
-		case Choice(c) -> var c = send(Gadget("LED Water Speakers"), c);
-		()
+		case Choice(c) -> close(send(Gadget("LED Water Speakers"), c))
 	}
 }
 
@@ -125,6 +123,7 @@ sig getSonBook : (SonOffer) ~> (Product)
 fun getSonBook(s) client
 {
 	var (choice, s) = receive(select Choice s);
+  close(s);
 	choice
 }
 
@@ -150,6 +149,7 @@ fun orderBooks(c) client
 
 	var c = send(myAddress, send(8753, select Checkout c));
 	var (summary, c) = receive(c);
+  close(c);
 	summary
 }
 

--- a/examples/sessions/Elvina/Extended_Calculator.links
+++ b/examples/sessions/Elvina/Extended_Calculator.links
@@ -7,35 +7,32 @@ fun calc(s) client {
     case Add(s) ->
       var (x,s) = receive(s);
       var (y,s) = receive(s);
-      var _ = send(x+y,s);
-      ()
+      close(send(x+y,s));
     case Mul(s) ->
       var (x,s) = receive(s);
       var (y,s) = receive(s);
-      var _ = send(x*y,s);
-      ()
+      close(send(x*y,s));
 
     case Sub(s) ->
       var (x,s) = receive(s);
       var (y,s) = receive(s);
-      var _ = send(y-x,s);
-      ()
+      close(send(y-x,s))
     case Div(s) ->
       var (x,s) = receive(s);
       var (y,s) = receive(s);
-      var _ = send(y/x,s);
-      ()
+      close(send(y/x,s))
   }
 }
 
 sig user : (CalcSelect, Int, Int, String) ~> Int
 fun user(s, op1, op2, operation) client {
+  fun recvAndClose(s) { var (x, s) = receive(s); close(s); x}
 
 	switch(operation) {
-		case "add" ->  { var s = select Add s; receive(send(op1,send(op2,s))).1 }
-		case "mult" -> { var s = select Mul s; receive(send(op1,send(op2,s))).1 }
-		case "sub" -> { var s = select Sub s; receive(send(op1,send(op2,s))).1 }
-		case "div" -> { var s = select Div s; receive(send(op1,send(op2,s))).1 }
+		case "add" ->  { var s = select Add s; recvAndClose(send(op1,send(op2,s))) }
+		case "mult" -> { var s = select Mul s; recvAndClose(send(op1,send(op2,s))) }
+		case "sub" -> { var s = select Sub s; recvAndClose(send(op1,send(op2,s))) }
+		case "div" -> { var s = select Div s; recvAndClose(send(op1,send(op2,s))) }
 	}
 }
 

--- a/examples/sessions/ap-multi-client.links
+++ b/examples/sessions/ap-multi-client.links
@@ -9,7 +9,7 @@ fun giver(x, y, a, b) client {
   var s = request(a);
   var z = receive(send(y,send(x,s))).1;
   var t = accept(b);
-  ignore(send(z, t));
+  close(send(z, t));
 }
 
 fun main() client {
@@ -19,8 +19,10 @@ fun main() client {
   var c = new ();
   var _ = spawn { giver(6, 7, a, b) };
   var _ = spawn { giver(8, 9, a, c) };
-  var x = receive(request(b)).1;
-  var y = receive(request(c)).1;
+  var (x, s) = receive(request(b));
+  close(s);
+  var (y, s) = receive(request(c));
+  close(s);
 
   page
     <html><body>

--- a/examples/sessions/atm.links
+++ b/examples/sessions/atm.links
@@ -14,7 +14,7 @@ fun atm(balance, c) {
   if(check(card, pin)) {
     menu(card, balance, select Accept c)
   } else {
-    ignore(send(card, select Reject c))
+    close(send(card, select Reject c))
   }
 }
 
@@ -24,12 +24,12 @@ fun menu(card, balance, c) {
     case Withdraw(c) ->
       var (amount, c) = receive(c);
       if(amount <= balance) {
-        ignore(send(amount, send(card, select Accept c)))
+        close(send(amount, send(card, select Accept c)))
       } else {
-        ignore(send(card, select Reject c))
+        close(send(card, select Reject c))
       }
     case Balance(c) ->
-      ignore(send(card, send(balance, c)))
+      close(send(card, send(balance, c)))
   }
 }
 
@@ -44,11 +44,15 @@ fun user1(c) {
     case Accept(c) ->
       offer (send (16, select Withdraw c)) {
         case Accept(c) -> var (card, c) = receive(c);
-                          var (cash, c) = receive(c); cash
-        case Reject(c) -> var (card, c) = receive(c); 0
+                          var (cash, c) = receive(c);
+                          close(c);
+                          cash
+        case Reject(c) -> var (card, c) = receive(c);
+                          close(c);
+                          0
       }
     case Reject(c) ->
-      var (card, c) = receive(c); 0
+      var (card, c) = receive(c); close(c); 0
   }
 }
 
@@ -58,11 +62,14 @@ fun user2(c) {
     case Accept(c) ->
       offer (send (16, select Withdraw c)) {
         case Accept(c) -> var (card, c) = receive(c);
-                          var (cash, c) = receive(c); cash
-        case Reject(c) -> var (card, c) = receive(c); 0
+                          var (cash, c) = receive(c);
+                          close(c);
+                          cash
+        case Reject(c) -> var (card, c) = receive(c);
+                          close(c); 0
       }
     case Reject(c) ->
-      var (card, c) = receive(c); 0
+      var (card, c) = receive(c); close(c); 0
   }
 }
 
@@ -71,9 +78,9 @@ fun user3(c) {
   offer (send(1024, send(16777216, c))) {
     case Accept(c) ->
       var (balance, c) = receive(select Balance c);
-      var (card, c) = receive(c); Just(balance)
+      var (card, c) = receive(c); close(c); Just(balance)
     case Reject(c) ->
-      var (card, c) = receive(c); Nothing
+      var (card, c) = receive(c); close(c); Nothing
   }
 }
 

--- a/examples/sessions/bookshop.links
+++ b/examples/sessions/bookshop.links
@@ -14,15 +14,15 @@ fun waitForClient(s) client {
       appendChildren(stringToXml(", card number received: " ^^ intToString(card)), getNodeById("items"));
       var (address, s) = receive(s);
       appendChildren(stringToXml(", address received: " ^^ address), getNodeById("items"));
-      ()
+      close(s)
   }
 }
 
 sig orderBooks : (~Shop) ~> ()
 fun orderBooks(c) client {
   var c = send("Alice in Wonderland", select Add c);
-  var _ = send("Summerhall Square", send(8753, select Checkout c));
-  ()
+  var c = send("Summerhall Square", send(8753, select Checkout c));
+  close(c)
 }
 
 sig main : () ~> ()

--- a/examples/sessions/bookshopAppServer.links
+++ b/examples/sessions/bookshopAppServer.links
@@ -14,15 +14,15 @@ fun waitForClient(s) client {
       appendChildren(stringToXml(", card number received: " ^^ intToString(card)), getNodeById("items"));
       var (address, s) = receive(s);
       appendChildren(stringToXml(", address received: " ^^ address), getNodeById("items"));
-      ()
+      close(s)
   }
 }
 
 sig orderBooks : (~Shop) ~> ()
 fun orderBooks(c) client {
   var c = send("Alice in Wonderland", select Add c);
-  var _ = send("Summerhall Square", send(8753, select Checkout c));
-  ()
+  var c = send("Summerhall Square", send(8753, select Checkout c));
+  close(c)
 }
 
 fun mainPage(_, clientLoc) {

--- a/examples/sessions/calc-client-server.links
+++ b/examples/sessions/calc-client-server.links
@@ -3,19 +3,21 @@ fun calc(s) {
     case Add(s) ->
       var (x,s) = receive(s);
       var (y,s) = receive(s);
-      var _ = send(x+y,s);
-      ()
+      var s = send(x+y,s);
+      close(s)
     case Mul(s) ->
       var (x,s) = receive(s);
       var (y,s) = receive(s);
-      var _ = send(x*y,s);
-      ()
+      var s = send(x*y,s);
+      close(s)
   }
 }
 
 fun user(s) {
   var s = select Mul s;
-  receive(send(6,send(7,s))).1
+  var (x, s) = receive(send(7,send(7,s)));
+  close(s);
+  x
 }
 
 fun main() server {

--- a/examples/sessions/calc-client.links
+++ b/examples/sessions/calc-client.links
@@ -3,19 +3,21 @@ fun calc(s) client {
     case Add(s) ->
       var (x,s) = receive(s);
       var (y,s) = receive(s);
-      var _ = send(x+y,s);
-      ()
+      var s = send(x+y,s);
+      close(s)
     case Mul(s) ->
       var (x,s) = receive(s);
       var (y,s) = receive(s);
-      var _ = send(x*y,s);
-      ()
+      var s = send(x*y,s);
+      close(s)
   }
 }
 
 fun user(s) client {
   var s = select Mul s;
-  receive(send(6,send(7,s))).1
+  var (x, s) = receive(send(6,send(7,s)));
+  close(s);
+  x
 }
 
 fun main() client {

--- a/examples/sessions/calc-cp.links
+++ b/examples/sessions/calc-cp.links
@@ -3,13 +3,13 @@ typename Calc = [&|Add:?Int.?Int.!Int.End, Mul:?Int.?Int.!Int.End|&];
 sig calc : (Calc) ~> ()
 fun calc(s) {
   <| offer s {
-       case Add -> s(x).s(y).s[x+y].{()}
-       case Mul -> s(x).s(y).s[x*y].{()}} |>
+       case Add -> s(x).s(y).s[x+y].{close(s)}
+       case Mul -> s(x).s(y).s[x*y].{close(s)}} |>
 }
 
 sig user : (~Calc) ~> Int
 fun user(s) {
-  <| Mul s.s[6].s[7].s(z).{z} |>
+  <| Mul s.s[6].s[7].s(z).{close(s); z} |>
 }
 
 user(fork (calc))

--- a/examples/sessions/calc.links
+++ b/examples/sessions/calc.links
@@ -6,13 +6,13 @@ fun calc(s) {
     case Add(s) ->
       var (x,s) = receive(s);
       var (y,s) = receive(s);
-      var _ = send(x+y,s);
-      ()
+      var s = send(x+y,s);
+      close(s)
     case Mul(s) ->
       var (x,s) = receive(s);
       var (y,s) = receive(s);
-      var _ = send(x*y,s);
-      ()
+      var s = send(x*y,s);
+      close(s)
   }
 }
 
@@ -20,6 +20,7 @@ sig user : (~Calc) ~> Int
 fun user(s) {
   var s = select Mul s;
   var (x, s) = receive(send(6,send(7,s)));
+  close(s);
   x
 }
 

--- a/examples/sessions/chatserver/chatClient.links
+++ b/examples/sessions/chatserver/chatClient.links
@@ -86,7 +86,8 @@ fun outgoingLoop(ap, s) {
 
   fun receiveMsg() {
     var msgChan = accept(ap);
-    var (msg, _) = receive(msgChan);
+    var (msg, s) = receive(msgChan);
+    close(s);
     msg
   }
 
@@ -112,7 +113,7 @@ fun beginChat(topic, nicks, incoming, outgoing) {
   ignore(spawn {incomingLoop(incoming)});
 
   fun chat() {
-    ignore(send(getInputContents(chatBoxId), request(ap)));
+    close(send(getInputContents(chatBoxId), request(ap)));
     clearInput(chatBoxId)
   }
 
@@ -141,7 +142,8 @@ fun connect() {
     debug("sent nick");
     offer(s) {
       case Nope(s) ->
-        println("Nickname '" ^^ nick ^^ "' already taken")
+        println("Nickname '" ^^ nick ^^ "' already taken");
+        close(s)
       case Join(s) ->
         var ((topic, nicks, incoming), s) = receive(s);
         debug("received data");

--- a/examples/sessions/chatserver/chatServer.links
+++ b/examples/sessions/chatserver/chatServer.links
@@ -23,7 +23,8 @@ fun supervisor(topic, nicks, cs) {
   var s = accept(sap);
   offer(s) {
     case Join(s) ->
-      var (d, _) = receive(s);
+      var (d, s) = receive(s);
+      close(s);
       var (name, d) = receive(d);
       switch (filter(fun (nick) {nick == name}, nicks)) {
         case [] ->
@@ -40,11 +41,12 @@ fun supervisor(topic, nicks, cs) {
             }, cs);
           supervisor(topic, name :: nicks, LinCons(workerSend, cs))
         case _ ->
-          ignore(select Nope d);
+          close(select Nope d);
           supervisor(topic, nicks, cs)
       }
     case Chat(s) ->
-      var ((nick, msg), _) = receive(s);
+      var ((nick, msg), s) = receive(s);
+      close(s);
       var cs = linMap(
         fun(c) {
           var c = select Chat c;
@@ -52,7 +54,8 @@ fun supervisor(topic, nicks, cs) {
         }, cs);
       supervisor(topic, nicks, cs)
     case NewTopic(s) ->
-      var (newTopic, _) = receive(s);
+      var (newTopic, s) = receive(s);
+      close(s);
       var cs = linMap(
         fun(c) {
           var c = select NewTopic c;
@@ -60,7 +63,8 @@ fun supervisor(topic, nicks, cs) {
         }, cs);
       supervisor(newTopic, nicks, cs)
     case Leave(s) ->
-      var (nick, _) = receive(s);
+      var (nick, s) = receive(s);
+      close(s);
       var (nicks, cs) = disconnect(nick, nicks, cs);
       var cs = linMap(
         fun(c) {
@@ -113,22 +117,22 @@ fun disconnect(nick, ns, cs) {
 
 sig join : (ChatServer) ~> ()
 fun join(c) {
-  ignore(send(c, select Join request(sap)))
+  close(send(c, select Join request(sap)))
 }
 
 sig chat : (Nickname, Message) ~> ()
 fun chat(nick, msg) {
-  ignore(send((nick, msg), select Chat request(sap)))
+  close(send((nick, msg), select Chat request(sap)))
 }
 
 sig newTopic : (Topic) ~> ()
 fun newTopic(newTopic) {
-  ignore(send(newTopic, select NewTopic request(sap)))
+  close(send(newTopic, select NewTopic request(sap)))
 }
 
 sig leave : (Nickname) ~> ()
 fun leave(nick) {
-  ignore(send(nick, select Leave request(sap)))
+  close(send(nick, select Leave request(sap)))
 }
 
 sig acceptor : () ~> ()

--- a/examples/sessions/choice.links
+++ b/examples/sessions/choice.links
@@ -3,11 +3,12 @@ typename Choice(r::Row(Any,Session)) = ?[|r|].End;
 
 #sig sel_A : Selection({A:~s|r} ~> s
 sig sel_A : forall s::Session.(![|A:s|r|].End) ~> ~s
-fun sel_A(e) {linFork (linfun (x) {ignore(send(A(x), e))})}
+fun sel_A(e) {linFork (linfun (x) {close(send(A(x), e))})}
 
 sig off : forall r::Row(Any,Session).(Choice({ | r}), ([|r|]) ~e~> a) ~e~> a
 fun off(e, f) {
-  var (x, _) = receive(e);
+  var (x, s) = receive(e);
+  close(s);
   f(x)
 }
 

--- a/examples/sessions/counter.links
+++ b/examples/sessions/counter.links
@@ -3,14 +3,15 @@ typename Counter = AP (!Int.End);
 sig counter : (Counter, Int) ~> ()
 fun counter(p, i) {
   var s = accept(p);
-  var _ = send(i, s);
+  close(send(i, s));
   counter(p, i+1)
 }
 
 sig readCounter : (Counter) ~> Int
 fun readCounter(p) {
   var c = request(p);
-  receive(c).1
+  var (x, s) = receive(c);
+  close(s); x
 }
 
 sig user : (Int, Counter, Process ({hear:(Int, (Int, Int))|_})) ~> ()
@@ -35,3 +36,4 @@ fun main() {
 }
 
 spawnWait { main() }
+

--- a/examples/sessions/mind/mindClient.links
+++ b/examples/sessions/mind/mindClient.links
@@ -168,12 +168,14 @@ sig outgoingLoop : (AP(Outgoing), ClientSend) ~> ()
 fun outgoingLoop(ap, s) {
   offer(accept(ap)) {
     case Chat(c) ->
-      var (msg, _) = receive(c);
+      var (msg, c) = receive(c);
+      close(c);
       var s = select Chat s;
       var s = send(msg, s);
       outgoingLoop(ap, s)
     case Play(c) ->
-      var(card, _) = receive(c);
+      var (card, c) = receive(c);
+      close(c);
       var s = send(card, select Play s);
       var (status, s) = receive(s);
       # ignore the status (we will be informed if the play actually
@@ -193,12 +195,12 @@ fun beginChat(st, incoming, outgoing) {
   ignore(spawn {incomingLoop(st, incoming)});
 
   fun chat() {
-    ignore(send(getInputContents(chatBoxId), select Chat (request(ap))));
+    close(send(getInputContents(chatBoxId), select Chat (request(ap))));
     clearInput(chatBoxId)
   }
 
   fun play(card) {
-    ignore(send(card, select Play (request(ap))))
+    close(send(card, select Play (request(ap))))
   }
 
   fun playButton(card) {
@@ -239,7 +241,8 @@ fun connect() {
     debug("sent nick");
     offer(s) {
       case Nope(s) ->
-        println("Nickname '" ^^ nick ^^ "' already taken")
+        println("Nickname '" ^^ nick ^^ "' already taken");
+        close(s)
       case Join(s) ->
         var ((numPlayers, cards, players, incoming), s) = receive(s);
         debug("received data");

--- a/examples/sessions/mind/mindServer.links
+++ b/examples/sessions/mind/mindServer.links
@@ -55,14 +55,15 @@ fun supervisor(st, cs) {
   var s = accept(sap);
   offer(s) {
     case Join(s) ->
-      var (d, _) = receive(s);
+      var (d, s) = receive(s);
+      close(s);
       var (name, d) = receive(d);
       switch (filter(fun ((nick, _)) {nick == name}, st.players)) {
         case [] ->
           if (st.mode <> Waiting || length(st.players) >= numPlayers || length(st.pack) < level) {
             debug("full quota of players");
             # full quota of players / no more cards
-            ignore(select Nope d);
+            close(select Nope d);
             supervisor(st, cs)
           } else {
             var hand = sortBy(id, take(level, st.pack));
@@ -85,11 +86,12 @@ fun supervisor(st, cs) {
           }
         case _ ->
           # nickname already registered
-          ignore(select Nope d);
+          close(select Nope d);
           supervisor(st, cs)
       }
     case Chat(s) ->
-      var ((nick, msg), _) = receive(s);
+      var ((nick, msg), s) = receive(s);
+      close(s);
       var cs = linMap(
         fun(c) {
           var c = select Chat c;
@@ -100,7 +102,7 @@ fun supervisor(st, cs) {
       var ((nick, card), s) = receive(s);
       var hand = assoc(nick, st.players);
       if (st.mode == Playing && elem(card, hand)) {
-        ignore(send(true, s));
+        close(send(true, s));
         var newHand = filter (fun (i) {i <> card}, hand);
         var players = map (fun ((name, hand)) {
                              if (nick == name) {(nick, newHand)}
@@ -114,11 +116,12 @@ fun supervisor(st, cs) {
         var mode = if (st.lastCard >= card) {Done} else {Playing};
         supervisor((st with lastCard=card, mode=mode, players=players), cs)
       } else {
-        ignore(send(false, s));
+        close(send(false, s));
         supervisor(st, cs)
       }
     case Leave(s) ->
-      var (nick, _) = receive(s);
+      var (nick, s) = receive(s);
+      close(s);
       var (_, cs) = disconnect(nick, st.players, cs);
       var st = if (empty(assoc(nick, st.players))) {
                  st
@@ -175,23 +178,24 @@ fun disconnect(nick, players, cs) {
 
 sig join : (ChatServer) ~> ()
 fun join(c) {
-  ignore(send(c, select Join request(sap)))
+  close(send(c, select Join request(sap)))
 }
 
 sig chat : (Nickname, Message) ~> ()
 fun chat(nick, msg) {
-  ignore(send((nick, msg), select Chat request(sap)))
+  close(send((nick, msg), select Chat request(sap)))
 }
 
 sig play : (Nickname, Int) ~> Bool
 fun play(nick, card) {
-  var (status, _) = receive(send((nick, card), select Play request(sap)));
+  var (status, s) = receive(send((nick, card), select Play request(sap)));
+  close(s);
   status
 }
 
 sig leave : (Nickname) ~> ()
 fun leave(nick) {
-  ignore(send(nick, select Leave request(sap)))
+  close(send(nick, select Leave request(sap)))
 }
 
 sig acceptor : () ~> ()

--- a/examples/sessions/pi.links
+++ b/examples/sessions/pi.links
@@ -11,13 +11,15 @@ fun newChannel(p)() {
 
 sig sendChannel : (Channel, Channel, (Channel, Channel) {}~> Proc) {}~> Proc
 fun sendChannel(c, d, p)() {
-  ignore(send(c, accept(d)));
+  close(send(c, accept(d)));
   p(c, d)()
 }
 
 sig receiveChannel : (Channel, (Channel, Channel) {}~> Proc) {}~> Proc
 fun receiveChannel(d, p)() {
-  p(d, receive(request(d)).1)()
+  var (x, s) = receive(request(d));
+  close(s);
+  p(d, x)()
 }
 
 sig par : (Proc, Proc) {}~> Proc
@@ -41,7 +43,10 @@ fun repeat(p)() {
 sig repeatReceive : (Channel, (Channel, Channel) {}~> Proc) {}~> Proc
 fun repeatReceive(d, p)() {
   var s = request(d);
-  var _ = spawn {p(d, receive(s).1)()};
+  var _ = spawn {
+    var (x, s) = receive(s);
+    close(s);
+    p(d, x)()};
   repeatReceive(d, p)()
 }
 

--- a/examples/sessions/reccalc-client.links
+++ b/examples/sessions/reccalc-client.links
@@ -15,7 +15,7 @@ fun calc(s) client {
       var s = send(x*y,s);
       calc(s)
     case Stop(s) ->
-      ()
+      close(s)
   }
 }
 
@@ -24,7 +24,7 @@ fun user(s) client {
   var (x, s) = receive(send(6,send(7,select Mul s)));
   var (y, s) = receive(send(6,send(7,select Mul s)));
   var (z, s) = receive(send(x,send(y,select Add s)));
-  var _ = select Stop s;
+  close(select Stop s);
   z
 }
 

--- a/examples/sessions/reccalc.links
+++ b/examples/sessions/reccalc.links
@@ -16,7 +16,7 @@ fun calc(s) {
       var s = send(x*y,s);
       calc(s)
     case Done(s) ->
-      ()
+      close(s)
   }
 }
 
@@ -26,7 +26,7 @@ fun user(s) {
   var (v, s) = receive(send(6,send(7,s)));
   var s = select Add s;
   var (v, s) = receive(send(v,send(v,s)));
-  var _ = select Done s;
+  close(select Done s);
   v
 }
 

--- a/examples/sessions/sim-calc.links
+++ b/examples/sessions/sim-calc.links
@@ -5,30 +5,34 @@ typename Calc  = ?CalcOptions.End;
 
 sig calc : (Calc) ~> ()
 fun calc(s) {
-  switch (receive(s).1) {
+  var (x, s) = receive(s);
+  close(s);
+  switch (x) {
     case Add(s) ->
       var (x,s) = receive(s);
       var (y,s) = receive(s);
-      var _ = send(x+y,s);
-      ()
+      var s = send(x+y,s);
+      close(s)
     case Mul(s) ->
       var (x,s) = receive(s);
       var (y,s) = receive(s);
-      var _ = send(x*y,s);
-      ()
+      var s = send(x*y,s);
+      close(s)
   }
 }
 
 sig sel_Add : (~Calc) ~> !Int.!Int.?Int.End
-fun sel_Add(c) {linFork (linfun (d) {ignore(send(Add(d), c))})}
+fun sel_Add(c) {linFork (linfun (d) {close(send(Add(d), c))})}
 
 sig sel_Mul : (~Calc) ~> !Int.!Int.?Int.End
-fun sel_Mul(c) {linFork (linfun (d) {ignore(send(Mul(d), c))})}
+fun sel_Mul(c) {linFork (linfun (d) {close(send(Mul(d), c))})}
 
 sig user : (~Calc) ~> Int
 fun user(s) {
   var s = sel_Mul(s);
-  receive(send(6,send(7,s))).1
+  var (x, s) = receive(send(6,send(7,s)));
+  close(s);
+  x
 }
 
 fun main() {

--- a/examples/sessions/smtp-end.links
+++ b/examples/sessions/smtp-end.links
@@ -74,8 +74,7 @@ fun sendBody(c, message) {
     case []    ->
       var c = send(message.subject, select DATA c);
       var c = send(message.body, c);
-      var c = select QUIT c;
-      ()
+      close(select QUIT c);
     case x::xs ->
       var c = send(x, select RCPT c);
       println("C: RCPT TO:<" ^^ x ^^ ">");
@@ -109,7 +108,7 @@ fun smtpServer(s) {
       } else {
         receiveMail(select ACCEPT s, socket)
       }
-    case QUIT(s) -> ()
+    case QUIT(s) -> close(s)
   }
 }
 
@@ -130,7 +129,8 @@ fun receiveMail(s, socket) {
       println("C: QUIT");
       write("QUIT\n", socket);
       var farewellMessage = read(socket);
-      closeSocket(socket)
+      closeSocket(socket);
+      close(s)
   }
 }
 

--- a/examples/sessions/smtp-factored-more.links
+++ b/examples/sessions/smtp-factored-more.links
@@ -93,8 +93,7 @@ fun sendBody(c, message) {
     case []    ->
       var c = send(message.subject, select DATA c);
       var c = send(message.body, c);
-      var c = select QUIT c;
-      ()
+      close(select QUIT c)
     case x::xs ->
       var c = send(x, select RCPT c);
       println("C: RCPT TO:<" ^^ x ^^ ">");
@@ -122,7 +121,7 @@ fun smtpServer(s) {
       var (domain, s) = receive(s);
       write("HELO " ^^ domain ^^ "\n", socket);
       checker(socket, s, receiveMail, fun (s, _) {smtpServer(s)})
-    case QUIT(s) -> quit(socket)
+    case QUIT(s) -> close(s); quit(socket)
   }
 }
 
@@ -134,7 +133,7 @@ fun receiveMail(s, socket) {
       write("MAIL FROM:<" ^^ address ^^ ">\n", socket);
       checker(socket, s, receiveRecipient, receiveMail)
 
-    case QUIT(s) -> quit(socket)
+    case QUIT(s) -> close(s); quit(socket)
   }
 }
 
@@ -145,7 +144,7 @@ fun receiveRecipient(s, socket) {
       var (rcpt, s) = receive(s);
       write("RCPT TO:<" ^^ rcpt ^^ ">\n", socket);
       checker(socket, s, receiveBody, receiveRecipient)
-    case QUIT(s) -> quit(socket)
+    case QUIT(s) -> close(s); quit(socket)
   }
 }
 
@@ -169,7 +168,7 @@ fun receiveBody(s, socket) {
       println("C: .");
       var acceptMessage = read(socket);
       receiveMail(s, socket)
-    case QUIT(s) -> quit(socket)
+    case QUIT(s) -> close(s); quit(socket)
   }
 }
 

--- a/examples/sessions/smtp-factored.links
+++ b/examples/sessions/smtp-factored.links
@@ -93,8 +93,7 @@ fun sendBody(c, message) {
     case []    ->
       var c = send(message.subject, select DATA c);
       var c = send(message.body, c);
-      var c = select QUIT c;
-      ()
+      close(select QUIT c)
     case x::xs ->
       var c = send(x, select RCPT c);
       println("C: RCPT TO:<" ^^ x ^^ ">");
@@ -127,7 +126,7 @@ fun smtpServer(s) {
       } else {
         smtpServer(select REJECT s)
       }
-    case QUIT(s) -> quit(socket)
+    case QUIT(s) -> close(s); quit(socket)
   }
 }
 
@@ -144,7 +143,7 @@ fun receiveMail(s, socket) {
         receiveMail(select REJECT s, socket)
       }
 
-    case QUIT(s) -> quit(socket)
+    case QUIT(s) -> close(s); quit(socket)
   }
 }
 
@@ -160,7 +159,7 @@ fun receiveRecipient(s, socket) {
       } else {
         receiveRecipient(select REJECT s, socket)
       }
-    case QUIT(s) -> quit(socket)
+    case QUIT(s) -> close(s); quit(socket)
   }
 }
 
@@ -189,7 +188,7 @@ fun receiveBody(s, socket) {
       println("C: .");
       var acceptMessage = read(socket);
       receiveMail(s, socket)
-    case QUIT(s) -> quit(socket)
+    case QUIT(s) -> close(s); quit(socket)
   }
 }
 

--- a/examples/sessions/state.links
+++ b/examples/sessions/state.links
@@ -3,29 +3,32 @@ typename State(a) = AP (!a.End);
 sig newCell : forall a::Any.(a) ~> State(a)
 fun newCell(v) {
   var x = new();
-  var _ = spawn {send(v, accept(x))};
+  var _ = spawn {close(send(v, accept(x)))};
   x
 }
 
 sig put : (State(a), a) ~> ()
 fun put(x, v) {
-  var _ = receive(request(x)).1;
-  var _ = spawn {send(v, accept(x))};
+  var (_, s) = receive(request(x));
+  close(s);
+  var _ = spawn {close(send(v, accept(x)))};
   ()
 }
 
 sig get : (State(a)) ~> a
 fun get(x) {
-  var v = receive(request(x)).1;
-  var _ = spawn {send(v, accept(x))};
+  var (v, s) = receive(request(x));
+  close(s);
+  var _ = spawn {close(send(v, accept(x)))};
   v
 }
 
 # an atomic swap operation
 sig swap : forall a::Any.(State(a), a) ~> a
 fun swap(x, w) {
-  var v = receive(request(x)).1;
-  var _ = spawn {send(w, accept(x))};
+  var (v, s) = receive(request(x));
+  close(s);
+  var _ = spawn {close(send(w, accept(x)))};
   v
 }
 

--- a/lib/js/jslib.js
+++ b/lib/js/jslib.js
@@ -3412,6 +3412,11 @@ function link(c, d, kappa) {
   throw "link not implemented on the client yet"
 }
 
+function _close(c) {
+  const local_ep = c._sessEP2;
+  delete _buffers[local_ep];
+  return {};
+}
 
 // SCHEDULER
 

--- a/prelude.links
+++ b/prelude.links
@@ -1200,12 +1200,13 @@ typename EndQuery = ?().End;
 
 sig wait : (EndQuery) ~> ()
 fun wait(s) {
-  ignore(receive(s))
+  var (_, s) = receive(s);
+  close(s)
 }
 
-sig close : (EndBang) ~> ()
-fun close(s) {
-  ignore(send((), s))
+sig closeBang : (EndBang) ~> ()
+fun closeBang(s) {
+  close(send((), s))
 }
 
 sig makeEndBang : () ~> EndBang
@@ -1226,7 +1227,7 @@ fun forkSync(f) {
   var _ = spawn {
     var c = accept(ap);
     var c = f(c);
-    close(c)
+    closeBang(c)
   };
   request(ap)
 }
@@ -1237,7 +1238,7 @@ fun linForkSync(f) {
   var _ = spawn {
     var c = accept(ap);
     var c = f(c);
-    close(c)
+    closeBang(c)
   };
   request(ap)
 }

--- a/tests/sessions.tests
+++ b/tests/sessions.tests
@@ -37,6 +37,11 @@ fun (c) {ignore(send(42, c))}
 stdout : fun : (!(Int)._::(Unl,Session)) ~> ()
 exit : 0
 
+Linear end
+ignore(request((new(): AP(End))))
+stderr : @..*
+exit : 1
+
 Non-linear generalisation (1)
 {var x = A; ()}
 stdout : () : ()


### PR DESCRIPTION
As identified in #449, while having an unrestricted `End` type is convenient for programming, it is difficult to see how buffers can be garbage-collected. In contrast, a linear `End` type coupled with a `close` operation makes this trivial. This PR should therefore fix #449.

This PR makes `End` linear, and introduces a `close` primitive which deletes the corresponding entry in the buffers table.