### PR TITLE
Add <!doctype html> to each page

### DIFF
--- a/core/page.ml
+++ b/core/page.ml
@@ -77,6 +77,7 @@ module Make_RealPage (C : JS_PAGE_COMPILER) (G : JS_CODEGEN) = struct
       script_tag("  var cgiEnv = {" ^
                     mapstrcat "," (fun (name, value) -> "'" ^ name ^ "':'" ^ value ^ "'") cgi_env ^
                     "};\n  _makeCgiEnvironment();\n") in
+    "<!DOCTYPE html>\n" ^
     in_tag "html" (in_tag "head"
                      (  debug_flag (Settings.get_value Debug.debugging_enabled)
                         ^ ext_script_tag "jslib.js" ^ "\n"


### PR DESCRIPTION
Did you know that not having a `doctype` on a page can cause subtle CSS bugs? Neither did I, until I spent an hour and a half trying to work out why on earth my CSS was displaying differently despite the class structure being exactly the same!