### PR TITLE
Require recent ppx_deriving_yojson version?

### DIFF
--- a/core/ir.ml
+++ b/core/ir.ml
@@ -2,7 +2,6 @@
 
 open CommonTypes
 
-[@@@ocaml.warning "-39"] (** disables warnings about unused rec flags **)
 
 type scope = Var.scope
   [@@deriving show]

--- a/core/value.ml
+++ b/core/value.ml
@@ -2,7 +2,6 @@ open Utility
 open Notfound
 open ProcessTypes
 
-[@@@ocaml.warning "-39"] (** disables warnings about unused rec flags **)
 
 let _ = ParseSettings.config_file
 

--- a/links.opam
+++ b/links.opam
@@ -18,7 +18,7 @@ depends: [
   "ocaml" {>= "4.06.0"}
   "dune" {build}
   "ppx_deriving"
-  "ppx_deriving_yojson"
+  "ppx_deriving_yojson" {> "3.1"}
   "base64"
   "linenoise"
   "ANSITerminal"

--- a/links.opam
+++ b/links.opam
@@ -18,7 +18,7 @@ depends: [
   "ocaml" {>= "4.06.0"}
   "dune" {build}
   "ppx_deriving"
-  "ppx_deriving_yojson" {> "3.1"}
+  "ppx_deriving_yojson" {>= "3.3"}
   "base64"
   "linenoise"
   "ANSITerminal"


### PR DESCRIPTION
Janek realized that we don't need to suppress warning 39 (about unused rec flags) anymore (see 381fdee26314cc4ae). The warning originated from code generated by earlier versions of ppx_deriving_yojson. Since version 3.3, the generated code doesn't seem to yield those warnings any more. I've therefore un-suppressed those warnings in two additional files.

I'm creating this PR because I'm unsure how we deal with versioning of our dependencies. After my and Janek's change, building a release version of links (or installing a potential future release via opam) would error if one has a pre-3.3 version of ppx_deriving_yojson installed. I therefore added a version constraint to our opam file. Or do we generally give up on tracking the exact version requirements of our dependencies and just hope that users have recent versions installed?

