### PR TITLE
Saner printing of sugar ASTs; settings for dumping ASTs before and after frontend pipeline

### DIFF
--- a/core/basicsettings.ml
+++ b/core/basicsettings.ml
@@ -177,10 +177,10 @@ let print_types_pretty = Settings.add_bool ("print_types_pretty", true, `User)
 let print_colors = Settings.add_bool ("print_colors", false, `User)
 
 (* Print Sugar AST before frontend processing? *)
-let show_pre_frontend_sugar_ast = Settings.add_bool("show_pre_frontend_sugar_ast", false, `User)
+let show_pre_frontend_ast = Settings.add_bool("show_pre_frontend_ast", false, `User)
 
 (* Print Sugar AST after frontend processing? *)
-let show_post_frontend_sugar_ast = Settings.add_bool("show_post_frontend_sugar_ast", false, `User)
+let show_post_frontend_ast = Settings.add_bool("show_post_frontend_ast", false, `User)
 
 (* When dumping sugar constructs, shall we print the embedded position information *)
 let show_sugar_positions =  Settings.add_bool("show_sugar_positions", false, `User)

--- a/core/basicsettings.ml
+++ b/core/basicsettings.ml
@@ -176,6 +176,15 @@ let print_types_pretty = Settings.add_bool ("print_types_pretty", true, `User)
 
 let print_colors = Settings.add_bool ("print_colors", false, `User)
 
+(* Print Sugar AST before frontend processing? *)
+let show_pre_frontend_sugar_ast = Settings.add_bool("show_pre_frontend_sugar_ast", false, `User)
+
+(* Print Sugar AST after frontend processing? *)
+let show_post_frontend_sugar_ast = Settings.add_bool("show_post_frontend_sugar_ast", false, `User)
+
+(* When dumping sugar constructs, shall we print the embedded position information *)
+let show_sugar_positions =  Settings.add_bool("show_sugar_positions", false, `User)
+
 (* Base URL for websocket connections *)
 let websocket_url = Settings.add_string("websocket_url", "/ws/", `User)
 

--- a/core/errors.ml
+++ b/core/errors.ml
@@ -23,10 +23,6 @@ exception TypeApplicationKindMismatch of
   { pos: Position.t; name: string; tyarg_number: int;
     expected: string; provided: string }
 
-let show_pos : Position.t -> string =
-  fun (pos) ->
-    let pos = Position.start pos in
-    Printf.sprintf "%s:%d" pos.Lexing.pos_fname pos.Lexing.pos_lnum
 
 let prefix_lines prefix s =
   prefix ^ Str.global_replace (Str.regexp "\n") ("\n" ^ prefix) s
@@ -73,7 +69,7 @@ let format_exception =
       "*** Error: Duplicate mutually-defined bindings\n" ^
         StringMap.fold (fun name positions message ->
                           message^" "^name^":\n  "^
-			    (mapstrcat "\n  " show_pos (List.rev positions)))
+			    (mapstrcat "\n  " Position.show (List.rev positions)))
           duplicates ""
   | InvalidMutualBinding pos ->
       let pos, expr = Position.resolve_start_expr pos in
@@ -175,5 +171,3 @@ let display ?(default=(fun e -> raise e)) ?(stream=stderr) (e) =
 
 let internal_error ~filename ~message =
   InternalError { filename; message }
-
-

--- a/core/frontend.ml
+++ b/core/frontend.ml
@@ -76,12 +76,12 @@ struct
 
 
 let program tyenv pos_context program =
-  if Settings.get_value Basicsettings.show_pre_frontend_sugar_ast then
+  if Settings.get_value Basicsettings.show_pre_frontend_ast then
     Debug.print ("Pre-Frontend AST:\n" ^ Sugartypes.show_program program);
 
   let ((post_program, _, _), _) as result = program_pipeline tyenv pos_context program in
 
-  if Settings.get_value Basicsettings.show_post_frontend_sugar_ast then
+  if Settings.get_value Basicsettings.show_post_frontend_ast then
     Debug.print ("Post-Frontend AST:\n" ^ Sugartypes.show_program post_program);
 
   result
@@ -110,12 +110,12 @@ let program tyenv pos_context program =
 
 
 let interactive tyenv pos_context sentence =
-  if Settings.get_value Basicsettings.show_pre_frontend_sugar_ast then
+  if Settings.get_value Basicsettings.show_pre_frontend_ast then
     Debug.print ("Pre-Frontend AST:\n" ^ Sugartypes.show_sentence sentence);
 
   let (post_sentence, _, _) as result = interactive_pipeline tyenv pos_context sentence in
 
-  if Settings.get_value Basicsettings.show_post_frontend_sugar_ast then
+  if Settings.get_value Basicsettings.show_post_frontend_ast then
     Debug.print ("Post-Frontend AST:\n" ^ Sugartypes.show_sentence post_sentence);
 
   result

--- a/core/frontend.ml
+++ b/core/frontend.ml
@@ -36,7 +36,7 @@ struct
   let after_typing_ext enabled = extension enabled after_typing
   let before_typing_ext enabled f x = if enabled then f x else x
 
-  let program =
+  let program_pipeline =
     fun tyenv pos_context program ->
       let program = (ResolvePositions.resolve_positions pos_context)#program program in
       let program = DesugarAlienBlocks.transform_alien_blocks program in
@@ -73,6 +73,18 @@ struct
        ->- after_typing ((DesugarPages.desugar_pages tyenv)#program ->- snd3)
        ->- after_typing ((DesugarFuns.desugar_funs tyenv)#program ->- snd3))
         program), ffi_files)
+
+
+let program tyenv pos_context program =
+  if Settings.get_value Basicsettings.show_pre_frontend_sugar_ast then
+    Debug.print ("Pre-Frontend AST:\n" ^ Sugartypes.show_program program);
+
+  let ((post_program, _, _), _) as result = program_pipeline tyenv pos_context program in
+
+  if Settings.get_value Basicsettings.show_post_frontend_sugar_ast then
+    Debug.print ("Post-Frontend AST:\n" ^ Sugartypes.show_program post_program);
+
+  result
 
 
   let interactive =

--- a/core/frontend.ml
+++ b/core/frontend.ml
@@ -87,7 +87,7 @@ let program tyenv pos_context program =
   result
 
 
-  let interactive =
+  let interactive_pipeline =
     fun tyenv pos_context sentence ->
     let sentence = (ResolvePositions.resolve_positions pos_context)#sentence sentence in
     let _sentence = CheckXmlQuasiquotes.checker#sentence sentence in
@@ -107,4 +107,18 @@ let program tyenv pos_context program =
        ->- after_typing ((DesugarFormlets.desugar_formlets tyenv)#sentence ->- snd)
        ->- after_typing ((DesugarPages.desugar_pages tyenv)#sentence ->- snd)
        ->- after_typing ((DesugarFuns.desugar_funs tyenv)#sentence ->- snd)) sentence
+
+
+let interactive tyenv pos_context sentence =
+  if Settings.get_value Basicsettings.show_pre_frontend_sugar_ast then
+    Debug.print ("Pre-Frontend AST:\n" ^ Sugartypes.show_sentence sentence);
+
+  let (post_sentence, _, _) as result = interactive_pipeline tyenv pos_context sentence in
+
+  if Settings.get_value Basicsettings.show_post_frontend_sugar_ast then
+    Debug.print ("Post-Frontend AST:\n" ^ Sugartypes.show_sentence post_sentence);
+
+  result
+
+
 end

--- a/core/sourceCode.ml
+++ b/core/sourceCode.ml
@@ -101,13 +101,13 @@ module Position = struct
       if start_line = finish_line then
         if start_char = finish_char then
           Format.fprintf fmt
-            "line %d, char %d"  start_line start_char
+            "line %d, column %d"  start_line start_char
         else
           Format.fprintf fmt
-            "line %d, chars %d to %d" start_line start_char finish_char
+            "line %d, columns %d to %d" start_line start_char finish_char
       else
         Format.fprintf fmt
-          "line %d, char %d, to line %d, char %d" start_line finish_line start_char finish_char
+          "line %d, column %d, to line %d, column %d" start_line finish_line start_char finish_char
     in
     if pos.start = Lexing.dummy_pos || pos.finish = Lexing.dummy_pos then
       Format.fprintf fmt "<dummy position>"


### PR DESCRIPTION
This PR addresses two printing related things that frequently annoy me while debugging:

**Dumping ASTs**
 I often find myself in a position where I would like to see the sugar AST for a program and hacking something into `frontend.ml` to achieve this.
I've introduced the two settings `show_pre_frontend_sugar_ast` and `show_post_frontend_sugar_ast`. I've switched on, the program AST will be dumped right before, resp. after, executing the frontend pipeline in `frontend.ml`.

**Annoying `pos` fields**
Dumping sugar ASTs (e.g., using Sugartypes.show_program) currently yields a lot of ugly output of the following form:
```
 { SourceCode.WithPos.node =
                           (Sugartypes.Block
                              ([],
                               { SourceCode.WithPos.node =
                                 (Sugartypes.FnAppl (
                                    { SourceCode.WithPos.node =
                                      (Sugartypes.Var "f"); pos = ... },
                                    [{ SourceCode.WithPos.node =
                                       (Sugartypes.Var "x"); pos = ... }
                                      ]
                                    ));
                                 pos = ... }));
                           pos = ... }),
                        CommonTypes.Location.Unknown));
                     pos = ... }))
