### PR TITLE
changed gitattributes file for crlf

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -3,4 +3,4 @@
 
 # An important exception is a file for testing Links' support for DOS line
 # endings
-tests/dos-newlines.links text eol=crlf
+tests/dos-newlines.links text=auto eol=CRLF

--- a/.gitattributes
+++ b/.gitattributes
@@ -3,4 +3,4 @@
 
 # An important exception is a file for testing Links' support for DOS line
 # endings
-tests/dos-newlines.links text=auto eol=CRLF
+tests/dos-newlines.links text=auto eol=crlf


### PR DESCRIPTION
For some reason my git was suddenly showing me that the `tests/dos-newlinks.links` file was modified because of CRLF settings. Seemingly also setting the `text=auto` flag rather than just `text` helps.