### PR TITLE
Remove some polymorphic variants in Sugartypes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,4 +19,4 @@ script:
   - make nc-release
   - make tests
   - ./run-tests db-only shredding
-  - ./run-tests unit 
+  - ./run-tests unit

--- a/bin/repl.ml
+++ b/bin/repl.ml
@@ -1,6 +1,7 @@
 open Links_core
 open Utility
 open List
+open Sugartypes
 
 module BS = Basicsettings
 
@@ -283,15 +284,15 @@ let interact envs =
           (* FIXME: What's going on here? Why is this not part of
              Frontend.Pipeline.interactive?*)
         let sentence' = match sentence with
-          | `Definitions defs ->
+          | Definitions defs ->
               let tenv = Var.varify_env (nenv, tyenv.Types.var_env) in
               let defs, nenv' = Sugartoir.desugar_definitions (nenv, tenv, tyenv.Types.effect_row) defs in
                 `Definitions (defs, nenv')
-          | `Expression e     ->
+          | Expression e     ->
               let tenv = Var.varify_env (nenv, tyenv.Types.var_env) in
               let e = Sugartoir.desugar_expression (nenv, tenv, tyenv.Types.effect_row) e in
                 `Expression (e, t)
-          | `Directive d      -> `Directive d
+          | Directive d      -> `Directive d
         in
           sentence', tyenv'
       in

--- a/core/compilePatterns.ml
+++ b/core/compilePatterns.ml
@@ -1057,9 +1057,10 @@ let compile_handle_cases
         ih_return = return;
         ih_cases  = compiled_effect_cases;
         ih_depth  =
-          match Sugartypes.(desc.shd_depth) with
-          | `Shallow -> `Shallow
-          | `Deep -> `Deep params
+          let open Sugartypes in
+          match desc.shd_depth with
+          | Shallow -> `Shallow
+          | Deep    -> `Deep params
       }
   in
   (outer_param_bindings, `Special handle)