```
Here, all of the shown `pos` fields of the `WithPos` are unnecessary clutter (in particular because their content is only ever printed as `...`.

In order to address this, the new setting `show_sugar_positions` determines whether or not to show the `pos` blocks at all. I've also implemented some logic to sanely print positions.

With  `show_sugar_positions` enabled we get the following:
```
{ SourceCode.WithPos.node =
                           (Sugartypes.Block
                              ([],
                               { SourceCode.WithPos.node =
                                 (Sugartypes.FnAppl (
                                    { SourceCode.WithPos.node =
                                      (Sugartypes.Var "f");
                                      pos =
                                      File ../my_examples/application.links, line 3, chars 26 to 27
                                      },
                                    [{ SourceCode.WithPos.node =
                                       (Sugartypes.Var "x");
                                       pos =
                                       File ../my_examples/application.links, line 3, chars 28 to 29
                                       }
                                      ]
                                    ));
                                 pos =
                                 File ../my_examples/application.links, line 3, chars 26 to 30
                                 }));
                           pos =
                           File ../my_examples/application.links, line 2, char 4, to line 20, char 34
                           }),
```

without it, we get the following:
```
([],
 (Some (Sugartypes.FunLit (None, CommonTypes.DeclaredLinearity.Unl,
          ([[(Sugartypes.Pattern.Variable ("f", None))]],
           (Sugartypes.Block
              ([],
               (Sugartypes.FunLit (None, CommonTypes.DeclaredLinearity.Unl,
                  ([[(Sugartypes.Pattern.Variable ("x", None))]],
                   (Sugartypes.Block
                      ([],
                       (Sugartypes.FnAppl ((Sugartypes.Var "f"),
                          [(Sugartypes.Var "x")]))))),
                  CommonTypes.Location.Unknown))))),
          CommonTypes.Location.Unknown)))
```

Note that this is supposed to only affect debugging/dumping ASTs, not user-facing stuff. The setting is disabled by default.

However, I've noticed that many of the messages in errors.ml try to do their own formatting of source code positions and ranges. We may want to consolidate that and only use `Position.show` in the future.



