### PR TITLE
Stop printing frames in debug output

### DIFF
--- a/core/irtojs.ml
+++ b/core/irtojs.ml
@@ -1173,7 +1173,6 @@ end = functor (K : CONTINUATION) -> struct
     (* Compile a thunk to be invoked if the operation fails *)
     let cancellation_thunk_name =
       gensym ~prefix:"cancellation_thunk" () in
-    let () = Debug.print ("Kappa in GCS: " ^ K.to_string kappa) in
     (* Grab affected variables from the continuation *)
     let affected_vars_name = gensym ~prefix:"affected_vars" () in
     let fresh_var = Var.fresh_raw_var () in


### PR DESCRIPTION
This debug output is useless and large, and is a relic from when I was debugging session exceptions. While the `to_string` function is useful for debugging frames, the debug output should never have made it into master. This simple patch removes it, so we have some semblance of useful debug output again.