### PR TITLE
Generate type applications for desugared anonymous functions

### DIFF
--- a/core/transformSugar.ml
+++ b/core/transformSugar.ml
@@ -243,7 +243,7 @@ class transform (env : Types.typing_environment) =
       | Constant c -> let (o, c, t) = o#constant c in (o, Constant c, t)
       | Var var -> (o, Var var, o#lookup_type var)
       | FunLit (Some argss, lin, lam, location) ->
-          let inner_e = snd (try last argss with Invalid_argument s -> raise (Invalid_argument ("@" ^ s))) in
+          let inner_e = snd (last argss) in
           let (o, lam, rt) = o#funlit inner_e lam in
           let (o, t) =
             List.fold_right

--- a/tests/empty_prelude.links
+++ b/tests/empty_prelude.links
@@ -1,0 +1,5 @@
+# This is an empty prelude file for the purpose of running IR typing tests.
+# Since standard Links prelude does not currently produce a type-correct IR we
+# to use an empty one so that we only focus on IR type errors arising from tests
+# programs and not the prelude functions.
+()

--- a/tests/typed_ir.tests
+++ b/tests/typed_ir.tests
@@ -1,0 +1,15 @@
+Anonymous constant function
+fun (x) {1}
+stdout : fun : (_) -> Int
+
+Anonymous identity function
+fun (x) {x}
+stdout : fun : (a::Any) -> a::Any
+
+Anonymous composition function
+fun (f,g) {fun (x){f (g(x))}}
+stdout : fun : ((a::Any) -b-> c::Any, (d::Any) -b-> a::Any) -> (d::Any) -b-> c::Any
+
+XML typing
+fun (x) {<a>{x}</a>}
+stdout : fun : (Xml) -> Xml

--- a/tests/typed_ir.tests.config
+++ b/tests/typed_ir.tests.config
@@ -1,0 +1,3 @@
+typecheck_ir=true
+fail_on_ir_type_error=true
+prelude=tests/empty_prelude.links


### PR DESCRIPTION
This is a speculative fix for some of the IR typing problems reported in #446. Namely, this patch fixes unbound type variable errors for anonymous functions. These two examples now compile without IR errors:

```
fun (x) {x};
fun (x) {1};
```
Moreover, compilation of anonymous composition function `fun (f,g) {fun (x){f (g(x))}};` no longer generates these errors but still has some other errors.

The idea behind a fix is that if we see an anonymous function wrapped in a type abstraction we generate a corresponding type application. So previously we would generate:

```
TAbs Y. { 
  fun freshfun(x:Z) {x}
  freshfun
} 
```
whereas now we generate:
```
TAbs Y. { 
  fun freshfun(x:Z) {x}
  TApp freshfun [Y]
}
```

There is some voodoo coding here, so please review carefully. If this fix is correct then I plan on also updating the comments in `desugarFuns.ml`, because at least some of them are inaccurate.

Now, how would I write a test for this patch? Should I create a custom config file to enable IR typechecking or should I do it some other way?