### PR TITLE
Updates the development and release build profiles.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,9 @@ ROOT:=$(shell pwd)
 BUILD_DIR:=$(ROOT)/_build
 # The build command and some standard build system flags
 BUILD=dune build
-FLAGS=--build-dir=$(BUILD_DIR) --profile=development
+COMMON_FLAGS=--build-dir=$(BUILD_DIR)
+DEV_FLAGS=$(COMMON_FLAGS) --profile=development
+REL_FLAGS=$(COMMON_FLAGS) --profile=release
 
 .PHONY: build-dev-nodb build-dev clean install nc native rule-check tests uninstall
 .DEFAULT_GOAL: nc
@@ -23,13 +25,13 @@ create-startup-script:
 	ln -fs links linx
 
 build-dev-all: dune dune-project
-	$(BUILD) --only-packages links,links-postgresql $(FLAGS) @install
+	$(BUILD) --only-packages links,links-postgresql $(DEV_FLAGS) @install
 
 build-dev-nodb: dune dune-project
-	$(BUILD) --only-packages links $(FLAGS) @install
+	$(BUILD) --only-packages links $(DEV_FLAGS) @install
 
 build-release-all:
-	$(BUILD) -p links,links-postgresql @install
+	$(BUILD) --only-packages links,links-postgresql $(REL_FLAGS) @install
 
 install:
 	dune install

--- a/bin/dune
+++ b/bin/dune
@@ -3,5 +3,4 @@
   (public_name linx)
   (package links)
   (modes native)
-  (link_flags -linkall)
   (libraries threads dynlink links.core))

--- a/core/lexer.mll
+++ b/core/lexer.mll
@@ -145,7 +145,7 @@ object
     Stack.push lexer lexers
 
   method pop_lexer =
-    Stack.pop lexers
+    let _ = Stack.pop lexers in ()
 
   method next_lexer =
     Stack.top lexers
@@ -426,7 +426,10 @@ and regexrepl ctxt nl = parse
   | '/' (regex_flags as f)              { ctxt#pop_lexer; ctxt#pop_lexer; SLASHFLAGS (f) }
 
 {
- let lexer ctxt ~newline_hook =
+ let lexer : lexer_context
+         -> newline_hook:(unit -> unit)
+         -> (Lexing.lexbuf -> Parser.token) =
+fun ctxt ~newline_hook ->
    ctxt#push_lexer (lex ctxt newline_hook);
    fun lexbuf -> ctxt#next_lexer lexbuf
 }

--- a/core/performance.ml
+++ b/core/performance.ml
@@ -19,15 +19,15 @@ let time_l e          = measure_diff_l Sys.time (-.) e
 let measure_memory_l e = measure_diff_l Gc.counters statdiff e
 
 let write_begin s =
-  Printf.fprintf stderr "%.20s : started\n" s;
+  Printf.fprintf stderr "%20s : started\n" s;
   flush stderr
 
 let write_time s t =
-  Printf.fprintf stderr "%.20s : %3f seconds taken\n" s t;
+  Printf.fprintf stderr "%20s : %3f seconds taken\n" s t;
   flush stderr
 
 let write_memory s t =
-  Printf.fprintf stderr "%.20s : %d words allocated\n" s t;
+  Printf.fprintf stderr "%20s : %d words allocated\n" s t;
   flush stderr
 
 let measure_l name (e) : 'b =

--- a/core/xmlLexer.mll
+++ b/core/xmlLexer.mll
@@ -16,7 +16,7 @@
       Stack.push lexer lexers
 
     method pop_lexer =
-      Stack.pop lexers
+      let _ = Stack.pop lexers in ()
 
     method next_lexer =
       Stack.top lexers

--- a/dune
+++ b/dune
@@ -1,5 +1,20 @@
 (env
  (development
-  (flags (:standard -safe-string -dtypes -w Ae-44-45-60 -g -cclib -lunix -thread)))
+  (flags (:standard
+          -strict-formats  ;; Disallows legacy formats.
+          -strict-sequence ;; Enforces the lhs of a sequence to have type `unit'.
+          -safe-string     ;; Immutable strings.
+          -annot           ;; Dumps information per (file) module about types, bindings, tail-calls, etc. Used by some tools.
+          -w Ae-44-45-60   ;; Ignores warnings 44, 45, and 60.
+          -g               ;; Adds debugging information to the resulting executable / library.
+         )))
  (release
-  (flags (:standard -safe-string -dtypes -warn-error Ae-44-45-60 -cclib -lunix -thread))))
+  (flags (:standard
+          ;; The following flags are the same as for the "development" profile.
+          -strict-formats -strict-sequence -safe-string -annot
+          ;; The following flags are unique to the "release" profile.
+          -w @a-4-44-45-60 ;; Treats all warnings as errors, except that 4, 44, 45, and 60 are ignored altogether.
+          ))
+  (ocamlopt_flags (:standard
+                   -O3 ;; Applies (aggressive) optimisations to the resulting executable.
+                  ))))


### PR DESCRIPTION
This PR includes the following changes.
 * The release profile treats (most) warnings as errors.

 * The build rule \`nc-release' *explicitly* instructs \`dune' to use
   the release profile.

 * Both build profiles include flags, which disallow some legacy OCaml
   features such deprecated modifiers in the Format language. The
   profiles also enforces strict sequences, which means that the left
   hand side of a sequence must have type \`unit'. The lexers have been
   updated to adhere to the strict sequence rule.

 * Removes \`-cclib -lunix' and \`-thread' flags from the common build
   profile flags, as those are implied by \`core/dune' and \`bin/dune'
   respectively.

 * The release profile applies -O3 optimisations to the resulting
   executable. In the future, we may want to explore the optimisation
   space to identify a more fine-grained and suitable set of
   optimisations for Links.

Resolves #477.