### PR TITLE
Validate XML nodes during desugaring

### DIFF
--- a/core/desugarLAttributes.ml
+++ b/core/desugarLAttributes.ml
@@ -153,10 +153,12 @@ let replace_lattrs : phrasenode -> phrasenode =
 let desugar_lattributes =
 object
   inherit SugarTraversals.map as super
-  method! phrasenode = function
-    | Xml _ as x when has_lattrs x ->
-        super#phrasenode (replace_lattrs x)
-    | e -> super#phrasenode e
+  method! phrase = function
+    | {node=Xml _ as x; pos} when has_lattrs x ->
+       let x' = WithPos.make ~pos (replace_lattrs x) in
+       let () = validate_xml x' in
+       super#phrase x'
+    | e -> super#phrase e
 end
 
 let has_no_lattributes =

--- a/core/parse.ml
+++ b/core/parse.ml
@@ -38,7 +38,7 @@ fun ~context ?nlhook ~parse ~infun ~name ->
                   Errors.message = "";
                   Errors.linetext = line;
                   Errors.marker = String.make column ' ' ^ "^" })
-      | Sugartypes.ConcreteSyntaxError (msg, pos) ->
+      | Sugartypes.ConcreteSyntaxError (pos, msg) ->
           let start, finish = Position.start pos, Position.finish pos in
           let linespec =
             if start.pos_lnum = finish.pos_lnum

--- a/core/parseXml.ml
+++ b/core/parseXml.ml
@@ -36,7 +36,7 @@ fun ~context ?nlhook ~parse ~infun ~name ->
                   Errors.message = "";
                   Errors.linetext = line;
                   Errors.marker = String.make column ' ' ^ "^" })
-      | Sugartypes.ConcreteSyntaxError (msg, pos) ->
+      | Sugartypes.ConcreteSyntaxError (pos, msg) ->
           let start, finish = Position.start pos, Position.finish pos in
           let linespec =
             if start.pos_lnum = finish.pos_lnum

--- a/core/parser.mly
+++ b/core/parser.mly
@@ -80,14 +80,14 @@ let primary_kind_of_string p =
   | "Row"      -> pk_row
   | "Presence" -> pk_presence
   | pk         ->
-     raise (ConcreteSyntaxError ("Invalid primary kind: " ^ pk, pos p))
+     raise (ConcreteSyntaxError (pos p, "Invalid primary kind: " ^ pk))
 
 let linearity_of_string p =
   function
   | "Any" -> lin_any
   | "Unl" -> lin_unl
   | lin   ->
-     raise (ConcreteSyntaxError ("Invalid kind linearity: " ^ lin, pos p))
+     raise (ConcreteSyntaxError (pos p, "Invalid kind linearity: " ^ lin))
 
 let restriction_of_string p =
   function
@@ -95,7 +95,7 @@ let restriction_of_string p =
   | "Base"    -> res_base
   | "Session" -> res_session
   | rest      ->
-     raise (ConcreteSyntaxError ("Invalid kind restriction: " ^ rest, pos p))
+     raise (ConcreteSyntaxError (pos p, "Invalid kind restriction: " ^ rest))
 
 let full_kind_of pos prim lin rest =
   let p = primary_kind_of_string pos prim in
@@ -128,7 +128,7 @@ let kind_of p =
   | "Base"     -> (pk_type, Some (lin_unl, res_base))
   | "Session"  -> (pk_type, Some (lin_any, res_session))
   | "Eff"      -> (pk_row , Some (lin_unl, res_effect))
-  | k          -> raise (ConcreteSyntaxError ("Invalid kind: " ^ k, pos p))
+  | k          -> raise (ConcreteSyntaxError (pos p, "Invalid kind: " ^ k))
 
 let subkind_of p =
   function
@@ -137,7 +137,7 @@ let subkind_of p =
   | "Base"    -> Some (lin_unl, res_base)
   | "Session" -> Some (lin_any, res_session)
   | "Eff"     -> Some (lin_unl, res_effect)
-  | sk        -> raise (ConcreteSyntaxError ("Invalid subkind: " ^ sk, pos p))
+  | sk        -> raise (ConcreteSyntaxError (pos p, "Invalid subkind: " ^ sk))
 
 let attach_kind (t, k) = (t, k, `Rigid)
 

--- a/core/sugarConstructorsIntf.ml
+++ b/core/sugarConstructorsIntf.ml
@@ -149,6 +149,8 @@ module type SugarConstructorsSig = sig
   val unary_appl  : ?ppos:t ->           UnaryOp.t  -> phrase -> phrase
 
   (* XML *)
+  val validate_xml
+      : ?tags:(string * string) -> phrase -> unit
   val xml
       : ?ppos:t -> ?tags:(string * string) -> name
      -> (name * (phrase list)) list -> phrase option -> phrase list

--- a/core/sugartypes.ml
+++ b/core/sugartypes.ml
@@ -309,14 +309,9 @@ type sentence =
 type program = binding list * phrase option
   [@@deriving show]
 
-(* Why does ConcreteSyntaxError take an
-   unresolved position and yet
-   PatternDuplicateNameError and
-   RedundantPatternMatch take resolved positions?
-*)
-exception ConcreteSyntaxError of (string * Position.t)
+exception ConcreteSyntaxError       of (string * Position.t)
 exception PatternDuplicateNameError of (Position.t * string)
-exception RedundantPatternMatch of Position.t
+exception RedundantPatternMatch     of  Position.t
 
 let tabstr : tyvar list * phrasenode -> phrasenode = fun (tyvars, e) ->
   match tyvars with

--- a/core/sugartypes.ml
+++ b/core/sugartypes.ml
@@ -309,7 +309,7 @@ type sentence =
 type program = binding list * phrase option
   [@@deriving show]
 
-exception ConcreteSyntaxError       of (string * Position.t)
+exception ConcreteSyntaxError       of (Position.t * string)
 exception PatternDuplicateNameError of (Position.t * string)
 exception RedundantPatternMatch     of  Position.t
 

--- a/core/utility.ml
+++ b/core/utility.ml
@@ -406,6 +406,11 @@ struct
     else if less l r then -1
     else 0
 
+  (** Checks whether list contains duplicates *)
+  let rec has_duplicates = function
+    | []        -> false
+    | (x :: xs) -> List.mem x xs || has_duplicates xs
+
   (** Remove duplicates from a list, using the given relation to
       determine `duplicates' *)
   let rec unduplicate equal = function

--- a/core/xmlParser.mly
+++ b/core/xmlParser.mly
@@ -9,12 +9,14 @@ struct
   module Value = Value
 end
 
-let pos (start, finish) : SourceCode.Position.t = SourceCode.Position.make ~start ~finish ~code:None
+let pos (start, finish) : SourceCode.Position.t =
+  SourceCode.Position.make ~start ~finish ~code:None
 
 let ensure_match p (opening : string) (closing : string) = function
   | result when opening = closing -> result
-  | _ -> raise (Sugartypes.ConcreteSyntaxError ("Closing tag '" ^ closing ^ "' does not match start tag '" ^ opening ^ "'.",
-                                     pos p))
+  | _ -> raise (Sugartypes.ConcreteSyntaxError (pos p,
+       Printf.sprintf "Closing tag '%s' does not match start tag '%s'."
+         closing opening))
 
 %}
 


### PR DESCRIPTION
This patch moves XML node validation from Sugar->Ir stage into the desugaring stage. It also ensures that smart constructor performs the same validation.

Fixes #511 