--- a/core/desugarCP.ml
+++ b/core/desugarCP.ml
@@ -94,7 +94,7 @@ object (o : 'self_type)
             let (o, right, t) = desugar_cp {< var_env = TyEnv.bind (o#get_var_env ()) (c, Types.dual_type s) >} right in
             let o = o#restore_envs envs in
             let left_block =
-                spawn `Angel NoSpawnLocation (block (
+                spawn Angel NoSpawnLocation (block (
                     [ val_binding (variable_pat ~ty:s c) (fn_appl_var accept_str c);
                       val_binding (variable_pat ~ty:Types.make_endbang_type c)
                                   (with_dummy_pos left)],

--- a/core/desugarCP.ml
+++ b/core/desugarCP.ml
@@ -22,18 +22,18 @@ object (o : 'self_type)
     | `CP p ->
        let rec desugar_cp = fun o {node = p; _} ->
          match p with
-         | `Unquote (bs, e) ->
+         | Unquote (bs, e) ->
             let envs = o#backup_envs in
             let (o, bs) = TransformSugar.listu o (fun o -> o#binding) bs in
             let (o, e, t) = o#phrase e in
             let o = o#restore_envs envs in
             o, block_node (bs, e), t
-         | `Grab ((c, _), None, p) ->
+         | Grab ((c, _), None, p) ->
             let (o, e, t) = desugar_cp o p in
             o, block_node
                 ([val_binding (any_pat dp) (fn_appl_var wait_str c)],
                  with_dummy_pos e), t
-         | `Grab ((c, Some (`Input (_a, s), grab_tyargs)), Some {node=x, Some u; _}, p) -> (* FYI: a = u *)
+         | Grab ((c, Some (`Input (_a, s), grab_tyargs)), Some {node=x, Some u; _}, p) -> (* FYI: a = u *)
             let envs = o#backup_envs in
             let venv = TyEnv.bind (TyEnv.bind (o#get_var_env ()) (x, u))
                                   (c, s) in
@@ -45,12 +45,12 @@ object (o : 'self_type)
                                                          ("2", variable_pat ~ty:s c)], None)))
                                (fn_appl receive_str grab_tyargs [var c])],
                  with_dummy_pos e), t
-         | `Give ((c, _), None, p) ->
+         | Give ((c, _), None, p) ->
             let (o, e, t) = desugar_cp o p in
             o, block_node
                 ([val_binding (any_pat dp) (fn_appl_var close_str c)],
                  with_dummy_pos e), t
-         | `Give ((c, Some (`Output (_t, s), give_tyargs)), Some e, p) ->
+         | Give ((c, Some (`Output (_t, s), give_tyargs)), Some e, p) ->
             let envs = o#backup_envs in
             let o = {< var_env = TyEnv.bind (o#get_var_env ()) (c, s) >} in
             let (o, e, _typ) = o#phrase e in
@@ -60,9 +60,9 @@ object (o : 'self_type)
                 ([val_binding (variable_pat ~ty:s c)
                               (fn_appl send_str give_tyargs [e; var c])],
                  with_dummy_pos p), t
-         | `GiveNothing ({node=c, Some t; _}) ->
+         | GiveNothing ({node=c, Some t; _}) ->
             o, `Var c, t
-         | `Select ({node=c, Some s; _}, label, p) ->
+         | Select ({node=c, Some s; _}, label, p) ->
             let envs = o#backup_envs in
             let o = {< var_env = TyEnv.bind (o#get_var_env ()) (c, TypeUtils.select_type label s) >} in
             let (o, p, t) = desugar_cp o p in
@@ -71,7 +71,7 @@ object (o : 'self_type)
                 ([val_binding (variable_pat ~ty:(TypeUtils.select_type label s) c)
                                (with_dummy_pos (`Select (label, var c)))],
                  with_dummy_pos p), t
-         | `Offer ({node=c, Some s; _}, cases) ->
+         | Offer ({node=c, Some s; _}, cases) ->
             let desugar_branch (label, p) (o, cases) =
               let envs = o#backup_envs in
               let o = {< var_env = TyEnv.bind (o#get_var_env ()) (c, TypeUtils.choice_at label s) >} in
@@ -84,11 +84,11 @@ object (o : 'self_type)
                 | (_, []) -> assert false (* Case list cannot be empty *)
                 | (cases, t :: _ts) ->
                     o, `Offer (var c, cases, Some t), t)
-         | `Link ({node=c, Some ct; _}, {node=d, Some _; _}) ->
+         | Link ({node=c, Some ct; _}, {node=d, Some _; _}) ->
             o, fn_appl_node link_sync_str [`Type ct; `Row o#lookup_effects]
                             [var c; var d],
             Types.make_endbang_type
-         | `Comp ({node=c, Some s; _}, left, right) ->
+         | Comp ({node=c, Some s; _}, left, right) ->
             let envs = o#backup_envs in
             let (o, left, _typ) = desugar_cp {< var_env = TyEnv.bind (o#get_var_env ()) (c, s) >} left in
             let (o, right, t) = desugar_cp {< var_env = TyEnv.bind (o#get_var_env ()) (c, Types.dual_type s) >} right in

--- a/core/desugarCP.ml
+++ b/core/desugarCP.ml
@@ -94,7 +94,7 @@ object (o : 'self_type)
             let (o, right, t) = desugar_cp {< var_env = TyEnv.bind (o#get_var_env ()) (c, Types.dual_type s) >} right in
             let o = o#restore_envs envs in
             let left_block =
-                spawn `Angel `NoSpawnLocation (block (
+                spawn `Angel NoSpawnLocation (block (
                     [ val_binding (variable_pat ~ty:s c) (fn_appl_var accept_str c);
                       val_binding (variable_pat ~ty:Types.make_endbang_type c)
                                   (with_dummy_pos left)],

--- a/core/desugarDatatypes.ml
+++ b/core/desugarDatatypes.ml
@@ -558,12 +558,12 @@ let program alias_env (bindings, p : Sugartypes.program) : Sugartypes.program =
     (bindings, opt_map (phrase alias_env ->- snd) p)
 
 let sentence typing_env = function
-  | `Definitions bs ->
+  | Definitions bs ->
       let alias_env, bs' = toplevel_bindings typing_env.tycon_env bs in
-        {typing_env with tycon_env = alias_env}, `Definitions bs'
-  | `Expression  p  -> let o, p = phrase typing_env.tycon_env p in
-      {typing_env with tycon_env = o#aliases}, `Expression p
-  | `Directive   d  -> typing_env, `Directive d
+        {typing_env with tycon_env = alias_env}, Definitions bs'
+  | Expression  p  -> let o, p = phrase typing_env.tycon_env p in
+      {typing_env with tycon_env = o#aliases}, Expression p
+  | Directive   d  -> typing_env, Directive d
 
 let read ~aliases s =
   let dt, _ = Parse.parse_string ~in_context:(Parse.fresh_context ()) Parse.datatype s in

--- a/core/desugarDatatypes.ml
+++ b/core/desugarDatatypes.ml
@@ -417,7 +417,7 @@ struct
              (fun label t (write, needed) ->
               match lookup label constraints with
               | Some cs ->
-                 if List.exists ((=) `Readonly) cs then
+                 if List.exists ((=) Readonly) cs then
                    (write, needed)
                  else (* if List.exists ((=) `Default) cs then *)
                    (Types.row_with (label, t) write, needed)

--- a/core/desugarProcesses.ml
+++ b/core/desugarProcesses.ml
@@ -18,7 +18,7 @@ object (o : 'self_type)
   inherit (TransformSugar.transform env) as super
 
   method! phrasenode : Sugartypes.phrasenode -> ('self_type * Sugartypes.phrasenode * Types.datatype) = function
-    | `Spawn (`Wait, spawn_loc, body, Some inner_eff) ->
+    | `Spawn (Wait, spawn_loc, body, Some inner_eff) ->
         assert (spawn_loc = NoSpawnLocation);
         (* bring the inner effects into scope, then restore the
            outer effects afterwards *)
@@ -52,9 +52,9 @@ object (o : 'self_type)
 
         let spawn_fun =
           match k with
-          | `Demon  -> "spawnAt"
-          | `Angel  -> "spawnAngelAt"
-          | `Wait   -> assert false in
+          | Demon  -> "spawnAt"
+          | Angel  -> "spawnAngelAt"
+          | Wait   -> assert false in
 
         (* At this point, the location in the funlit doesn't matter -- we'll have an explicit
          * location in the form of spawn_loc_phr. It was useless before anyway, given that it

--- a/core/desugarProcesses.ml
+++ b/core/desugarProcesses.ml
@@ -19,7 +19,7 @@ object (o : 'self_type)
 
   method! phrasenode : Sugartypes.phrasenode -> ('self_type * Sugartypes.phrasenode * Types.datatype) = function
     | `Spawn (`Wait, spawn_loc, body, Some inner_eff) ->
-        assert (spawn_loc = `NoSpawnLocation);
+        assert (spawn_loc = NoSpawnLocation);
         (* bring the inner effects into scope, then restore the
            outer effects afterwards *)
 
@@ -46,9 +46,9 @@ object (o : 'self_type)
 
         let spawn_loc_phr =
           match spawn_loc with
-            | `ExplicitSpawnLocation phr -> phr
-            | `SpawnClient -> fn_appl "there" [] [tuple []]
-            | `NoSpawnLocation -> fn_appl "here" [] [tuple []] in
+            | ExplicitSpawnLocation phr -> phr
+            | SpawnClient -> fn_appl "there" [] [tuple []]
+            | NoSpawnLocation -> fn_appl "here" [] [tuple []] in
 
         let spawn_fun =
           match k with

--- a/core/desugarRegexes.ml
+++ b/core/desugarRegexes.ml
@@ -37,27 +37,27 @@ let desugar_regex phrase regex_type regex : phrase =
       end in
   let rec aux : regex -> phrase =
     function
-      | `Range (f, t) ->
-         constructor' ~body:(tuple [constant_char f; constant_char t]) range_str
-      | `Simply s           -> constructor' simply_str ~body:(constant_str s)
-      | `Quote s            -> constructor' quote_str  ~body:(aux s)
-      | `Any                -> constructor' any_str
-      | `StartAnchor        -> constructor' start_anchor_str
-      | `EndAnchor          -> constructor' end_anchor_str
-      | `Seq rs             ->
-         constructor' seq_str ~body:(list ~ty:(Types.make_list_type regex_type)
-                                          (List.map (fun s -> aux s) rs))
-      | `Alternate (r1, r2) ->
-         constructor' alternative_str ~body:(tuple [aux r1; aux r2])
-      | `Group s ->
-         constructor' group_str ~body:(aux s)
-      | `Repeat (rep, r) ->
-         constructor' repeat_str ~body:(tuple [desugar_repeat rep; aux r])
-      | `Splice e ->
-         constructor' quote_str ~body:(constructor' ~body:(expr e) simply_str)
-      | `Replace (re, (`Literal tmpl)) ->
-         constructor' replace_str ~body:(tuple [aux re; constant_str tmpl])
-      | `Replace (re, (`Splice e)) ->
+      | Range (f, t) ->
+        constructor' ~body:(tuple [constant_char f; constant_char t]) range_str
+      | Simply s           -> constructor' simply_str ~body:(constant_str s)
+      | Quote s            -> constructor' quote_str  ~body:(aux s)
+      | Any                -> constructor' any_str
+      | StartAnchor        -> constructor' start_anchor_str
+      | EndAnchor          -> constructor' end_anchor_str
+      | Seq rs             ->
+        constructor' seq_str ~body:(list ~ty:(Types.make_list_type regex_type)
+                                         (List.map (fun s -> aux s) rs))
+      | Alternate (r1, r2) ->
+        constructor' alternative_str ~body:(tuple [aux r1; aux r2])
+      | Group s ->
+        constructor' group_str ~body:(aux s)
+      | Repeat (rep, r) ->
+        constructor' repeat_str ~body:(tuple [desugar_repeat rep; aux r])
+      | Splice e ->
+        constructor' quote_str ~body:(constructor' ~body:(expr e) simply_str)
+      | Replace (re, (`Literal tmpl)) ->
+        constructor' replace_str ~body:(tuple [aux re; constant_str tmpl])
+      | Replace (re, (`Splice e)) ->
          constructor' replace_str ~body:(tuple [aux re; expr e])
   in block (List.map (fun (v, e1, t) ->
                 val_binding (variable_pat ~ty:t v) e1) !exprs,
@@ -71,7 +71,7 @@ object(self)
   val regex_type = Instantiate.alias "Regex" [] env.Types.tycon_env
 
   method! phrase ({node=p; pos} as ph) = match p with
-    | `InfixAppl ((tyargs, `RegexMatch flags), e1, {node=`Regex((`Replace(_,_) as r)); _}) ->
+    | `InfixAppl ((tyargs, `RegexMatch flags), e1, {node=`Regex((Replace(_,_) as r)); _}) ->
         let libfn =
           if List.exists ((=)`RegexNative) flags
           then "sntilde"

--- a/core/desugarRegexes.ml
+++ b/core/desugarRegexes.ml
@@ -73,14 +73,14 @@ object(self)
   method! phrase ({node=p; pos} as ph) = match p with
     | `InfixAppl ((tyargs, `RegexMatch flags), e1, {node=`Regex((Replace(_,_) as r)); _}) ->
         let libfn =
-          if List.exists ((=)`RegexNative) flags
+          if List.exists ((=)RegexNative) flags
           then "sntilde"
           else "stilde" in
           self#phrase (fn_appl libfn tyargs
                             [e1; desugar_regex self#phrase regex_type r])
     | `InfixAppl ((tyargs, `RegexMatch flags), e1, {node=`Regex r; _}) ->
-        let nativep = List.exists ((=) `RegexNative) flags
-        and listp   = List.exists ((=) `RegexList)   flags in
+        let nativep = List.exists ((=) RegexNative) flags
+        and listp   = List.exists ((=) RegexList)   flags in
         let libfn = match listp, nativep with
           | true, true   -> "lntilde"
           | true, false  -> "ltilde"

--- a/core/desugarSessionExceptions.ml
+++ b/core/desugarSessionExceptions.ml
@@ -23,7 +23,7 @@ object (o: 'self_type)
   inherit (TransformSugar.transform env) as super
 
   method! phrasenode = function
-    | (`Spawn (`Wait, _, _, _)) as sw ->
+    | (`Spawn (Wait, _, _, _)) as sw ->
         super#phrasenode sw
     | `Spawn (k, spawn_loc, {node=body;_}, Some inner_effects) ->
         let as_var = Utility.gensym ~prefix:"spawn_aspat" () in

--- a/core/desugarSessionExceptions.ml
+++ b/core/desugarSessionExceptions.ml
@@ -96,7 +96,7 @@ object (o : 'self_type)
            Types.make_empty_closed_row (), otherwise_dt) in
 
         let hndl_desc = {
-          shd_depth = `Deep;
+          shd_depth = Deep;
           shd_types = types;
           shd_raw_row = raw_row;
           shd_params = None;

--- a/core/parser.mly
+++ b/core/parser.mly
@@ -504,12 +504,12 @@ op:
 | INFIX9 | INFIXL9 | INFIXR9                                   { with_pos $loc $1 }
 
 spawn_expression:
-| SPAWNAT LPAREN exp COMMA block RPAREN                        { spawn ~ppos:$loc `Demon (`ExplicitSpawnLocation $3) $5 }
-| SPAWN block                                                  { spawn ~ppos:$loc `Demon  `NoSpawnLocation           $2 }
-| SPAWNANGELAT LPAREN exp COMMA block RPAREN                   { spawn ~ppos:$loc `Angel (`ExplicitSpawnLocation $3) $5 }
-| SPAWNANGEL  block                                            { spawn ~ppos:$loc `Angel  `NoSpawnLocation           $2 }
-| SPAWNCLIENT block                                            { spawn ~ppos:$loc `Demon  `SpawnClient               $2 }
-| SPAWNWAIT   block                                            { spawn ~ppos:$loc `Wait   `NoSpawnLocation           $2 }
+| SPAWNAT LPAREN exp COMMA block RPAREN                        { spawn ~ppos:$loc `Demon (ExplicitSpawnLocation $3) $5 }
+| SPAWN block                                                  { spawn ~ppos:$loc `Demon  NoSpawnLocation           $2 }
+| SPAWNANGELAT LPAREN exp COMMA block RPAREN                   { spawn ~ppos:$loc `Angel (ExplicitSpawnLocation $3) $5 }
+| SPAWNANGEL  block                                            { spawn ~ppos:$loc `Angel  NoSpawnLocation           $2 }
+| SPAWNCLIENT block                                            { spawn ~ppos:$loc `Demon  SpawnClient               $2 }
+| SPAWNWAIT   block                                            { spawn ~ppos:$loc `Wait   NoSpawnLocation           $2 }
 
 postfix_expression:
 | primary_expression | spawn_expression                        { $1 }

--- a/core/parser.mly
+++ b/core/parser.mly
@@ -160,9 +160,9 @@ let parseRegexFlags f =
     else
       asList f (i+1) ((String.get f i)::l) in
     List.map (function
-                'l' -> `RegexList
-              | 'n' -> `RegexNative
-              | 'g' -> `RegexGlobal
+                'l' -> RegexList
+              | 'n' -> RegexNative
+              | 'g' -> RegexGlobal
               | _ -> assert false) (asList f 0 [])
 
 
@@ -1102,7 +1102,7 @@ regex:
 | SLASH regex_flags_opt                                        { with_pos $loc (`Regex (Simply "")), $2 }
 | SSLASH regex_pattern_alternate SLASH regex_replace
     regex_flags_opt                                            { with_pos $loc (`Regex (Replace ($2, $4))),
-                                                                 `RegexReplace :: $5 }
+                                                                 RegexReplace :: $5 }
 
 regex_flags_opt:
 | SLASH                                                        { [] }

--- a/core/parser.mly
+++ b/core/parser.mly
@@ -1099,9 +1099,9 @@ kinded_row_var:
  */
 regex:
 | SLASH regex_pattern_alternate regex_flags_opt                { with_pos $loc($2) (`Regex $2), $3 }
-| SLASH regex_flags_opt                                        { with_pos $loc (`Regex (`Simply "")), $2 }
+| SLASH regex_flags_opt                                        { with_pos $loc (`Regex (Simply "")), $2 }
 | SSLASH regex_pattern_alternate SLASH regex_replace
-    regex_flags_opt                                            { with_pos $loc (`Regex (`Replace ($2, $4))),
+    regex_flags_opt                                            { with_pos $loc (`Regex (Replace ($2, $4))),
                                                                  `RegexReplace :: $5 }
 
 regex_flags_opt:
@@ -1114,21 +1114,21 @@ regex_replace:
 | block                                                        { `Splice $1 }
 
 regex_pattern:
-| RANGE                                                        { `Range $1 }
-| STRING                                                       { `Simply $1 }
-| QUOTEDMETA                                                   { `Quote (`Simply $1) }
-| DOT                                                          { `Any }
-| CARET                                                        { `StartAnchor }
-| DOLLAR                                                       { `EndAnchor }
-| LPAREN regex_pattern_alternate RPAREN                        { `Group $2 }
-| regex_pattern STAR                                           { `Repeat (Regex.Star, $1) }
-| regex_pattern PLUS                                           { `Repeat (Regex.Plus, $1) }
-| regex_pattern QUESTION                                       { `Repeat (Regex.Question, $1) }
-| block                                                        { `Splice $1 }
+| RANGE                                                        { Range $1 }
+| STRING                                                       { Simply $1 }
+| QUOTEDMETA                                                   { Quote (Simply $1) }
+| DOT                                                          { Any }
+| CARET                                                        { StartAnchor }
+| DOLLAR                                                       { EndAnchor }
+| LPAREN regex_pattern_alternate RPAREN                        { Group $2 }
+| regex_pattern STAR                                           { Repeat (Regex.Star, $1) }
+| regex_pattern PLUS                                           { Repeat (Regex.Plus, $1) }
+| regex_pattern QUESTION                                       { Repeat (Regex.Question, $1) }
+| block                                                        { Splice $1 }
 
 regex_pattern_alternate:
-| regex_pattern_sequence                                       { `Seq $1 }
-| regex_pattern_sequence ALTERNATE regex_pattern_alternate     { `Alternate (`Seq $1, $3) }
+| regex_pattern_sequence                                       { Seq $1 }
+| regex_pattern_sequence ALTERNATE regex_pattern_alternate     { Alternate (Seq $1, $3) }
 
 regex_pattern_sequence:
 | regex_pattern+                                               { $1 }

--- a/core/parser.mly
+++ b/core/parser.mly
@@ -469,8 +469,8 @@ handler_parameterization:
 | arg_lists? handler_body                                      { ($2, $1) }
 
 handler_depth:
-| HANDLER                                                      { `Deep }
-| SHALLOWHANDLER                                               { `Shallow }
+| HANDLER                                                      { Deep    }
+| SHALLOWHANDLER                                               { Shallow }
 
 handler_body:
 | LBRACE cases RBRACE                                          { $2 }
@@ -713,11 +713,11 @@ perhaps_cases:
 case_expression:
 | SWITCH LPAREN exp RPAREN LBRACE perhaps_cases RBRACE         { with_pos $loc (`Switch ($3, $6, None)) }
 | RECEIVE LBRACE perhaps_cases RBRACE                          { with_pos $loc (`Receive ($3, None)) }
-| SHALLOWHANDLE LPAREN exp RPAREN LBRACE cases RBRACE          { with_pos $loc (`Handle (untyped_handler $3 $6 `Shallow)) }
-| HANDLE LPAREN exp RPAREN LBRACE perhaps_cases RBRACE         { with_pos $loc (`Handle (untyped_handler $3 $6 `Deep   )) }
+| SHALLOWHANDLE LPAREN exp RPAREN LBRACE cases RBRACE          { with_pos $loc (`Handle (untyped_handler $3 $6 Shallow)) }
+| HANDLE LPAREN exp RPAREN LBRACE perhaps_cases RBRACE         { with_pos $loc (`Handle (untyped_handler $3 $6 Deep   )) }
 | HANDLE LPAREN exp RPAREN LPAREN handle_params RPAREN LBRACE perhaps_cases RBRACE
                                                                { with_pos $loc (`Handle (untyped_handler ~parameters:(List.rev $6)
-                                                                                         $3 $9 `Deep)) }
+                                                                                         $3 $9 Deep)) }
 | RAISE                                                        { with_pos $loc (`Raise) }
 | TRY exp AS pattern IN exp OTHERWISE exp                      { with_pos $loc (`TryInOtherwise ($2, $4, $6, $8, None)) }
 

--- a/core/parser.mly
+++ b/core/parser.mly
@@ -504,12 +504,12 @@ op:
 | INFIX9 | INFIXL9 | INFIXR9                                   { with_pos $loc $1 }
 
 spawn_expression:
-| SPAWNAT LPAREN exp COMMA block RPAREN                        { spawn ~ppos:$loc `Demon (ExplicitSpawnLocation $3) $5 }
-| SPAWN block                                                  { spawn ~ppos:$loc `Demon  NoSpawnLocation           $2 }
-| SPAWNANGELAT LPAREN exp COMMA block RPAREN                   { spawn ~ppos:$loc `Angel (ExplicitSpawnLocation $3) $5 }
-| SPAWNANGEL  block                                            { spawn ~ppos:$loc `Angel  NoSpawnLocation           $2 }
-| SPAWNCLIENT block                                            { spawn ~ppos:$loc `Demon  SpawnClient               $2 }
-| SPAWNWAIT   block                                            { spawn ~ppos:$loc `Wait   NoSpawnLocation           $2 }
+| SPAWNAT LPAREN exp COMMA block RPAREN                        { spawn ~ppos:$loc Demon (ExplicitSpawnLocation $3) $5 }
+| SPAWN block                                                  { spawn ~ppos:$loc Demon  NoSpawnLocation           $2 }
+| SPAWNANGELAT LPAREN exp COMMA block RPAREN                   { spawn ~ppos:$loc Angel (ExplicitSpawnLocation $3) $5 }
+| SPAWNANGEL  block                                            { spawn ~ppos:$loc Angel  NoSpawnLocation           $2 }
+| SPAWNCLIENT block                                            { spawn ~ppos:$loc Demon  SpawnClient               $2 }
+| SPAWNWAIT   block                                            { spawn ~ppos:$loc Wait   NoSpawnLocation           $2 }
 
 postfix_expression:
 | primary_expression | spawn_expression                        { $1 }

--- a/core/parser.mly
+++ b/core/parser.mly
@@ -777,8 +777,8 @@ field_constraints:
 | field_constraint+                                            { $1 }
 
 field_constraint:
-| READONLY                                                     { `Readonly }
-| DEFAULT                                                      { `Default  }
+| READONLY                                                     { Readonly }
+| DEFAULT                                                      { Default  }
 
 perhaps_db_args:
 | atomic_expression?                                           { $1 }

--- a/core/parser.mly
+++ b/core/parser.mly
@@ -262,12 +262,12 @@ let parseRegexFlags f =
 | x = X           { [x] }
 
 interactive:
-| nofun_declaration                                            { `Definitions [$1] }
-| fun_declarations SEMICOLON                                   { `Definitions $1   }
-| SEMICOLON                                                    { `Definitions []   }
-| exp SEMICOLON                                                { `Expression $1    }
-| directive                                                    { `Directive $1     }
-| END                                                          { `Directive ("quit", []) (* rather hackish *) }
+| nofun_declaration                                            { Definitions [$1] }
+| fun_declarations SEMICOLON                                   { Definitions $1   }
+| SEMICOLON                                                    { Definitions []   }
+| exp SEMICOLON                                                { Expression $1    }
+| directive                                                    { Directive $1     }
+| END                                                          { Directive ("quit", []) (* rather hackish *) }
 
 file:
 | declarations exp? END                                        { ($1, $2     ) }

--- a/core/parser.mly
+++ b/core/parser.mly
@@ -443,17 +443,17 @@ perhaps_name:
 | cp_name?                                                     { $1 }
 
 cp_expression:
-| LBRACE block_contents RBRACE                                 { with_pos $loc (`Unquote $2) }
-| cp_name LPAREN perhaps_name RPAREN DOT cp_expression         { with_pos $loc (`Grab ((name_of_binder $1, None), $3, $6)) }
-| cp_name LPAREN perhaps_name RPAREN                           { with_pos $loc (`Grab ((name_of_binder $1, None), $3, cp_unit $loc)) }
-| cp_name LBRACKET exp RBRACKET DOT cp_expression              { with_pos $loc (`Give ((name_of_binder $1, None), Some $3, $6)) }
-| cp_name LBRACKET exp RBRACKET                                { with_pos $loc (`Give ((name_of_binder $1, None), Some $3, cp_unit $loc)) }
-| cp_name LBRACKET RBRACKET                                    { with_pos $loc (`GiveNothing $1) }
-| OFFER cp_name LBRACE perhaps_cp_cases RBRACE                 { with_pos $loc (`Offer ($2, $4)) }
-| cp_label cp_name DOT cp_expression                           { with_pos $loc (`Select ($2, $1, $4)) }
-| cp_label cp_name                                             { with_pos $loc (`Select ($2, $1, cp_unit $loc)) }
-| cp_name LRARROW cp_name                                      { with_pos $loc (`Link ($1, $3)) }
-| NU cp_name DOT LPAREN cp_expression VBAR cp_expression RPAREN{ with_pos $loc (`Comp ($2, $5, $7)) }
+| LBRACE block_contents RBRACE                                 { with_pos $loc (Unquote $2) }
+| cp_name LPAREN perhaps_name RPAREN DOT cp_expression         { with_pos $loc (Grab ((name_of_binder $1, None), $3, $6)) }
+| cp_name LPAREN perhaps_name RPAREN                           { with_pos $loc (Grab ((name_of_binder $1, None), $3, cp_unit $loc)) }
+| cp_name LBRACKET exp RBRACKET DOT cp_expression              { with_pos $loc (Give ((name_of_binder $1, None), Some $3, $6)) }
+| cp_name LBRACKET exp RBRACKET                                { with_pos $loc (Give ((name_of_binder $1, None), Some $3, cp_unit $loc)) }
+| cp_name LBRACKET RBRACKET                                    { with_pos $loc (GiveNothing $1) }
+| OFFER cp_name LBRACE perhaps_cp_cases RBRACE                 { with_pos $loc (Offer ($2, $4)) }
+| cp_label cp_name DOT cp_expression                           { with_pos $loc (Select ($2, $1, $4)) }
+| cp_label cp_name                                             { with_pos $loc (Select ($2, $1, cp_unit $loc)) }
+| cp_name LRARROW cp_name                                      { with_pos $loc (Link ($1, $3)) }
+| NU cp_name DOT LPAREN cp_expression VBAR cp_expression RPAREN{ with_pos $loc (Comp ($2, $5, $7)) }
 
 primary_expression:
 | atomic_expression                                            { $1 }

--- a/core/refineBindings.ml
+++ b/core/refineBindings.ml
@@ -448,12 +448,12 @@ object (self)
       refined_bindings, body
 
   method! sentence : sentence -> sentence = function
-    |`Definitions defs ->
+    | Definitions defs ->
        let defs = self#list (fun o -> o#binding) defs in
        let refined_bindings =
          (RefineTypeBindings.refineTypeBindings ->-
          refine_bindings) defs in
-       `Definitions (refined_bindings)
+       Definitions (refined_bindings)
     | d -> super#sentence d
 
 end

--- a/core/sugarConstructors.ml
+++ b/core/sugarConstructors.ml
@@ -92,7 +92,7 @@ module SugarConstructors (Position : Pos)
     | [e] -> record ~ppos [("1", e)]
     | es  -> with_pos ppos (`TupleLit es)
 
-  let cp_unit ppos = with_pos ppos (`Unquote ([], tuple ~ppos []))
+  let cp_unit ppos = with_pos ppos (Unquote ([], tuple ~ppos []))
 
   let list ?(ppos=dp) ?ty elems =
     with_pos ppos (`ListLit (elems, ty))

--- a/core/sugarConstructorsIntf.ml
+++ b/core/sugarConstructorsIntf.ml
@@ -94,7 +94,7 @@ module type SugarConstructorsSig = sig
      -> ?location:location -> declared_linearity -> pattern list list -> phrase
      -> phrase
   val hnlit_arg
-      : [`Deep | `Shallow ] -> pattern -> clause list * pattern list list option
+      : handler_depth -> pattern -> clause list * pattern list list option
      -> handlerlit
   val handler_lit
       : ?ppos:t -> handlerlit -> phrase
@@ -151,6 +151,6 @@ module type SugarConstructorsSig = sig
   (* Handlers *)
   val untyped_handler
       : ?val_cases:(clause list) -> ?parameters:((phrase * pattern) list)
-     -> phrase -> clause list -> [`Deep | `Shallow]
+     -> phrase -> clause list -> handler_depth
      -> handler
 end

--- a/core/sugarTraversals.ml
+++ b/core/sugarTraversals.ml
@@ -54,10 +54,10 @@ class map =
 
     method sentence : sentence -> sentence =
       function
-      | `Definitions _x ->
-          let _x = o#list (fun o -> o#binding) _x in `Definitions _x
-      | `Expression _x -> let _x = o#phrase _x in `Expression _x
-      | `Directive _x -> let _x = o#directive _x in `Directive _x
+      | Definitions _x ->
+          let _x = o#list (fun o -> o#binding) _x in Definitions _x
+      | Expression _x -> let _x = o#phrase _x in Expression _x
+      | Directive _x -> let _x = o#directive _x in Directive _x
 
     method sec : sec -> sec =
       function
@@ -779,9 +779,9 @@ class fold =
 
     method sentence : sentence -> 'self_type =
       function
-      | `Definitions _x -> let o = o#list (fun o -> o#binding) _x in o
-      | `Expression _x -> let o = o#phrase _x in o
-      | `Directive _x -> let o = o#directive _x in o
+      | Definitions _x -> let o = o#list (fun o -> o#binding) _x in o
+      | Expression _x -> let o = o#phrase _x in o
+      | Directive _x -> let o = o#directive _x in o
 
     method sec : sec -> 'self_type =
       function
@@ -1453,11 +1453,11 @@ class fold_map =
 
     method sentence : sentence -> ('self_type * sentence) =
       function
-      | `Definitions _x ->
+      | Definitions _x ->
           let (o, _x) = o#list (fun o -> o#binding) _x
-          in (o, (`Definitions _x))
-      | `Expression _x -> let (o, _x) = o#phrase _x in (o, (`Expression _x))
-      | `Directive _x -> let (o, _x) = o#directive _x in (o, (`Directive _x))
+          in (o, Definitions _x)
+      | Expression _x -> let (o, _x) = o#phrase _x in (o, Expression _x)
+      | Directive _x -> let (o, _x) = o#directive _x in (o, Directive _x)
 
     method sec : sec -> ('self_type * sec) =
       function

--- a/core/sugarTraversals.ml
+++ b/core/sugarTraversals.ml
@@ -109,11 +109,7 @@ class map =
       | `Splice _x -> let _x = o#phrase _x in `Splice _x
 
     method regexflag : regexflag -> regexflag =
-      function
-      | `RegexList -> `RegexList
-      | `RegexNative -> `RegexNative
-      | `RegexGlobal -> `RegexGlobal
-      | `RegexReplace -> `RegexReplace
+      fun flag -> flag
 
     method regex : regex -> regex =
       function
@@ -831,11 +827,7 @@ class fold =
       | `Splice _x -> let o = o#phrase _x in o
 
     method regexflag : regexflag -> 'self_type =
-      function
-      | `RegexList -> o
-      | `RegexNative -> o
-      | `RegexGlobal -> o
-      | `RegexReplace -> o
+      fun _ -> o
 
     method regex : regex -> 'self_type =
       function
@@ -1509,11 +1501,7 @@ class fold_map =
       | `Splice _x -> let (o, _x) = o#phrase _x in (o, (`Splice _x))
 
     method regexflag : regexflag -> ('self_type * regexflag) =
-      function
-      | `RegexList -> (o, `RegexList)
-      | `RegexNative -> (o, `RegexNative)
-      | `RegexGlobal -> (o, `RegexGlobal)
-      | `RegexReplace -> (o, `RegexReplace)
+      fun flag -> (o, flag)
 
     method regex : regex -> ('self_type * regex) =
       function

--- a/core/sugarTraversals.ml
+++ b/core/sugarTraversals.ml
@@ -493,12 +493,6 @@ class map =
         let node = o#patternnode node in
         let pos = o#position pos in {node; pos}
 
-    method operator : operator -> operator =
-      function
-      | (#unary_op as x) -> (o#unary_op x :> operator)
-      | (#binop as x) -> (o#binop x :> operator)
-      | `Project _x -> let _x = o#name _x in `Project _x
-
     method name : name -> name = o#string
 
     method logical_binop : logical_binop -> logical_binop =
@@ -1167,12 +1161,6 @@ class fold =
         let o = o#patternnode node in
         let o = o#position pos in
         o
-
-    method operator : operator -> 'self_type =
-      function
-      | (#unary_op as x) -> o#unary_op x
-      | (#binop as x) -> o#binop x
-      | `Project _x -> let o = o#name _x in o
 
     method name : name -> 'self_type = o#string
 
@@ -1930,12 +1918,6 @@ class fold_map =
         let (o, node) = o#patternnode node in
         let (o, pos ) = o#position pos in
         (o, {node; pos})
-
-    method operator : operator -> ('self_type * operator) =
-      function
-      | (#unary_op as x) -> (o#unary_op x :> 'self_type * operator)
-      | (#binop as x) -> (o#binop x :> 'self_type * operator)
-      | `Project _x -> let (o, _x) = o#name _x in (o, (`Project _x))
 
     method name : name -> ('self_type * name) = o#string
 

--- a/core/sugarTraversals.ml
+++ b/core/sugarTraversals.ml
@@ -117,26 +117,26 @@ class map =
 
     method regex : regex -> regex =
       function
-      | `Range ((_x, _x_i1)) ->
+      | Range ((_x, _x_i1)) ->
           let _x = o#char _x in
-          let _x_i1 = o#char _x_i1 in `Range ((_x, _x_i1))
-      | `Simply _x -> let _x = o#string _x in `Simply _x
-      | `Quote _x -> let _x = o#regex _x in `Quote _x
-      | `Any -> `Any
-      | `StartAnchor -> `StartAnchor
-      | `EndAnchor -> `EndAnchor
-      | `Seq _x -> let _x = o#list (fun o -> o#regex) _x in `Seq _x
-      | `Alternate ((_x, _x_i1)) ->
+          let _x_i1 = o#char _x_i1 in Range ((_x, _x_i1))
+      | Simply _x -> let _x = o#string _x in Simply _x
+      | Quote _x -> let _x = o#regex _x in Quote _x
+      | Any -> Any
+      | StartAnchor -> StartAnchor
+      | EndAnchor -> EndAnchor
+      | Seq _x -> let _x = o#list (fun o -> o#regex) _x in Seq _x
+      | Alternate ((_x, _x_i1)) ->
           let _x = o#regex _x in
-          let _x_i1 = o#regex _x_i1 in `Alternate ((_x, _x_i1))
-      | `Group _x -> let _x = o#regex _x in `Group _x
-      | `Repeat ((_x, _x_i1)) ->
+          let _x_i1 = o#regex _x_i1 in Alternate ((_x, _x_i1))
+      | Group _x -> let _x = o#regex _x in Group _x
+      | Repeat ((_x, _x_i1)) ->
           let _x = o#unknown _x in
-          let _x_i1 = o#regex _x_i1 in `Repeat ((_x, _x_i1))
-      | `Splice _x -> let _x = o#phrase _x in `Splice _x
-      | `Replace ((_x, _x_i1)) ->
+          let _x_i1 = o#regex _x_i1 in Repeat ((_x, _x_i1))
+      | Splice _x -> let _x = o#phrase _x in Splice _x
+      | Replace ((_x, _x_i1)) ->
           let _x = o#regex _x in
-          let _x_i1 = o#replace_rhs _x_i1 in `Replace ((_x, _x_i1))
+          let _x_i1 = o#replace_rhs _x_i1 in Replace ((_x, _x_i1))
 
     method position : position -> position =
       fun (_x, _x_i1, _x_i2) ->
@@ -839,21 +839,21 @@ class fold =
 
     method regex : regex -> 'self_type =
       function
-      | `Range ((_x, _x_i1)) ->
+      | Range ((_x, _x_i1)) ->
           let o = o#char _x in let o = o#char _x_i1 in o
-      | `Simply _x -> let o = o#string _x in o
-      | `Quote _x -> let o = o#regex _x in o
-      | `Any -> o
-      | `StartAnchor -> o
-      | `EndAnchor -> o
-      | `Seq _x -> let o = o#list (fun o -> o#regex) _x in o
-      | `Alternate ((_x, _x_i1)) ->
+      | Simply _x -> let o = o#string _x in o
+      | Quote _x -> let o = o#regex _x in o
+      | Any -> o
+      | StartAnchor -> o
+      | EndAnchor -> o
+      | Seq _x -> let o = o#list (fun o -> o#regex) _x in o
+      | Alternate ((_x, _x_i1)) ->
           let o = o#regex _x in let o = o#regex _x_i1 in o
-      | `Group _x -> let o = o#regex _x in o
-      | `Repeat ((_x, _x_i1)) ->
+      | Group _x -> let o = o#regex _x in o
+      | Repeat ((_x, _x_i1)) ->
           let o = o#unknown _x in let o = o#regex _x_i1 in o
-      | `Splice _x -> let o = o#phrase _x in o
-      | `Replace ((_x, _x_i1)) ->
+      | Splice _x -> let o = o#phrase _x in o
+      | Replace ((_x, _x_i1)) ->
           let o = o#regex _x in let o = o#replace_rhs _x_i1 in o
 
     method position : position -> 'self_type =
@@ -1517,28 +1517,28 @@ class fold_map =
 
     method regex : regex -> ('self_type * regex) =
       function
-      | `Range ((_x, _x_i1)) ->
+      | Range ((_x, _x_i1)) ->
           let (o, _x) = o#char _x in
-          let (o, _x_i1) = o#char _x_i1 in (o, (`Range ((_x, _x_i1))))
-      | `Simply _x -> let (o, _x) = o#string _x in (o, (`Simply _x))
-      | `Quote _x -> let (o, _x) = o#regex _x in (o, (`Quote _x))
-      | `Any -> (o, `Any)
-      | `StartAnchor -> (o, `StartAnchor)
-      | `EndAnchor -> (o, `EndAnchor)
-      | `Seq _x ->
-          let (o, _x) = o#list (fun o -> o#regex) _x in (o, (`Seq _x))
-      | `Alternate ((_x, _x_i1)) ->
+          let (o, _x_i1) = o#char _x_i1 in (o, (Range ((_x, _x_i1))))
+      | Simply _x -> let (o, _x) = o#string _x in (o, (Simply _x))
+      | Quote _x -> let (o, _x) = o#regex _x in (o, (Quote _x))
+      | Any -> (o, Any)
+      | StartAnchor -> (o, StartAnchor)
+      | EndAnchor -> (o, EndAnchor)
+      | Seq _x ->
+          let (o, _x) = o#list (fun o -> o#regex) _x in (o, (Seq _x))
+      | Alternate ((_x, _x_i1)) ->
           let (o, _x) = o#regex _x in
-          let (o, _x_i1) = o#regex _x_i1 in (o, (`Alternate ((_x, _x_i1))))
-      | `Group _x -> let (o, _x) = o#regex _x in (o, (`Group _x))
-      | `Repeat ((_x, _x_i1)) ->
+          let (o, _x_i1) = o#regex _x_i1 in (o, (Alternate ((_x, _x_i1))))
+      | Group _x -> let (o, _x) = o#regex _x in (o, (Group _x))
+      | Repeat ((_x, _x_i1)) ->
           let (o, _x) = o#unknown _x in
-          let (o, _x_i1) = o#regex _x_i1 in (o, (`Repeat ((_x, _x_i1))))
-      | `Splice _x -> let (o, _x) = o#phrase _x in (o, (`Splice _x))
-      | `Replace ((_x, _x_i1)) ->
+          let (o, _x_i1) = o#regex _x_i1 in (o, (Repeat ((_x, _x_i1))))
+      | Splice _x -> let (o, _x) = o#phrase _x in (o, (Splice _x))
+      | Replace ((_x, _x_i1)) ->
           let (o, _x) = o#regex _x in
           let (o, _x_i1) = o#replace_rhs _x_i1
-          in (o, (`Replace ((_x, _x_i1))))
+          in (o, (Replace ((_x, _x_i1))))
 
     method program : program -> ('self_type * program) =
       fun (_x, _x_i1) ->

--- a/core/sugarTraversals.ml
+++ b/core/sugarTraversals.ml
@@ -558,7 +558,7 @@ class map =
       | `Var _x -> let _x = o#known_type_variable _x in `Var _x
 
     method fieldconstraint : fieldconstraint -> fieldconstraint =
-      function | `Readonly -> `Readonly | `Default -> `Default
+      fun fc -> fc
 
     method directive : directive -> directive =
       fun (_x, _x_i1) ->
@@ -1227,7 +1227,7 @@ class fold =
       | `Var _x -> let o = o#known_type_variable _x in o
 
     method fieldconstraint : fieldconstraint -> 'self_type =
-      function | `Readonly -> o | `Default -> o
+      fun _ -> o
 
     method directive : directive -> 'self_type =
       fun (_x, _x_i1) ->
@@ -1995,9 +1995,8 @@ class fold_map =
       | `Absent -> (o, `Absent)
       | `Var _x -> let (o, _x) = o#known_type_variable _x in (o, `Var _x)
 
-    method fieldconstraint :
-      fieldconstraint -> ('self_type * fieldconstraint) =
-      function | `Readonly -> (o, `Readonly) | `Default -> (o, `Default)
+    method fieldconstraint : fieldconstraint -> ('self_type * fieldconstraint) =
+      fun fc -> (o, fc)
 
     method directive : directive -> ('self_type * directive) =
       fun (_x, _x_i1) ->

--- a/core/sugarTraversals.ml
+++ b/core/sugarTraversals.ml
@@ -152,7 +152,7 @@ class map =
 
     method given_spawn_location : given_spawn_location -> given_spawn_location =
       function
-        | `ExplicitSpawnLocation p -> `ExplicitSpawnLocation (o#phrase p)
+        | ExplicitSpawnLocation p -> ExplicitSpawnLocation (o#phrase p)
         | l -> l
 
     method phrasenode : phrasenode -> phrasenode =
@@ -869,7 +869,7 @@ class fold =
           o
 
     method given_spawn_location : given_spawn_location -> 'self_type = function
-      | `ExplicitSpawnLocation p -> let o = o#phrase p in o
+      | ExplicitSpawnLocation p -> let o = o#phrase p in o
       | _ -> o
 
     method phrasenode : phrasenode -> 'self_type =
@@ -1554,7 +1554,7 @@ class fold_map =
         in (o, (_x, _x_i1, _x_i2))
 
     method given_spawn_location : given_spawn_location -> ('self_type * given_spawn_location) = function
-      | `ExplicitSpawnLocation _p -> let (o, _p) = o#phrase _p in (o, `ExplicitSpawnLocation _p)
+      | ExplicitSpawnLocation _p -> let (o, _p) = o#phrase _p in (o, ExplicitSpawnLocation _p)
       | l -> (o, l)
 
     method phrasenode : phrasenode -> ('self_type * phrasenode) =

--- a/core/sugarTraversals.ml
+++ b/core/sugarTraversals.ml
@@ -441,14 +441,14 @@ class map =
 
     method cp_phrasenode : cp_phrasenode -> cp_phrasenode =
       function
-      | `Unquote (bs, e) -> `Unquote (o#list (fun o -> o#binding) bs, o#phrase e)
-      | `Grab (c, x, p) -> `Grab (c, x, o#cp_phrase p)
-      | `Give (c, e, p) -> `Give (c, o#option (fun o -> o#phrase) e, o#cp_phrase p)
-      | `GiveNothing c -> `GiveNothing (o#binder c)
-      | `Select (c, l, p) -> `Select (c, l, o#cp_phrase p)
-      | `Offer (c, bs) -> `Offer (c, o#list (fun o (l, p) -> (l, o#cp_phrase p)) bs)
-      | `Link (c, d) -> `Link (c, d)
-      | `Comp (c, p, q) -> `Comp (c, o#cp_phrase p, o#cp_phrase q)
+      | Unquote (bs, e)  -> Unquote (o#list (fun o -> o#binding) bs, o#phrase e)
+      | Grab (c, x, p)   -> Grab (c, x, o#cp_phrase p)
+      | Give (c, e, p)   -> Give (c, o#option (fun o -> o#phrase) e, o#cp_phrase p)
+      | GiveNothing c    -> GiveNothing (o#binder c)
+      | Select (c, l, p) -> Select (c, l, o#cp_phrase p)
+      | Offer (c, bs)    -> Offer (c, o#list (fun o (l, p) -> (l, o#cp_phrase p)) bs)
+      | Link (c, d)      -> Link (c, d)
+      | Comp (c, p, q)   -> Comp (c, o#cp_phrase p, o#cp_phrase q)
 
     method cp_phrase : cp_phrase -> cp_phrase =
       fun {node; pos} -> with_pos (o#position pos) (o#cp_phrasenode node)
@@ -1126,14 +1126,14 @@ class fold =
 
     method cp_phrasenode : cp_phrasenode -> 'self_type =
       function
-      | `Unquote (bs, e) -> (o#list (fun o -> o#binding) bs)#phrase e
-      | `Grab (_c, _x, p) -> o#cp_phrase p
-      | `Give (_c, e, p) -> (o#option (fun o -> o#phrase) e)#cp_phrase p
-      | `GiveNothing c -> o#binder c
-      | `Select (_c, _l, p) -> o#cp_phrase p
-      | `Offer (_c, bs) -> o#list (fun o (_l, b) -> o#cp_phrase b) bs
-      | `Link (_c, _d) -> o
-      | `Comp (_c, p, q) -> (o#cp_phrase p)#cp_phrase q
+      | Unquote (bs, e)    -> (o#list (fun o -> o#binding) bs)#phrase e
+      | Grab (_c, _x, p)   -> o#cp_phrase p
+      | Give (_c, e, p)    -> (o#option (fun o -> o#phrase) e)#cp_phrase p
+      | GiveNothing c      -> o#binder c
+      | Select (_c, _l, p) -> o#cp_phrase p
+      | Offer (_c, bs)     -> o#list (fun o (_l, b) -> o#cp_phrase b) bs
+      | Link (_c, _d)      -> o
+      | Comp (_c, p, q)    -> (o#cp_phrase p)#cp_phrase q
 
     method cp_phrase : cp_phrase -> 'self_node =
       fun {node; pos} -> (o#cp_phrasenode node)#position pos
@@ -1862,34 +1862,34 @@ class fold_map =
 
     method cp_phrasenode : cp_phrasenode -> ('self_type * cp_phrasenode) =
       function
-      | `Unquote (bs, e) ->
+      | Unquote (bs, e) ->
          let o, bs = o#list (fun o -> o#binding) bs in
          let o, e = o#phrase e in
-         o, `Unquote (bs, e)
-      | `Grab (c, x, p) ->
+         o, Unquote (bs, e)
+      | Grab (c, x, p) ->
          let o, p = o#cp_phrase p in
-         o, `Grab (c, x, p)
-      | `Give (c, e, p) ->
+         o, Grab (c, x, p)
+      | Give (c, e, p) ->
          let o, e = o#option (fun o -> o#phrase) e in
          let o, p = o#cp_phrase p in
-         o, `Give (c, e, p)
-      | `GiveNothing c ->
+         o, Give (c, e, p)
+      | GiveNothing c ->
          let o, c = o#binder c in
-         o, `GiveNothing c
-      | `Select (c, l, p) ->
+         o, GiveNothing c
+      | Select (c, l, p) ->
          let o, p = o#cp_phrase p in
-         o, `Select (c, l, p)
-      | `Offer (c, bs) ->
+         o, Select (c, l, p)
+      | Offer (c, bs) ->
          let o, bs = o#list (fun o (l, p) ->
                              let o, p = o#cp_phrase p in
                              o, (l, p)) bs in
-         o, `Offer (c, bs)
-      | `Link (c, d) ->
-         o, `Link (c, d)
-      | `Comp (c, p, q) ->
+         o, Offer (c, bs)
+      | Link (c, d) ->
+         o, Link (c, d)
+      | Comp (c, p, q) ->
          let o, p = o#cp_phrase p in
          let o, q = o#cp_phrase q in
-         o, `Comp (c, p, q)
+         o, Comp (c, p, q)
 
     method cp_phrase : cp_phrase -> ('self_type * cp_phrase) =
       fun {node; pos} ->

--- a/core/sugarTraversals.mli
+++ b/core/sugarTraversals.mli
@@ -45,7 +45,6 @@ class map :
     method cp_phrase       : cp_phrase -> cp_phrase
     method patternnode     : patternnode -> patternnode
     method pattern         : pattern -> pattern
-    method operator        : operator -> operator
     method name            : name -> name
     method logical_binop   : logical_binop -> logical_binop
     method location        : location -> location
@@ -116,7 +115,6 @@ class fold :
     method cp_phrase       : cp_phrase -> 'self
     method patternnode     : patternnode -> 'self
     method pattern         : pattern -> 'self
-    method operator        : operator -> 'self
     method name            : name -> 'self
     method logical_binop   : logical_binop -> 'self
     method location        : location -> 'self
@@ -179,7 +177,6 @@ object ('self)
   method location        : location -> 'self * location
   method logical_binop   : logical_binop -> 'self * logical_binop
   method name            : name -> 'self * name
-  method operator        : operator -> 'self * operator
   method option          : 'a . ('self -> 'a -> 'self * 'a) -> 'a option -> 'self * 'a option
   method patternnode     : patternnode -> 'self * patternnode
   method pattern         : pattern -> 'self * pattern

--- a/core/sugartypes.ml
+++ b/core/sugartypes.ml
@@ -204,11 +204,10 @@ type replace_rhs = [
 | `Literal of string
 | `Splice  of phrase
 ]
-and given_spawn_location = [
-  | `ExplicitSpawnLocation of phrase (* spawnAt function *)
-  | `SpawnClient (* spawnClient function *)
-  | `NoSpawnLocation (* spawn function *)
-]
+and given_spawn_location =
+| ExplicitSpawnLocation of phrase (* spawnAt function *)
+| SpawnClient (* spawnClient function *)
+| NoSpawnLocation (* spawn function *)
 and regex = [
 | `Range     of char * char
 | `Simply    of string

--- a/core/sugartypes.ml
+++ b/core/sugartypes.ml
@@ -223,7 +223,8 @@ and regex =
 | Replace   of (regex * replace_rhs)
 and clause = pattern * phrase
 and funlit = pattern list list * phrase
-and handlerlit = [`Deep | `Shallow] * pattern * clause list * pattern list list option (* computation arg, cases, parameters *)
+and handler_depth = Deep | Shallow
+and handlerlit = handler_depth * pattern * clause list * pattern list list option (* computation arg, cases, parameters *)
 and handler = {
   sh_expr: phrase;
   sh_effect_cases: clause list;
@@ -231,7 +232,7 @@ and handler = {
   sh_descr: handler_descriptor
 }
 and handler_descriptor = {
-  shd_depth: [`Deep | `Shallow];
+  shd_depth: handler_depth;
   shd_types: Types.row * Types.datatype * Types.row * Types.datatype;
   shd_raw_row: Types.row;
   shd_params: handler_parameterisation option

--- a/core/sugartypes.ml
+++ b/core/sugartypes.ml
@@ -130,7 +130,7 @@ type quantifier = type_variable
 
 let rigidify (name, kind, _) = (name, kind, `Rigid)
 
-type fieldconstraint = [ `Readonly | `Default ]
+type fieldconstraint = Readonly | Default
     [@@deriving show]
 
 type datatypenode =

--- a/core/sugartypes.ml
+++ b/core/sugartypes.ml
@@ -18,7 +18,7 @@ type unary_op = [
 | `FloatMinus
 | `Name of name
 ]
-and regexflag = [`RegexList | `RegexNative | `RegexGlobal | `RegexReplace ]
+and regexflag = RegexList | RegexNative | RegexGlobal | RegexReplace
     [@@deriving show]
 type logical_binop = [`And | `Or ]
     [@@deriving show]

--- a/core/sugartypes.ml
+++ b/core/sugartypes.ml
@@ -337,15 +337,15 @@ and sentence = [
 | `Definitions of binding list
 | `Expression  of phrase
 | `Directive   of directive ]
-and cp_phrasenode = [
-| `Unquote of binding list * phrase
-| `Grab of (string * (Types.datatype * tyarg list) option) * binder option * cp_phrase
-| `Give of (string * (Types.datatype * tyarg list) option) * phrase option * cp_phrase
-| `GiveNothing of binder
-| `Select of binder * string * cp_phrase
-| `Offer of binder * (string * cp_phrase) list
-| `Link of binder * binder
-| `Comp of binder * cp_phrase * cp_phrase ]
+and cp_phrasenode =
+| Unquote     of (binding list * phrase)
+| Grab        of (string * (Types.datatype * tyarg list) option) * binder option * cp_phrase
+| Give        of (string * (Types.datatype * tyarg list) option) * phrase option * cp_phrase
+| GiveNothing of binder
+| Select      of (binder * string * cp_phrase)
+| Offer       of (binder * (string * cp_phrase) list)
+| Link        of (binder * binder)
+| Comp        of (binder * cp_phrase * cp_phrase)
 and cp_phrase = cp_phrasenode with_pos
     [@@deriving show]
 
@@ -574,18 +574,18 @@ struct
     | `Replace (r, `Literal _) -> regex r
     | `Replace (r, `Splice p) -> union (regex r) (phrase p)
   and cp_phrase {node = p; _ } = match p with
-    | `Unquote e -> block e
-    | `Grab ((c, _t), Some bndr, p) ->
-       union (singleton c) (diff (cp_phrase p) (singleton (name_of_binder bndr)))
-    | `Grab ((c, _t), None, p) -> union (singleton c) (cp_phrase p)
-    | `Give ((c, _t), e, p) -> union (singleton c) (union (option_map phrase e) (cp_phrase p))
-    | `GiveNothing bndr -> singleton (name_of_binder bndr)
-    | `Select (bndr, _label, p) ->
-       union (singleton (name_of_binder bndr)) (cp_phrase p)
-    | `Offer (bndr, cases) ->
-       union (singleton (name_of_binder bndr)) (union_map (fun (_label, p) -> cp_phrase p) cases)
-    | `Link (bndr1, bndr2) ->
-       union (singleton (name_of_binder bndr1)) (singleton (name_of_binder bndr2))
-    | `Comp (bndr, left, right) ->
+    | Unquote e -> block e
+    | Grab ((c, _t), Some bndr, p) ->
+      union (singleton c) (diff (cp_phrase p) (singleton (name_of_binder bndr)))
+    | Grab ((c, _t), None, p) -> union (singleton c) (cp_phrase p)
+    | Give ((c, _t), e, p) -> union (singleton c) (union (option_map phrase e) (cp_phrase p))
+    | GiveNothing bndr -> singleton (name_of_binder bndr)
+    | Select (bndr, _label, p) ->
+      union (singleton (name_of_binder bndr)) (cp_phrase p)
+    | Offer (bndr, cases) ->
+      union (singleton (name_of_binder bndr)) (union_map (fun (_label, p) -> cp_phrase p) cases)
+    | Link (bndr1, bndr2) ->
+      union (singleton (name_of_binder bndr1)) (singleton (name_of_binder bndr2))
+    | Comp (bndr, left, right) ->
        diff (union (cp_phrase left) (cp_phrase right)) (singleton (name_of_binder bndr))
 end

--- a/core/sugartypes.ml
+++ b/core/sugartypes.ml
@@ -333,10 +333,10 @@ and bindingnode = [
 and binding = bindingnode with_pos
 and block_body = binding list * phrase
 and directive = string * string list
-and sentence = [
-| `Definitions of binding list
-| `Expression  of phrase
-| `Directive   of directive ]
+and sentence =
+| Definitions of binding list
+| Expression  of phrase
+| Directive   of directive
 and cp_phrasenode =
 | Unquote     of (binding list * phrase)
 | Grab        of (string * (Types.datatype * tyarg list) option) * binder option * cp_phrase

--- a/core/sugartypes.ml
+++ b/core/sugartypes.ml
@@ -24,8 +24,6 @@ type logical_binop = [`And | `Or ]
     [@@deriving show]
 type binop = [ `Minus | `FloatMinus | `RegexMatch of regexflag list | logical_binop | `Cons | `Name of name ]
     [@@deriving show]
-type operator = [ unary_op | binop | `Project of name ]
-    [@@deriving show]
 
 let string_of_unary_op =
   function

--- a/core/sugartypes.ml
+++ b/core/sugartypes.ml
@@ -208,20 +208,19 @@ and given_spawn_location =
 | ExplicitSpawnLocation of phrase (* spawnAt function *)
 | SpawnClient (* spawnClient function *)
 | NoSpawnLocation (* spawn function *)
-and regex = [
-| `Range     of char * char
-| `Simply    of string
-| `Quote     of regex
-| `Any
-| `StartAnchor
-| `EndAnchor
-| `Seq       of regex list
-| `Alternate of regex * regex
-| `Group     of regex
-| `Repeat    of Regex.repeat * regex
-| `Splice    of phrase
-| `Replace   of regex * replace_rhs
-]
+and regex =
+| Range     of (char * char)
+| Simply    of string
+| Quote     of regex
+| Any
+| StartAnchor
+| EndAnchor
+| Seq       of regex list
+| Alternate of (regex * regex)
+| Group     of regex
+| Repeat    of (Regex.repeat * regex)
+| Splice    of phrase
+| Replace   of (regex * replace_rhs)
 and clause = pattern * phrase
 and funlit = pattern list list * phrase
 and handlerlit = [`Deep | `Shallow] * pattern * clause list * pattern list list option (* computation arg, cases, parameters *)
@@ -559,19 +558,19 @@ struct
               union exprfree (diff bodyfree patbound))
   and case (pat, body) : StringSet.t = diff (phrase body) (pattern pat)
   and regex = function
-    | `Range _
-    | `Simply _
-    | `Any
-    | `StartAnchor
-    | `EndAnchor
-    | `Quote _ -> empty
-    | `Seq rs -> union_map regex rs
-    | `Alternate (r1, r2) -> union (regex r1) (regex r2)
-    | `Group r
-    | `Repeat (_, r) -> regex r
-    | `Splice p -> phrase p
-    | `Replace (r, `Literal _) -> regex r
-    | `Replace (r, `Splice p) -> union (regex r) (phrase p)
+    | Range _
+    | Simply _
+    | Any
+    | StartAnchor
+    | EndAnchor
+    | Quote _ -> empty
+    | Seq rs -> union_map regex rs
+    | Alternate (r1, r2) -> union (regex r1) (regex r2)
+    | Group r
+    | Repeat (_, r) -> regex r
+    | Splice p -> phrase p
+    | Replace (r, `Literal _) -> regex r
+    | Replace (r, `Splice p) -> union (regex r) (phrase p)
   and cp_phrase {node = p; _ } = match p with
     | Unquote e -> block e
     | Grab ((c, _t), Some bndr, p) ->

--- a/core/sugartypes.ml
+++ b/core/sugartypes.ml
@@ -197,7 +197,7 @@ type patternnode = [
 and pattern = patternnode with_pos
     [@@deriving show]
 
-type spawn_kind = [ `Angel | `Demon | `Wait ]
+type spawn_kind = Angel | Demon | Wait
     [@@deriving show]
 
 type replace_rhs = [

--- a/core/transformSugar.ml
+++ b/core/transformSugar.ml
@@ -28,9 +28,9 @@ let type_binary_op env tycon_env =
   | `Minus        -> TyEnv.lookup env "-"
   | `FloatMinus   -> TyEnv.lookup env "-."
   | `RegexMatch flags ->
-      let nativep  = List.exists ((=) `RegexNative)  flags
-      and listp    = List.exists ((=) `RegexList)    flags
-      and replacep = List.exists ((=) `RegexReplace) flags in
+      let nativep  = List.exists ((=) RegexNative)  flags
+      and listp    = List.exists ((=) RegexList)    flags
+      and replacep = List.exists ((=) RegexReplace) flags in
         (match replacep, listp, nativep with
            | true,   _   , false -> (* stilde  *) datatype "(String, Regex) -> String"
            | false, true , false -> (* ltilde *)  datatype "(String, Regex) -> [String]"

--- a/core/transformSugar.ml
+++ b/core/transformSugar.ml
@@ -184,11 +184,11 @@ class transform (env : Types.typing_environment) =
 
     method sentence : sentence -> ('self_type * sentence) =
       function
-      | `Definitions defs ->
+      | Definitions defs ->
           let (o, defs) = listu o (fun o -> o#binding) defs
-          in (o, `Definitions defs)
-      | `Expression e -> let (o, e, _) = o#phrase e in (o, `Expression e)
-      | `Directive d -> (o, `Directive d)
+          in (o, Definitions defs)
+      | Expression e -> let (o, e, _) = o#phrase e in (o, Expression e)
+      | Directive d -> (o, Directive d)
 
     method regex : regex -> ('self_type * regex) =
       function

--- a/core/transformSugar.ml
+++ b/core/transformSugar.ml
@@ -244,7 +244,7 @@ class transform (env : Types.typing_environment) =
           in
             (o, `FunLit (Some argss, lin, lam, location), t)
       | `HandlerLit _ -> assert false
-      | `Spawn (`Wait, loc, body, Some inner_effects) ->
+      | `Spawn (Wait, loc, body, Some inner_effects) ->
           assert (loc = NoSpawnLocation);
           (* bring the inner effects into scope, then restore the
              environments afterwards *)
@@ -253,7 +253,7 @@ class transform (env : Types.typing_environment) =
           let o = o#with_effects inner_effects in
           let (o, body, body_type) = o#phrase body in
           let o = o#restore_envs envs in
-            (o, `Spawn (`Wait, loc, body, Some inner_effects), body_type)
+            (o, `Spawn (Wait, loc, body, Some inner_effects), body_type)
       | `Spawn (k, spawn_loc, body, Some inner_effects) ->
           (* bring the inner effects into scope, then restore the
              environments afterwards *)

--- a/core/transformSugar.ml
+++ b/core/transformSugar.ml
@@ -192,25 +192,25 @@ class transform (env : Types.typing_environment) =
 
     method regex : regex -> ('self_type * regex) =
       function
-        | (`Range _ | `Simply _ | `Any  | `StartAnchor | `EndAnchor) as r -> (o, r)
-        | `Quote r -> let (o, r) = o#regex r in (o, `Quote r)
-        | `Seq rs ->
-            let (o, rs) = listu o (fun o -> o#regex) rs in (o, `Seq rs)
-        | `Alternate (r1, r2) ->
+        | (Range _ | Simply _ | Any  | StartAnchor | EndAnchor) as r -> (o, r)
+        | Quote r -> let (o, r) = o#regex r in (o, Quote r)
+        | Seq rs ->
+            let (o, rs) = listu o (fun o -> o#regex) rs in (o, Seq rs)
+        | Alternate (r1, r2) ->
             let (o, r1) = o#regex r1 in
             let (o, r2) = o#regex r2 in
-              (o, `Alternate (r1, r2))
-        | `Group r -> let (o, r) = o#regex r in (o, `Group r)
-        | `Repeat (repeat, r) ->
-            let (o, r) = o#regex r in (o, `Repeat (repeat, r))
-        | `Splice e -> let (o, e, _) = o#phrase e in (o, `Splice e)
-        | `Replace (r, `Literal s) ->
+              (o, Alternate (r1, r2))
+        | Group r -> let (o, r) = o#regex r in (o, Group r)
+        | Repeat (repeat, r) ->
+            let (o, r) = o#regex r in (o, Repeat (repeat, r))
+        | Splice e -> let (o, e, _) = o#phrase e in (o, Splice e)
+        | Replace (r, `Literal s) ->
             let (o, r) = o#regex r in
-              (o, `Replace (r, `Literal s))
-        | `Replace (r, `Splice e) ->
+              (o, Replace (r, `Literal s))
+        | Replace (r, `Splice e) ->
             let (o, r) = o#regex r in
             let (o, e, _) = o#phrase e in
-              (o, `Replace (r, `Splice e))
+              (o, Replace (r, `Splice e))
 
     method program : program -> ('self_type * program * Types.datatype option) =
       fun (bs, e) ->

--- a/core/transformSugar.ml
+++ b/core/transformSugar.ml
@@ -221,9 +221,9 @@ class transform (env : Types.typing_environment) =
     method given_spawn_location :
       given_spawn_location ->
       ('self_type * given_spawn_location) = function
-        | `ExplicitSpawnLocation p ->
+        | ExplicitSpawnLocation p ->
             let (o, phr, _phr_ty) = o#phrase p in
-            (o, `ExplicitSpawnLocation phr)
+            (o, ExplicitSpawnLocation phr)
         | l -> (o, l)
 
     method phrasenode : phrasenode -> ('self_type * phrasenode * Types.datatype) =
@@ -245,7 +245,7 @@ class transform (env : Types.typing_environment) =
             (o, `FunLit (Some argss, lin, lam, location), t)
       | `HandlerLit _ -> assert false
       | `Spawn (`Wait, loc, body, Some inner_effects) ->
-          assert (loc = `NoSpawnLocation);
+          assert (loc = NoSpawnLocation);
           (* bring the inner effects into scope, then restore the
              environments afterwards *)
           let envs = o#backup_envs in

--- a/core/transformSugar.ml
+++ b/core/transformSugar.ml
@@ -821,44 +821,44 @@ class transform (env : Types.typing_environment) =
 
     (* TODO: should really invoke o#datatype on type annotations! *)
     method cp_phrasenode : cp_phrasenode -> ('self_type * cp_phrasenode * Types.datatype) = function
-      | `Unquote (bs, e) ->
+      | Unquote (bs, e) ->
          let envs = o#backup_envs in
          let (o, bs) = listu o (fun o -> o#binding) bs in
          let (o, e, t) = o#phrase e in
          let o = o#restore_envs envs in
-         o, `Unquote (bs, e), t
-      | `Grab (cbind, None, p) ->
+         o, Unquote (bs, e), t
+      | Grab (cbind, None, p) ->
          let (o, p, t) = o#cp_phrase p in
-         o, `Grab (cbind, None, p), t
-      | `Grab ((c, Some (`Input (_a, s), _grab_tyargs) as cbind), Some b, p) -> (* FYI: a = u *)
+         o, Grab (cbind, None, p), t
+      | Grab ((c, Some (`Input (_a, s), _grab_tyargs) as cbind), Some b, p) -> (* FYI: a = u *)
          let envs = o#backup_envs in
          let (o, b) = o#binder b in
          let venv = TyEnv.bind (o#get_var_env ()) (c, s) in
          let o = {< var_env = venv >} in
          let (o, p, t) = o#cp_phrase p in
          let o = o#restore_envs envs in
-         o, `Grab (cbind, Some b, p), t
-      | `Give ((c, Some (`Output (_t, s), _tyargs) as cbind), e, p) ->
+         o, Grab (cbind, Some b, p), t
+      | Give ((c, Some (`Output (_t, s), _tyargs) as cbind), e, p) ->
          let envs = o#backup_envs in
          let o = {< var_env = TyEnv.bind (o#get_var_env ()) (c, s) >} in
          let (o, e, _typ) = option o (fun o -> o#phrase) e in
          let (o, p, t) = o#cp_phrase p in
          let o = o#restore_envs envs in
-         o, `Give (cbind, e, p), t
-      | `GiveNothing c ->
+         o, Give (cbind, e, p), t
+      | GiveNothing c ->
          let envs = o#backup_envs in
          let o, c = o#binder c in
          let o = o#restore_envs envs in
-         o, `GiveNothing c, Types.make_endbang_type
-      | `Grab _ -> failwith "Malformed grab in TransformSugar"
-      | `Give _ -> failwith "Malformed give in TransformSugar"
-      | `Select (b, label, p) ->
+         o, GiveNothing c, Types.make_endbang_type
+      | Grab _ -> failwith "Malformed grab in TransformSugar"
+      | Give _ -> failwith "Malformed give in TransformSugar"
+      | Select (b, label, p) ->
          let envs = o#backup_envs in
          let o, b = o#binder b in
          let (o, p, t) = o#cp_phrase p in
          let o = o#restore_envs envs in
-         o, `Select (b, label, p), t
-      | `Offer (b, cases) ->
+         o, Select (b, label, p), t
+      | Offer (b, cases) ->
          let (o, cases) = List.fold_right (fun (label, p) (o, cases) ->
                                            let envs = o#backup_envs in
                                            let o, _ = o#binder b in
@@ -867,16 +867,16 @@ class transform (env : Types.typing_environment) =
          begin
            match List.split cases with
            | cases, t :: _ts ->
-              o, `Offer (b, cases), t
+              o, Offer (b, cases), t
            | _ -> assert false
          end
-      | `Link (c, d) -> o, `Link (c, d), Types.unit_type
-      | `Comp ({node = c, Some s; _} as bndr, left, right) ->
+      | Link (c, d) -> o, Link (c, d), Types.unit_type
+      | Comp ({node = c, Some s; _} as bndr, left, right) ->
          let envs = o#backup_envs in
          let (o, left, _typ) = {< var_env = TyEnv.bind (o#get_var_env ()) (c, s) >}#cp_phrase left in
          let whiny_dual_type s = try Types.dual_type s with Invalid_argument _ -> raise (Invalid_argument ("Attempted to dualize non-session type " ^ Types.string_of_datatype s)) in
          let (o, right, t) = {< var_env = TyEnv.bind (o#get_var_env ()) (c, whiny_dual_type s) >}#cp_phrase right in
          let o = o#restore_envs envs in
-         o, `Comp (bndr, left, right), t
-      | `Comp _ -> assert false
+         o, Comp (bndr, left, right), t
+      | Comp _ -> assert false
   end

--- a/core/typeSugar.ml
+++ b/core/typeSugar.ml
@@ -3281,7 +3281,7 @@ let rec type_check : context -> phrase -> phrase * Types.datatype * usagemap =
                        | [] -> raise Not_found
                      in
                      match descr.shd_params with
-                     | Some params when descr.shd_depth = `Deep ->
+                     | Some params when descr.shd_depth = Deep ->
                         let handler_params = params.shp_types in
                         begin match kpat.node with
                         | `Any ->
@@ -3370,13 +3370,13 @@ let rec type_check : context -> phrase -> phrase * Types.datatype * usagemap =
                      let (_,_,pos') = SourceCode.resolve_pos @@ (fst3 kpat).pos in
                      let kt = TypeUtils.return_type (pattern_typ kpat) in
                      match descr.shd_depth with
-                     | `Deep ->
+                     | Deep ->
                         let eff = context.effect_row in
                         unify ~handle:Gripers.deep_resumption
                           ((pos', kt), no_pos bt);
                         unify ~handle:Gripers.deep_resumption_effects
                           ((pos', `Effect eff), no_pos (`Effect outer_eff))
-                     | `Shallow ->
+                     | Shallow ->
                         let eff = TypeUtils.effect_row (pattern_typ kpat) in
                         unify ~handle:Gripers.shallow_resumption
                           ((pos', kt), no_pos rt);

--- a/core/typeSugar.ml
+++ b/core/typeSugar.ml
@@ -3922,19 +3922,19 @@ and type_cp (context : context) = fun {node = p; pos} ->
   let unify ~pos ~handle (t, u) = unify_or_raise ~pos:pos ~handle:handle (("<unknown>", t), ("<unknown>", u)) in
 
   let (p, t, u) = match p with
-    | `Unquote (bindings, e) ->
+    | Unquote (bindings, e) ->
        let context', bindings, usage_builder = type_bindings context bindings in
        let (e, t, u) = type_check (Types.extend_typing_environment context context') e in
          if Settings.get_value endbang_antiquotes then
            unify ~pos:pos ~handle:Gripers.cp_unquote (t, Types.make_endbang_type);
-         `Unquote (bindings, e), t, usage_builder u
-    | `Grab ((c, _), None, p) ->
+         Unquote (bindings, e), t, usage_builder u
+    | Grab ((c, _), None, p) ->
        let (_, t, _) = type_check context (with_pos pos (`Var c)) in
        let ctype = `Alias (("EndQuery", []), `Input (Types.unit_type, `End)) in
        unify ~pos:pos ~handle:(Gripers.cp_grab c) (t, ctype);
        let (p, pt, u) = type_cp (unbind_var context c) p in
-       `Grab ((c, Some (ctype, [])), None, p), pt, use c u
-    | `Grab ((c, _), Some bndr, p) ->
+       Grab ((c, Some (ctype, [])), None, p), pt, use c u
+    | Grab ((c, _), Some bndr, p) ->
        let x = name_of_binder bndr in
        let (_, t, _) = type_check context (with_pos pos (`Var c)) in
        let a = Types.fresh_type_variable (`Any, `Any) in
@@ -3963,14 +3963,14 @@ and type_cp (context : context) = fun {node = p; pos} ->
               | _ -> assert false
             end
          | _ -> assert false in
-       `Grab ((c, Some (ctype, tyargs)), Some (set_binder_type bndr a), p), pt, use c (StringMap.remove x u)
-    | `Give ((c, _), None, p) ->
+       Grab ((c, Some (ctype, tyargs)), Some (set_binder_type bndr a), p), pt, use c (StringMap.remove x u)
+    | Give ((c, _), None, p) ->
        let (_, t, _) = type_check context (with_pos pos (`Var c)) in
        let ctype = `Output (Types.unit_type, `End) in
        unify ~pos:pos ~handle:(Gripers.cp_give c) (t, ctype);
        let (p, t, u) = type_cp (unbind_var context c) p in
-       `Give ((c, Some (ctype, [])), None, p), t, use c u
-    | `Give ((c, _), Some e, p) ->
+       Give ((c, Some (ctype, [])), None, p), t, use c u
+    | Give ((c, _), Some e, p) ->
        let (_, t, _) = type_check context (with_pos pos (`Var c)) in
        let (e, t', u) = type_check context e in
        let s = Types.fresh_session_variable `Any in
@@ -3993,14 +3993,14 @@ and type_cp (context : context) = fun {node = p; pos} ->
               | _ -> assert false
             end
          | _ -> assert false in
-       `Give ((c, Some (ctype, tyargs)), Some e, p), t, use c (merge_usages [u; u'])
-    | `GiveNothing bndr ->
+       Give ((c, Some (ctype, tyargs)), Some e, p), t, use c (merge_usages [u; u'])
+    | GiveNothing bndr ->
        let c = name_of_binder bndr in
        let binder_pos = bndr.pos in
        let _, t, _ = type_check context (with_pos binder_pos (`Var c)) in
        unify ~pos:pos ~handle:Gripers.(cp_give c) (t, Types.make_endbang_type);
-       `GiveNothing (set_binder_type bndr t), t, StringMap.singleton c 1
-    | `Select (bndr, label, p) ->
+       GiveNothing (set_binder_type bndr t), t, StringMap.singleton c 1
+    | Select (bndr, label, p) ->
        let c = name_of_binder bndr in
        let (_, t, _) = type_check context (with_pos pos  (`Var c)) in
        let s = Types.fresh_session_variable `Any in
@@ -4009,8 +4009,8 @@ and type_cp (context : context) = fun {node = p; pos} ->
        unify ~pos:pos ~handle:(Gripers.cp_select c)
              (t, ctype);
        let (p, t, u) = with_channel c s (type_cp (bind_var context (c, s)) p) in
-       `Select (set_binder_type bndr ctype, label, p), t, use c u
-    | `Offer (bndr, branches) ->
+       Select (set_binder_type bndr ctype, label, p), t, use c u
+    | Offer (bndr, branches) ->
        let c = name_of_binder bndr in
        let (_, t, _) = type_check context (with_pos pos (`Var c)) in
        (*
@@ -4029,8 +4029,8 @@ and type_cp (context : context) = fun {node = p; pos} ->
        let t' = Types.fresh_type_variable (`Any, `Any) in
        List.iter (fun (_, t, _) -> unify ~pos:pos ~handle:Gripers.cp_offer_branches (t, t')) branches;
        let u = usage_compat (List.map (fun (_, _, u) -> u) branches) in
-       `Offer (set_binder_type bndr t, List.map (fun (x, _, _) -> x) branches), t', use c u
-    | `Link (bndr1, bndr2) ->
+       Offer (set_binder_type bndr t, List.map (fun (x, _, _) -> x) branches), t', use c u
+    | Link (bndr1, bndr2) ->
       let c = name_of_binder bndr1 in
       let d = name_of_binder bndr2 in
       let (_, tc, uc) = type_check context (with_pos pos (`Var c)) in
@@ -4040,14 +4040,14 @@ and type_cp (context : context) = fun {node = p; pos} ->
         unify ~pos:pos ~handle:Gripers.cp_link_session
           (td, Types.fresh_type_variable (`Any, `Session));
         unify ~pos:pos ~handle:Gripers.cp_link_dual (Types.dual_type tc, td);
-        `Link (set_binder_type bndr1 tc, set_binder_type bndr1 td), Types.make_endbang_type, merge_usages [uc; ud]
-    | `Comp (bndr, left, right) ->
+        Link (set_binder_type bndr1 tc, set_binder_type bndr1 td), Types.make_endbang_type, merge_usages [uc; ud]
+    | Comp (bndr, left, right) ->
        let c = name_of_binder bndr in
        let s = Types.fresh_session_variable `Any in
        let left, t, u = with_channel c s (type_cp (bind_var context (c, s)) left) in
        let right, t', u' = with_channel c (`Dual s) (type_cp (bind_var context (c, `Dual s)) right) in
        unify ~pos:pos ~handle:Gripers.cp_comp_left (Types.make_endbang_type, t);
-       `Comp (set_binder_type bndr s, left, right), t', merge_usages [u; u'] in
+       Comp (set_binder_type bndr s, left, right), t', merge_usages [u; u'] in
   {node = p; pos}, t, u
 
 let show_pre_sugar_typing = Basicsettings.TypeSugar.show_pre_sugar_typing

--- a/core/typeSugar.ml
+++ b/core/typeSugar.ml
@@ -4083,13 +4083,13 @@ struct
       (fun () ->
          "before type checking: \n"^ show_sentence sentence);
     match sentence with
-      | `Definitions bindings ->
+      | Definitions bindings ->
           let tyenv', bindings, _ = type_bindings tyenv bindings in
           let tyenv' = Types.normalise_typing_environment tyenv' in
-            `Definitions bindings, Types.unit_type, tyenv'
-      | `Expression body ->
+            Definitions bindings, Types.unit_type, tyenv'
+      | Expression body ->
           let body, t, _ = (type_check tyenv body) in
           let t = Types.normalise_datatype t in
-            `Expression body, t, tyenv
-      | `Directive d -> `Directive d, Types.unit_type, tyenv
+            Expression body, t, tyenv
+      | Directive d -> Directive d, Types.unit_type, tyenv
 end

--- a/core/typeSugar.ml
+++ b/core/typeSugar.ml
@@ -2602,7 +2602,7 @@ let rec type_check : context -> phrase -> phrase * Types.datatype * usagemap =
                           unify ~handle:Gripers.query_base_row (pos_and_typ p, no_pos shape) in
             `Query (range, erase p, Some (typ p)), typ p, merge_usages [range_usages; usages p]
         (* mailbox-based concurrency *)
-        | `Spawn (`Wait, l, p, _) ->
+        | `Spawn (Wait, l, p, _) ->
             assert (l = NoSpawnLocation);
             (* (() -{b}-> d) -> d *)
             let inner_effects = Types.make_empty_open_row (`Any, `Any) in
@@ -2616,7 +2616,7 @@ let rec type_check : context -> phrase -> phrase * Types.datatype * usagemap =
                   (no_pos (`Record context.effect_row), no_pos (`Record outer_effects)) in
             let p = type_check (bind_effects context inner_effects) p in
             let return_type = typ p in
-              `Spawn (`Wait, l, erase p, Some inner_effects), return_type, usages p
+              `Spawn (Wait, l, erase p, Some inner_effects), return_type, usages p
         | `Spawn (k, given_loc, p, _) ->
             (* Location -> (() -e-> _) -> Process (e) *)
             (match given_loc with

--- a/core/typeSugar.ml
+++ b/core/typeSugar.ml
@@ -2603,7 +2603,7 @@ let rec type_check : context -> phrase -> phrase * Types.datatype * usagemap =
             `Query (range, erase p, Some (typ p)), typ p, merge_usages [range_usages; usages p]
         (* mailbox-based concurrency *)
         | `Spawn (`Wait, l, p, _) ->
-            assert (l = `NoSpawnLocation);
+            assert (l = NoSpawnLocation);
             (* (() -{b}-> d) -> d *)
             let inner_effects = Types.make_empty_open_row (`Any, `Any) in
             (* TODO: check if pid_type is actually needed somewhere *)
@@ -2620,7 +2620,7 @@ let rec type_check : context -> phrase -> phrase * Types.datatype * usagemap =
         | `Spawn (k, given_loc, p, _) ->
             (* Location -> (() -e-> _) -> Process (e) *)
             (match given_loc with
-              | `ExplicitSpawnLocation loc_phr ->
+              | ExplicitSpawnLocation loc_phr ->
                   let target_ty = `Application (Types.spawn_location, []) in
                   let t = tc loc_phr in
                   let _ = unify ~handle:Gripers.spawn_location (pos_and_typ t, no_pos target_ty) in ()

--- a/core/typeSugar.ml
+++ b/core/typeSugar.ml
@@ -1414,9 +1414,9 @@ let type_binary_op ctxt =
   | `Minus        -> add_empty_usages (Utils.instantiate ctxt.var_env "-")
   | `FloatMinus   -> add_empty_usages (Utils.instantiate ctxt.var_env "-.")
   | `RegexMatch flags ->
-      let nativep  = List.exists ((=) `RegexNative)  flags
-      and listp    = List.exists ((=) `RegexList)    flags
-      and replacep = List.exists ((=) `RegexReplace) flags in
+      let nativep  = List.exists ((=) RegexNative)  flags
+      and listp    = List.exists ((=) RegexList)    flags
+      and replacep = List.exists ((=) RegexReplace) flags in
         begin
           match replacep, listp, nativep with
            | true,   _   , false -> (* stilde  *) add_empty_usages (datatype "(String, Regex) -> String")


### PR DESCRIPTION
A while back we had a discussion about possibly removing use of polymorphic variants in the frontend (Sugartypes). I've made another attempt at doing this with moderate success. There are some datatypes where we can remove the ticks and things Just Work. This patch redefines such easy-win datatypes as standard OCaml variants.

For the majority of the datatypes though the required changes are more involved. I'd like to discuss this during the next Links dev meeting.