### PR TITLE
Remove extra parentheses in Sugartypes datatypes

### DIFF
--- a/core/desugarFuns.ml
+++ b/core/desugarFuns.ml
@@ -78,13 +78,11 @@ object (o : 'self_type)
             argss
             rt in
         let f = gensym ~prefix:"_fun_" () in
-        let e =
-          block_node
-            ([with_dummy_pos (Fun (unwrap_def ( binder ~ty:ft f, lin, ([], lam)
-                                              , location, None)))],
-             var f)
-        in
-          (o, e, ft)
+        let (bndr, lin, tvs, loc, ty) =
+          unwrap_def ( binder ~ty:ft f, lin, ([], lam), location, None) in
+        let e = block_node ([with_dummy_pos (Fun (bndr, lin, tvs, loc, ty))],
+                            var f)
+        in (o, e, ft)
     | Section (Section.Project name) ->
         let ab, a = Types.fresh_type_quantifier (lin_any, res_any) in
         let rhob, (fields, rho, _) = Types.fresh_row_quantifier (lin_any, res_any) in
@@ -111,7 +109,10 @@ object (o : 'self_type)
         let (o, b) = super#bindingnode b in
           begin
             match b with
-              | Fun r -> (o, Fun (unwrap_def r))
+              | Fun (bndr, lin, tvs, loc, ty) ->
+                 let (bndr', lin', tvs', loc', ty') =
+                   unwrap_def (bndr, lin, tvs, loc, ty) in
+                 (o, Fun (bndr', lin', tvs', loc', ty'))
               | _ -> assert false
           end
     | Funs _ as b ->

--- a/core/desugarFuns.ml
+++ b/core/desugarFuns.ml
@@ -72,14 +72,11 @@ object (o : 'self_type)
         let inner_mb = snd (try last argss with Invalid_argument s -> raise (Invalid_argument ("!"^s))) in
         let (o, lam, rt) = o#funlit inner_mb lam in
         let ft =
-          List.fold_right
-            (fun (args, mb) rt ->
-               `Function (args, mb, rt))
-            argss
-            rt in
+          List.fold_right (fun (args, mb) rt -> `Function (args, mb, rt))
+                          argss rt in
         let f = gensym ~prefix:"_fun_" () in
         let (bndr, lin, tvs, loc, ty) =
-          unwrap_def ( binder ~ty:ft f, lin, ([], lam), location, None) in
+          unwrap_def (binder ~ty:ft f, lin, ([], lam), location, None) in
         let e = block_node ([with_dummy_pos (Fun (bndr, lin, tvs, loc, ty))],
                             var f)
         in (o, e, ft)

--- a/core/desugarModules.ml
+++ b/core/desugarModules.ml
@@ -137,8 +137,8 @@ let rec rename_binders_get_shadow_tbl module_table
       | Fun (bnd, lin, (tvs, fnlit), loc, dt_opt) ->
           let (o, bnd') = self#binder bnd in
           (o, Fun (bnd', lin, (tvs, fnlit), loc, dt_opt))
-      | Type (name, tvs, ty) -> (self, Type (name, tvs, ty))
-      | Val (pat, tvs, loc, ty) -> (self, Val (pat, tvs, loc, ty))
+      | (Type _) as ty -> (self, ty)
+      | (Val  _) as v  -> (self, v )
       | Exp b -> (self, Exp b)
       | Foreign (bnd, raw_name, lang, ext_file, dt) ->
           let (o, bnd') = self#binder bnd in
@@ -210,12 +210,9 @@ and perform_renaming module_table path term_ht type_ht =
           (self, (xs', rv'))
 
     method! bindingnode = function
-      | Module (n, bs) ->
-          (self, Module (n, bs))
-      | AlienBlock (lang, lib, decls) ->
-          (self, AlienBlock (lang, lib, decls))
-      | Foreign (bndr, fname, lang, file, ty) ->
-         (self, Foreign (bndr, fname, lang, file, ty))
+      | (Module     _) as m  -> (self, m )
+      | (AlienBlock _) as ab -> (self, ab)
+      | (Foreign    _) as f  -> (self, f )
       | Type (n, tvs, dt) ->
           (* Add type binding *)
           let fqn = make_path_string path n in

--- a/core/desugarModules.ml
+++ b/core/desugarModules.ml
@@ -137,8 +137,8 @@ let rec rename_binders_get_shadow_tbl module_table
       | Fun (bnd, lin, (tvs, fnlit), loc, dt_opt) ->
           let (o, bnd') = self#binder bnd in
           (o, Fun (bnd', lin, (tvs, fnlit), loc, dt_opt))
-      | Type t -> (self, Type t)
-      | Val v -> (self, Val v)
+      | Type (name, tvs, ty) -> (self, Type (name, tvs, ty))
+      | Val (pat, tvs, loc, ty) -> (self, Val (pat, tvs, loc, ty))
       | Exp b -> (self, Exp b)
       | Foreign (bnd, raw_name, lang, ext_file, dt) ->
           let (o, bnd') = self#binder bnd in
@@ -212,9 +212,10 @@ and perform_renaming module_table path term_ht type_ht =
     method! bindingnode = function
       | Module (n, bs) ->
           (self, Module (n, bs))
-      | AlienBlock ab ->
-          (self, AlienBlock ab)
-      | Foreign f -> (self, Foreign f)
+      | AlienBlock (lang, lib, decls) ->
+          (self, AlienBlock (lang, lib, decls))
+      | Foreign (bndr, fname, lang, file, ty) ->
+         (self, Foreign (bndr, fname, lang, file, ty))
       | Type (n, tvs, dt) ->
           (* Add type binding *)
           let fqn = make_path_string path n in

--- a/core/parser.mly
+++ b/core/parser.mly
@@ -741,7 +741,7 @@ perhaps_generators:
 | separated_list(COMMA, generator)                             { $1 }
 
 generator:
-| list_generator                                               { List  (fst $1, snd $1)  }
+| list_generator                                               { List  (fst $1, snd $1) }
 | table_generator                                              { Table (fst $1, snd $1) }
 
 list_generator:

--- a/core/parser.mly
+++ b/core/parser.mly
@@ -449,7 +449,7 @@ perhaps_name:
 | cp_name?                                                     { $1 }
 
 cp_expression:
-| LBRACE block_contents RBRACE                                 { with_pos $loc (CPUnquote $2) }
+| LBRACE block_contents RBRACE                                 { with_pos $loc (CPUnquote (fst $2, snd $2)) }
 | cp_name LPAREN perhaps_name RPAREN DOT cp_expression         { with_pos $loc (CPGrab ((Binder.to_name $1, None), $3, $6)) }
 | cp_name LPAREN perhaps_name RPAREN                           { with_pos $loc (CPGrab ((Binder.to_name $1, None), $3, cp_unit $loc)) }
 | cp_name LBRACKET exp RBRACKET DOT cp_expression              { with_pos $loc (CPGive ((Binder.to_name $1, None), Some $3, $6)) }
@@ -741,8 +741,8 @@ perhaps_generators:
 | separated_list(COMMA, generator)                             { $1 }
 
 generator:
-| list_generator                                               { List $1  }
-| table_generator                                              { Table $1 }
+| list_generator                                               { List  (fst $1, snd $1)  }
+| table_generator                                              { Table (fst $1, snd $1) }
 
 list_generator:
 | pattern LARROW exp                                           { ($1, $3) }
@@ -1122,7 +1122,7 @@ regex_replace:
 | block                                                        { SpliceExpr $1 }
 
 regex_pattern:
-| RANGE                                                        { Range $1 }
+| RANGE                                                        { Range (fst $1, snd $1) }
 | STRING                                                       { Simply $1 }
 | QUOTEDMETA                                                   { Quote (Simply $1) }
 | DOT                                                          { Any }

--- a/core/refineBindings.ml
+++ b/core/refineBindings.ml
@@ -321,9 +321,9 @@ module RefineTypeBindings = struct
       let ht = Hashtbl.create 30 in
       List.iter (fun {node = bind; pos} ->
         match bind with
-          | Type (name, _, _ as tyTy) ->
-              let refs = typeReferences tyTy typeHt in
-              let referencesSelf = refersToSelf tyTy refs in
+          | Type (name, tvs, ty) ->
+              let refs = typeReferences (name, tvs, ty) typeHt in
+              let referencesSelf = refersToSelf (name, tvs, ty) refs in
               Hashtbl.add ht name (refs, referencesSelf, pos)
           | _ -> assert false;
       ) binds;
@@ -393,8 +393,8 @@ module RefineTypeBindings = struct
       binding list =
     fun ri ht sccs ->
       List.map (fun name ->
-        let res = refineType (Hashtbl.find ht name) [] ht sccs ri in
-        WithPos.dummy (Type res)
+        let (name, tvs, ty) = refineType (Hashtbl.find ht name) [] ht sccs ri in
+        WithPos.dummy (Type (name, tvs, ty))
       ) sccs
 
   let isTypeGroup : binding list -> bool = function
@@ -408,8 +408,8 @@ module RefineTypeBindings = struct
       let ht = Hashtbl.create 30 in
       List.iter (fun {node; _} ->
         match node with
-          | Type (name, _, _ as tyTy) ->
-            Hashtbl.add ht name tyTy;
+          | Type (name, tvs, ty) ->
+            Hashtbl.add ht name (name, tvs, ty);
           | _ -> assert false;
       ) binds;
       let refInfoTable = referenceInfo binds ht in

--- a/core/sugarTraversals.ml
+++ b/core/sugarTraversals.ml
@@ -593,13 +593,10 @@ class map =
          let _x_i1 = o#datatype _x_i1 in
          let _x_i2 = o#datatype _x_i2 in Table (_x, _x_i1, _x_i2)
       | List _x -> let _x = o#datatype _x in List _x
-      | TypeApplication _x ->
-          let _x =
-            (fun (_x, _x_i1) ->
-               let _x = o#name _x in
-               let _x_i1 = o#list (fun o -> o#type_arg) _x_i1 in (_x, _x_i1))
-              _x
-          in TypeApplication _x
+      | TypeApplication (_x, _x_i1) ->
+          let _x = o#name _x in
+          let _x_i1 = o#list (fun o -> o#type_arg) _x_i1
+          in TypeApplication (_x, _x_i1)
       | Primitive _x -> let _x = o#unknown _x in Primitive _x
       | DB -> DB
       | Input (_x, _x_i1) ->
@@ -1252,13 +1249,9 @@ class fold =
       | Table (_x, _x_i1, _x_i2) ->
           let o = o#datatype _x in let o = o#datatype _x_i1 in let o = o#datatype _x_i2 in o
       | List _x -> let o = o#datatype _x in o
-      | TypeApplication _x ->
-          let o =
-            (fun (_x, _x_i1) ->
-               let o = o#name _x in
-               let o = o#list (fun o -> o#type_arg) _x_i1 in o)
-              _x
-          in o
+      | TypeApplication (_x, _x_i1) ->
+          let o = o#name _x in
+          let o = o#list (fun o -> o#type_arg) _x_i1 in o
       | Primitive _x -> let o = o#unknown _x in o
       | DB -> o
       | Input (_x, _x_i1) ->
@@ -2030,14 +2023,10 @@ class fold_map =
           let (o, _x_i1) = o#datatype _x_i1 in
           let (o, _x_i2) = o#datatype _x_i2 in (o, (Table (_x, _x_i1, _x_i2)))
       | List _x -> let (o, _x) = o#datatype _x in (o, (List _x))
-      | TypeApplication _x ->
-          let (o, _x) =
-            (fun (_x, _x_i1) ->
-               let (o, _x) = o#string _x in
-               let (o, _x_i1) = o#list (fun o -> o#type_arg) _x_i1
-               in (o, (_x, _x_i1)))
-              _x
-          in (o, (TypeApplication _x))
+      | TypeApplication (_x, _x_i1) ->
+          let (o, _x) = o#string _x in
+          let (o, _x_i1) = o#list (fun o -> o#type_arg) _x_i1
+          in (o, TypeApplication (_x, _x_i1))
       | Primitive _x ->
           let (o, _x) = o#unknown _x in (o, (Primitive _x))
       | DB -> (o, DB)

--- a/core/sugartypes.ml
+++ b/core/sugartypes.ml
@@ -69,7 +69,7 @@ type fieldconstraint = Readonly | Default
 module Datatype = struct
   type t =
     | TypeVar         of known_type_variable
-    | QualifiedTypeApplication of (name list * type_arg list)
+    | QualifiedTypeApplication of name list * type_arg list
     | Function        of with_pos list * row * with_pos
     | Lolli           of with_pos list * row * with_pos
     | Mu              of name * with_pos
@@ -81,7 +81,7 @@ module Datatype = struct
     | Effect          of row
     | Table           of with_pos * with_pos * with_pos
     | List            of with_pos
-    | TypeApplication of (string * type_arg list)
+    | TypeApplication of string * type_arg list
     | Primitive       of Primitive.t
     | DB
     | Input           of with_pos * with_pos
@@ -147,42 +147,42 @@ and given_spawn_location =
   | SpawnClient (* spawnClient function *)
   | NoSpawnLocation (* spawn function *)
 and regex =
-  | Range     of (char * char)
+  | Range     of char * char
   | Simply    of string
   | Quote     of regex
   | Any
   | StartAnchor
   | EndAnchor
   | Seq       of regex list
-  | Alternate of (regex * regex)
+  | Alternate of regex * regex
   | Group     of regex
-  | Repeat    of (Regex.repeat * regex)
+  | Repeat    of Regex.repeat * regex
   | Splice    of phrase
-  | Replace   of (regex * replace_rhs)
+  | Replace   of regex * replace_rhs
 and clause = Pattern.with_pos * phrase
 and funlit = Pattern.with_pos list list * phrase
 and handlerlit =
   handler_depth * Pattern.with_pos * clause list *
     Pattern.with_pos list list option (* computation arg, cases, parameters *)
-and handler = {
-  sh_expr: phrase;
-  sh_effect_cases: clause list;
-  sh_value_cases: clause list;
-  sh_descr: handler_descriptor
-}
-and handler_descriptor = {
-  shd_depth: handler_depth;
-  shd_types: Types.row * Types.datatype * Types.row * Types.datatype;
-  shd_raw_row: Types.row;
-  shd_params: handler_parameterisation option
-}
-and handler_parameterisation = {
-  shp_bindings: (phrase * Pattern.with_pos) list;
-  shp_types: Types.datatype list
-}
+and handler =
+  { sh_expr         : phrase
+  ; sh_effect_cases : clause list
+  ; sh_value_cases  : clause list
+  ; sh_descr        : handler_descriptor
+  }
+and handler_descriptor =
+  { shd_depth   : handler_depth
+  ; shd_types   : Types.row * Types.datatype * Types.row * Types.datatype
+  ; shd_raw_row : Types.row
+  ; shd_params  : handler_parameterisation option
+  }
+and handler_parameterisation =
+  { shp_bindings : (phrase * Pattern.with_pos) list
+  ; shp_types    : Types.datatype list
+  }
 and iterpatt =
-  | List  of (Pattern.with_pos * phrase)
-  | Table of (Pattern.with_pos * phrase)
+  | List  of Pattern.with_pos * phrase
+  | Table of Pattern.with_pos * phrase
 and phrasenode =
   | Constant         of Constant.t
   | Var              of name
@@ -196,7 +196,7 @@ and phrasenode =
                           Types.row option
   | Query            of (phrase * phrase) option * phrase *
                           Types.datatype option
-  | RangeLit         of (phrase * phrase)
+  | RangeLit         of phrase * phrase
   | ListLit          of phrase list * Types.datatype option
   | Iteration        of iterpatt list * phrase
                         * (*where:*)   phrase option
@@ -258,41 +258,41 @@ and phrasenode =
   | Offer            of phrase * (Pattern.with_pos * phrase) list *
                           Types.datatype option
   | CP               of cp_phrase
-  | TryInOtherwise   of (phrase * Pattern.with_pos * phrase * phrase *
-                           Types.datatype option)
+  | TryInOtherwise   of phrase * Pattern.with_pos * phrase * phrase *
+                          Types.datatype option
   | Raise
 and phrase = phrasenode WithPos.t
 and bindingnode =
-  | Val     of (Pattern.with_pos * (tyvar list * phrase) * Location.t *
-                  datatype' option)
-  | Fun     of (Binder.t * DeclaredLinearity.t * (tyvar list * funlit) * Location.t *
-                  datatype' option)
+  | Val     of Pattern.with_pos * (tyvar list * phrase) * Location.t *
+                 datatype' option
+  | Fun     of Binder.t * DeclaredLinearity.t * (tyvar list * funlit) *
+                 Location.t * datatype' option
   | Funs    of (Binder.t * DeclaredLinearity.t *
                   ((tyvar list *
                    (Types.datatype * Types.quantifier option list) option)
                    * funlit) * Location.t * datatype' option * Position.t) list
-  | Handler of (Binder.t * handlerlit * datatype' option)
-  | Foreign of (Binder.t * name * name * name * datatype')
+  | Handler of Binder.t * handlerlit * datatype' option
+  | Foreign of Binder.t * name * name * name * datatype'
                (* Binder, raw function name, language, external file, type *)
   | QualifiedImport of name list
-  | Type    of (name * (quantifier * tyvar option) list * datatype')
+  | Type    of name * (quantifier * tyvar option) list * datatype'
   | Infix
   | Exp     of phrase
-  | Module  of (name * binding list)
-  | AlienBlock of (name * name * ((Binder.t * datatype') list))
+  | Module  of name * binding list
+  | AlienBlock of name * name * ((Binder.t * datatype') list)
 and binding = bindingnode WithPos.t
 and block_body = binding list * phrase
 and cp_phrasenode =
-  | CPUnquote     of (binding list * phrase)
+  | CPUnquote     of binding list * phrase
   | CPGrab        of (string * (Types.datatype * tyarg list) option) *
                        Binder.t option * cp_phrase
   | CPGive        of (string * (Types.datatype * tyarg list) option) *
                        phrase option * cp_phrase
   | CPGiveNothing of Binder.t
-  | CPSelect      of (Binder.t * string * cp_phrase)
-  | CPOffer       of (Binder.t * (string * cp_phrase) list)
-  | CPLink        of (Binder.t * Binder.t)
-  | CPComp        of (Binder.t * cp_phrase * cp_phrase)
+  | CPSelect      of Binder.t * string * cp_phrase
+  | CPOffer       of Binder.t * (string * cp_phrase) list
+  | CPLink        of Binder.t * Binder.t
+  | CPComp        of Binder.t * cp_phrase * cp_phrase
 and cp_phrase = cp_phrasenode WithPos.t
                   [@@deriving show]
 
@@ -533,7 +533,7 @@ struct
     | Replace (r, Literal _) -> regex r
     | Replace (r, SpliceExpr p) -> union (regex r) (phrase p)
   and cp_phrase p = match WithPos.node p with
-    | CPUnquote e -> block e
+    | CPUnquote (binds, expr) -> block (binds, expr)
     | CPGrab ((c, _t), Some bndr, p) ->
       union (singleton c) (diff (cp_phrase p) (singleton (Binder.to_name bndr)))
     | CPGrab ((c, _t), None, p) -> union (singleton c) (cp_phrase p)


### PR DESCRIPTION
As promised, I am removing redundant parentheses in Sugartypes data declarations. Two question.

1. Previously I would say:

```
generator:
| list_generator    { List  $1 }
| table_generator   { Table $2 }
```
Now I have:
```
generator:
| list_generator    { List  (fst $1, snd $1) }
| table_generator   { Table (fst $1, snd $1) }
```
Feels awkward. Is there a better way?

2. Similarly:
```OCaml
Fun (unwrap_def (binder ~ty:ft f, lin, ([], lam), location, None))
```
became:
```OCaml
let (bndr, lin, tvs, loc, ty) =
   unwrap_def (binder ~ty:ft f, lin, ([], lam), location, None) in
Fun (bndr, lin, tvs, loc, ty)
```
Is that OK?