### PR TITLE
Some error message easy wins

### DIFF
--- a/core/checkXmlQuasiquotes.ml
+++ b/core/checkXmlQuasiquotes.ml
@@ -52,10 +52,10 @@ let check mode pos e =
         Printf.sprintf "%s %s in %s quasiquote" node_type expr kind in
       raise (desugaring_error ~pos ~stage:CheckQuasiquotes ~message) in
     match o#get_error with
-    | None -> ()
-    | Some (`FormletBinding, pos') -> raise_error "Formlet binding" pos'
+    | None                           -> ()
+    | Some (`FormletBinding, pos')   -> raise_error "Formlet binding" pos'
     | Some (`FormletPlacement, pos') -> raise_error "Formlet placement" pos'
-    | Some (`PagePlacement, pos') -> raise_error "Page placement" pos'
+    | Some (`PagePlacement, pos')    -> raise_error "Page placement" pos'
 
 (* traverse a whole tree searching for and then checking quasiquotes *)
 let checker =

--- a/core/checkXmlQuasiquotes.ml
+++ b/core/checkXmlQuasiquotes.ml
@@ -45,17 +45,17 @@ let check mode pos e =
     | `Formlet -> "formlet"
     | `Page -> "page"
   in
+    let raise_error node_type pos =
+      let open Errors in
+      let expr = Position.resolve_expression pos in
+      let message =
+        Printf.sprintf "%s %s in %s quasiquote" node_type expr kind in
+      raise (desugaring_error ~pos ~stage:CheckQuasiquotes ~message) in
     match o#get_error with
     | None -> ()
-    | Some (`FormletBinding, pos') ->
-      let expr = Position.resolve_expression pos' in
-        raise (Errors.SugarError (pos, "Formlet binding " ^ expr ^ " in " ^ kind ^ " quasiquote"))
-    | Some (`FormletPlacement, pos') ->
-      let expr = Position.resolve_expression pos' in
-        raise (Errors.SugarError (pos, "Formlet placement " ^ expr ^ " in " ^ kind ^ " quasiquote"))
-    | Some (`PagePlacement, pos') ->
-      let expr = Position.resolve_expression pos' in
-        raise (Errors.SugarError (pos, "Page placement " ^ expr ^ " in " ^ kind ^ " quasiquote"))
+    | Some (`FormletBinding, pos') -> raise_error "Formlet binding" pos'
+    | Some (`FormletPlacement, pos') -> raise_error "Formlet placement" pos'
+    | Some (`PagePlacement, pos') -> raise_error "Page placement" pos'
 
 (* traverse a whole tree searching for and then checking quasiquotes *)
 let checker =
@@ -87,7 +87,9 @@ object (o)
       o#phrase_with `Quasi body
     | (Formlet _ | Page _) when mode = `Quasi ->
       (* The parser should prevent this from ever happening *)
-      raise (Errors.SugarError (pos, "Malformed quasiquote (internal error)"))
+      let message =
+        Printf.sprintf "Malformed quasiquote (%s)" (Position.show pos) in
+      raise (Errors.internal_error ~filename:"checkXmlQuasiquotes.ml" ~message)
     | _ when mode = `Quasi ->
       o#phrase_with `Exp phrase
     | _ when mode = `Exp ->

--- a/core/desugarFormlets.ml
+++ b/core/desugarFormlets.ml
@@ -13,7 +13,11 @@ let rec is_raw phrase =
   | Xml (_, _, _, children) ->
       List.for_all is_raw children
   | _ ->
-      raise (Errors.SugarError (phrase.pos, "Invalid element in formlet literal"))
+      let open Errors in
+      raise (desugaring_error
+        ~pos:phrase.pos
+        ~stage:DesugarFormlets
+        ~message:"Invalid element in formlet literal")
 
 let tt =
   function

--- a/core/desugarLAttributes.ml
+++ b/core/desugarLAttributes.ml
@@ -17,8 +17,9 @@ let desugaring_error pos message =
   let open Errors in
   raise (desugaring_error ~pos ~stage:DesugarLAttributes ~message)
 
-let has_lattrs : phrasenode -> bool = function
-  | Xml (_, attrs, _, _) -> exists (fst ->- start_of ~is:"l:") attrs
+let has_lattrs : phrase -> bool = function
+  | { node=Xml (_, attrs, _, _); _ } ->
+      exists (fst ->- start_of ~is:"l:") attrs
   | _ -> false
 
 let apply name args : phrase = fn_appl name [] args
@@ -34,8 +35,8 @@ let fresh_names () =
   let name = gensym ~prefix:"lname_" () in
   id, name
 
-let desugar_lhref : phrasenode -> phrasenode = function
-  | Xml (("a"|"A") as a, attrs, attrexp, children)
+let desugar_lhref : phrase -> phrase = function
+  | { node=Xml (("a"|"A") as a, attrs, attrexp, children); pos }
       when mem_assoc "l:href" attrs ->
       let attrs =
         match partition (fst ->- (=)"l:href") attrs with
@@ -45,14 +46,15 @@ let desugar_lhref : phrasenode -> phrasenode = function
                 apply "pickleCont" [fun_lit ~location:loc_server dl_unl [[]]
                                             target]])
               :: rest
-          | _ -> assert false (* multiple l:hrefs, or an invalid rhs;
-                                 NOTE: this is a user error and should
-                                 be reported as such --ez.*)
-      in Xml (a, attrs, attrexp, children)
+          | _ ->
+              desugaring_error pos
+                ("Invalid l:href: check that there are not " ^
+                 "multiple l:href attributes")
+      in WithPos.make ~pos (Xml (a, attrs, attrexp, children))
   | e -> e
 
-let desugar_laction : phrasenode -> phrasenode = function
-  | Xml (("form"|"FORM") as form, attrs, attrexp, children)
+let desugar_laction : phrase -> phrase = function
+  | { node=Xml (("form"|"FORM") as form, attrs, attrexp, children); pos }
       when mem_assoc "l:action" attrs ->
       begin match partition (fst ->- (=)"l:action") attrs with
         | [_,[action_expr]], rest ->
@@ -64,15 +66,17 @@ let desugar_laction : phrasenode -> phrasenode = function
                                    [fun_lit ~location:loc_server dl_unl [[]]
                                             action_expr]]]
                   None []
-            and action = ("action", [constant_str "#"])
-            in Xml (form, action::rest, attrexp, hidden::children)
-        | _ -> assert false (* multiple l:actions, or an invalid rhs;
-                               NOTE: this is a user error and should
-                               be reported as such --ez. *)
+            and action = ("action", [constant_str "#"]) in
+            WithPos.make ~pos
+              (Xml (form, action::rest, attrexp, hidden::children))
+        | _ ->
+            desugaring_error pos
+              ("Invalid l:action: check that there are not " ^
+               "multiple l:action attributes")
       end
   | e -> e
 
-let desugar_lonevent : phrasenode -> phrasenode =
+let desugar_lonevent : phrase -> phrase =
   let event_handler_pair = function
     | (name, [rhs]) ->
         let event_name = StringLabels.sub ~pos:4 ~len:(String.length name - 4)
@@ -82,33 +86,36 @@ let desugar_lonevent : phrasenode -> phrasenode =
                          rhs]
     | _ -> assert false
   in function
-    | Xml (tag, attrs, attrexp, children)
+    | { node=Xml (tag, attrs, attrexp, children); pos }
         when exists (fst ->- start_of ~is:"l:on") attrs ->
         let lons, others = partition (fst ->- start_of ~is:"l:on") attrs in
         let idattr =
           ("key",
            [apply "registerEventHandlers"
                   [list (List.map (event_handler_pair) lons)]]) in
-          Xml (tag, idattr::others, attrexp, children)
+          WithPos.make ~pos (Xml (tag, idattr::others, attrexp, children))
     | e -> e
 
-let desugar_lnames (p : phrasenode) : phrasenode * (string * string) StringMap.t =
+let desugar_lnames (p : phrase) : phrase * (string * string) StringMap.t =
   let lnames = ref StringMap.empty in
   let add lname (id,name) = lnames := StringMap.add lname (id,name) !lnames in
-  let attr : string * phrase list -> (string * phrase list) list = function
-    | "l:name", [{node=Constant (Constant.String v); _}] ->
-        let id, name = fresh_names () in
-          add v (id,name);
-          [("name", [constant_str name]);
-           ("id"  , [constant_str id  ])]
-    | "l:name", _ -> failwith ("Invalid l:name binding")
-    | a -> [a] in
-  let rec aux : phrasenode -> phrasenode  = function
-    | Xml (tag, attrs, attrexp, children) ->
-        let attrs = concat_map attr attrs in
+  let attr : Position.t -> string * phrase list -> (string * phrase list) list =
+    fun pos attribute ->
+    match attribute with
+      | "l:name", [{node=Constant (Constant.String v); _}] ->
+          let id, name = fresh_names () in
+            add v (id,name);
+            [("name", [constant_str name]);
+             ("id"  , [constant_str id  ])]
+      | "l:name", _ ->
+          desugaring_error pos "The value l:name binding must be a string constant"
+      | a -> [a] in
+  let rec aux : phrase -> phrase  = function
+    | { node=Xml (tag, attrs, attrexp, children); pos } ->
+        let attrs = concat_map (attr pos) attrs in
         let children =
-          List.map (fun {node;pos} -> with_pos pos (aux node)) children in
-          Xml (tag, attrs, attrexp, children)
+          List.map (fun child -> aux child) children in
+          WithPos.make ~pos (Xml (tag, attrs, attrexp, children))
     | p -> p
   in
   let p' = aux p in
@@ -130,28 +137,25 @@ let bind_lname_vars lnames = function
              es)
   | attr -> attr
 
-let desugar_form : phrasenode -> phrasenode = function
-  | Xml (("form"|"FORM") as form, attrs, attrexp, children) ->
-      let children, poss   = List.split (List.map (fun t -> t.node, t.pos)
-                                                  children) in
+let desugar_form : phrase -> phrase = function
+  | { node=Xml (("form"|"FORM") as form, attrs, attrexp, children); pos } ->
       let children, lnames = List.split (List.map desugar_lnames    children) in
       let lnames =
         try List.fold_left StringMap.union_disjoint StringMap.empty lnames
         with StringMap.Not_disjoint (item, _) ->
-          (* SJF TODO: We should generalise these passes to `phrase`s instead of
-           * `phrasenode`s to get proper position information. *)
-          desugaring_error Position.dummy ("Duplicate l:name binding: " ^ item) in
+          desugaring_error pos ("Duplicate l:name binding: " ^ item) in
       let attrs = List.map (bind_lname_vars lnames) attrs in
-        Xml (form, attrs, attrexp, Utility.zip_with with_pos poss children)
+        WithPos.make ~pos
+          (Xml (form, attrs, attrexp, children))
   | e -> e
 
-let replace_lattrs : phrasenode -> phrasenode =
+let replace_lattrs : phrase -> phrase =
   desugar_form ->- desugar_laction ->- desugar_lhref ->- desugar_lonevent ->-
   (fun (xml) ->
      if (has_lattrs xml) then
        match xml with
-         | Xml (_tag, _attributes, _, _) ->
-            desugaring_error Position.dummy "Illegal l: attribute in XML node"
+         | { node=Xml (_tag, _attributes, _, _); pos } ->
+            desugaring_error pos "Illegal l: attribute in XML node"
          | _ -> assert false
      else
        xml)
@@ -160,10 +164,10 @@ let desugar_lattributes =
 object
   inherit SugarTraversals.map as super
   method! phrase = function
-    | {node=Xml _ as x; pos} when has_lattrs x ->
-       let x' = WithPos.make ~pos (replace_lattrs x) in
-       let () = validate_xml x' in
-       super#phrase x'
+    | {node=Xml _; _} as x when has_lattrs x ->
+       let x = replace_lattrs x in
+       let () = validate_xml x in
+       super#phrase x
     | e -> super#phrase e
 end
 
@@ -174,7 +178,8 @@ object (_self)
   val no_lattributes = true
   method satisfied = no_lattributes
 
-  method! phrasenode = function
-    | Xml _ as x when has_lattrs x -> {< no_lattributes = false >}
-    | e -> super#phrasenode e
+  method! phrase = function
+    | {node = Xml _; _ } as x when has_lattrs x ->
+        {< no_lattributes = false >}
+    | e -> super#phrase e
 end

--- a/core/desugarLAttributes.ml
+++ b/core/desugarLAttributes.ml
@@ -48,7 +48,7 @@ let desugar_lhref : phrase -> phrase = function
               :: rest
           | _ ->
               desugaring_error pos
-                ("Invalid l:href: check that there are not " ^
+                ("Invalid l:href: check that there are no " ^
                  "multiple l:href attributes")
       in WithPos.make ~pos (Xml (a, attrs, attrexp, children))
   | e -> e
@@ -71,7 +71,7 @@ let desugar_laction : phrase -> phrase = function
               (Xml (form, action::rest, attrexp, hidden::children))
         | _ ->
             desugaring_error pos
-              ("Invalid l:action: check that there are not " ^
+              ("Invalid l:action: check that there are no " ^
                "multiple l:action attributes")
       end
   | e -> e
@@ -108,13 +108,13 @@ let desugar_lnames (p : phrase) : phrase * (string * string) StringMap.t =
             [("name", [constant_str name]);
              ("id"  , [constant_str id  ])]
       | "l:name", _ ->
-          desugaring_error pos "The value l:name binding must be a string constant"
+          desugaring_error pos "The value of an l:name attribute must be a string constant"
       | a -> [a] in
   let rec aux : phrase -> phrase  = function
     | { node=Xml (tag, attrs, attrexp, children); pos } ->
         let attrs = concat_map (attr pos) attrs in
         let children =
-          List.map (fun child -> aux child) children in
+          List.map aux children in
           WithPos.make ~pos (Xml (tag, attrs, attrexp, children))
     | p -> p
   in

--- a/core/desugarPages.ml
+++ b/core/desugarPages.ml
@@ -3,6 +3,11 @@ open Sugartypes
 open SugarConstructors.DummyPositions
 open SourceCode.WithPos
 
+let raise_invalid_element pos =
+  let open Errors in
+  raise (desugaring_error ~pos ~stage:DesugarPages
+    ~message:"Invalid element in page literal")
+
 let rec is_raw phrase =
   match phrase.node with
   | TextNode _ -> true
@@ -11,8 +16,7 @@ let rec is_raw phrase =
   | PagePlacement _ -> false
   | Xml (_, _, _, children) ->
      List.for_all is_raw children
-  | _e ->
-     raise (Errors.SugarError (phrase.pos, "Invalid element in page literal"))
+  | _e -> raise_invalid_element phrase.pos
 
 (* DODGEYNESS:
 
@@ -53,8 +57,7 @@ let rec desugar_page (o, page_type) =
                         dl_unl [[variable_pat ~ty:Types.xml_type x]]
                         (xml name attrs dynattrs [block ([], var x)]);
                 desugar_nodes children]
-        | _ ->
-          raise (Errors.SugarError (pos, "Invalid element in page literal"))
+        | _ -> raise_invalid_element pos
 
 and desugar_pages env =
 object

--- a/core/desugarRegexes.ml
+++ b/core/desugarRegexes.ml
@@ -90,7 +90,9 @@ object(self)
           self#phrase (fn_appl libfn tyargs
                             [e1; desugar_regex self#phrase regex_type r])
     | InfixAppl ((_tyargs, BinaryOp.RegexMatch _), _, _) ->
-        raise (Errors.SugarError (pos, "Internal error: unexpected rhs of regex operator"))
+        let (_, expr) = SourceCode.Position.resolve_start_expr pos in
+        let message = "Unexpected RHS of regex operator: " ^ expr in
+        raise (Errors.internal_error ~filename:"desugarRegexes.ml" ~message)
     | _ -> super#phrase ph
 end
 

--- a/core/errors.ml
+++ b/core/errors.ml
@@ -16,12 +16,12 @@ type sugar_error_stage =
   | CheckXML
 
 let string_of_stage = function
-  | DesugarFormlets -> "compiling formlets"
-  | DesugarRegexes -> "compiling regular expressions"
-  | CheckQuasiquotes -> "checking quasiquotes"
+  | DesugarFormlets    -> "compiling formlets"
+  | DesugarRegexes     -> "compiling regular expressions"
+  | CheckQuasiquotes   -> "checking quasiquotes"
   | DesugarLAttributes -> "compiling attributes"
-  | DesugarPages -> "compiling page expressions"
-  | CheckXML -> "checking XML"
+  | DesugarPages       -> "compiling page expressions"
+  | CheckXML           -> "checking XML"
 
 exception Runtime_error of string
 exception UndefinedVariable of string

--- a/core/errors.ml
+++ b/core/errors.ml
@@ -95,73 +95,8 @@ let format_exception =
   | Sys.Break -> "Caught interrupt"
   | exn -> "*** Error: " ^ Printexc.to_string exn
 
-let format_exception_html = function
-  | RichSyntaxError s ->
-      ("<h1>Links syntax error</h1>\n<p>Syntax error in <code>" ^ s.filename ^ "</code> line "
-       ^ s.linespec ^ ":</p><p>"
-       ^ s.message ^ "</p><pre>" ^ xml_escape s.linetext ^ "\n"
-       ^ s.marker ^ "</pre>")
-  | SugarError (pos, s) ->
-      let pos, expr = Position.resolve_start_expr pos in
-        ("<h1>Links syntactic sugar error</h1>\n<p>Syntactic sugar error at <code>"
-         ^ pos.pos_fname ^"</code>:"
-         ^ string_of_int pos.pos_lnum ^ ":</p> <p>"
-         ^ s ^ "</p><p>In expression:</p>\n<pre>"
-         ^ xml_escape expr ^ "</pre>\n")
-  | Getopt.Error s -> s
-  | Type_error (pos, s) ->
-      let pos, expr = Position.resolve_start_expr pos in
-        Printf.sprintf ("<h1>Links type error</h1>\n<p>Type error at <code>%s</code>:%d:</p> <p>%s</p><p>In expression:</p>\n<pre>%s</pre>\n")
-          pos.pos_fname pos.pos_lnum s (xml_escape expr)
-  | UnboundTyCon (pos, tycon) ->
-      let pos, _ = Position.resolve_start_expr pos in
-        Printf.sprintf ("<h1>Links type error</h1>\n<p>Type error at <code>%s</code>:%d:</p> <p>Unbound type constructor:</p>\n<pre>%s</pre>\n")
-          pos.pos_fname pos.pos_lnum tycon
-  | MultiplyDefinedMutualNames duplicates ->
-      let show_pos : Position.t -> string = fun pos ->
-        let pos, _ = Position.resolve_start_expr pos in
-        Printf.sprintf "file <code>%s</code>, line %d" pos.Lexing.pos_fname pos.Lexing.pos_lnum
-      in
-        "<h1>Links Syntax Error</h1><p>Duplicate mutual bindings:</p><ul>" ^
-          (StringMap.fold (fun name positions message -> message ^ "<li>" ^
-                                     name ^ ":<ul>" ^
-			             (mapstrcat "\n"
-                                        (fun l -> "<li>" ^ l ^ "</li>")
-                                        (List.map show_pos (List.rev positions)))
-                                     ^ "</ul></li>\n")
-             duplicates "") ^ "</ul>"
-
-  | InvalidMutualBinding pos ->
-      let pos, expr = Position.resolve_start_expr pos in
-      ("<h1>Links mutual binding error</h1>\n<p>"
-         ^ "<code>" ^ expr ^ "</code> was contained in a mutual block, however "
-         ^ "mutual blocks may only contain function and typename bindings."
-         ^ "(at line " ^ string_of_int pos.pos_lnum ^ ")</p>\n")
-  | Runtime_error s -> "<h1>Links Runtime Error</h1> " ^ s
-  | Position.ASTSyntaxError (pos, s) ->
-      let pos, expr = Position.resolve_start_expr pos in
-        Printf.sprintf "<h1>Links Syntax Error</h1> Syntax error at <code>%s</code> line %d. %s\nIn expression: <code>%s</code>\n"
-          pos.pos_fname pos.pos_lnum s (xml_escape expr)
-  | Sugartypes.PatternDuplicateNameError(pos, name) ->
-      (* BUG: this can't be right (the pattern and the expression are the same!) *)
-      let pos, expr = Position.resolve_start_expr pos in
-      let pattern = expr in
-        Printf.sprintf
-          "<h1>Links Syntax Error</h1> <p><code>%s</code> line %d:</p><p>Duplicate name <code>%s</code> in pattern\n<code>%s</code>.</p>\n<p>In expression: <code>%s</code></p>"
-          pos.pos_fname pos.pos_lnum name (xml_escape pattern) (xml_escape expr)
-  | Failure msg -> "<h1>Links Fatal Error</h1>\n" ^ msg
-  | TypeApplicationArityMismatch { pos; name; expected; provided } ->
-      let pos, expr = Position.resolve_start_expr pos in
-        Printf.sprintf ("<h1>Links type error</h1>\n<p>Type error at <code>%s</code>:%d:</p> <p>In expression:</p>\n<pre>%s</pre>. Type constructor %s expects %d arguments, but %d were provided.\n")
-          pos.pos_fname pos.pos_lnum (xml_escape expr) name expected provided
-  | TypeApplicationKindMismatch { pos; name; tyarg_number; expected; provided } ->
-      let pos, expr = Position.resolve_start_expr pos in
-        Printf.sprintf "<h1>Links type error</h1>\n<p>Type error at <code>%s</code>:%d:</p> <p>In expression:</p>\n<pre>%s</pre>. Type argument %d for type constructor %s has kind %s, but an argument of kind %s was expected."
-          pos.pos_fname pos.pos_lnum (xml_escape expr) tyarg_number name provided expected
-  | InternalError { filename; message } ->
-      Printf.sprintf "<h1>Links Internal Error in %s</h1>\n<p>%s</p>" filename message
-  | exn -> "<h1>Links Error</h1>\n" ^ Printexc.to_string exn
-      (* raise exn  (* use for backtraces *) *)
+let format_exception_html e =
+  Printf.sprintf "<h1>Links Error</h1><p>%s</p>\n" (format_exception e)
 
 let display ?(default=(fun e -> raise e)) ?(stream=stderr) (e) =
   try

--- a/core/errors.mli
+++ b/core/errors.mli
@@ -5,16 +5,24 @@ type synerrspec = {filename : string; linespec : string;
                    message : string; linetext : string;
                    marker : string}
 
+type sugar_error_stage =
+  | DesugarFormlets
+  | DesugarRegexes
+  | CheckQuasiquotes
+  | DesugarLAttributes
+  | DesugarPages
+  | CheckXML
+
 
 exception Runtime_error of string
 exception UndefinedVariable of string
-
-exception MultiplyDefinedMutualNames of
-  ((Position.t list) Utility.stringmap)
 exception InvalidMutualBinding of Position.t
 exception Type_error of (Position.t * string)
+exception MultiplyDefinedMutualNames of
+  ((Position.t list) Utility.stringmap)
 exception RichSyntaxError of synerrspec
-exception SugarError of (Position.t * string)
+exception DesugaringError of
+  { pos: Position.t; stage: sugar_error_stage; message: string }
 exception UnboundTyCon of (Position.t * string)
 exception InternalError of { filename: string; message: string }
 exception TypeApplicationArityMismatch of
@@ -29,3 +37,4 @@ val format_exception_html : exn -> string
 val display : ?default:(exn -> 'a) -> ?stream:out_channel -> ('a lazy_t) -> 'a
 
 val internal_error : filename:string -> message:string -> exn (* filename in which internal error occurred *)
+val desugaring_error: pos:Position.t -> stage:sugar_error_stage -> message:string -> exn

--- a/core/sugarConstructors.ml
+++ b/core/sugarConstructors.ml
@@ -274,7 +274,7 @@ module SugarConstructors (Position : Pos)
        let () =
          if name = "#" && (List.length attr_list != 0 || blk_opt <> None) then
            xml_sugar_error pos
-            (Printf.sprintf "XML tag '%s' has duplicate attributes" name) in
+            "XML forest literals cannot have attributes" in
        ()
     | _ -> assert false
 

--- a/core/sugarConstructors.ml
+++ b/core/sugarConstructors.ml
@@ -261,17 +261,20 @@ module SugarConstructors (Position : Pos)
                   closing opening))
          | _ -> () in
        (* Check uniqueness of attributes *)
+       let xml_sugar_error pos message =
+         let open Errors in
+         raise (desugaring_error ~pos ~stage:CheckXML ~message) in
+
        let () =
          let attr_names = fst (List.split attr_list) in
          if ListUtils.has_duplicates attr_names then
-           raise (Errors.SugarError (pos,
-                  Printf.sprintf "XML tag '%s' has duplicate attributes"
-                    name)); in
+           xml_sugar_error pos
+            (Printf.sprintf "XML tag '%s' has duplicate attributes" name) in
        (* Check that XML forests don't have attributes *)
        let () =
          if name = "#" && (List.length attr_list != 0 || blk_opt <> None) then
-           raise (Errors.SugarError (pos,
-                    "XML forest literals cannot have attributes")); in
+           xml_sugar_error pos
+            (Printf.sprintf "XML tag '%s' has duplicate attributes" name) in
        ()
     | _ -> assert false
 


### PR DESCRIPTION
The result of two train-rides' work refactoring how we do error messages in the frontend.

This firstly fixes #531 by removing the logic duplication in formatting HTML -- in turn, this should make it less painful to add new errors (and encourage people to do that, instead of using `failwith`).

This secondly addresses #514 by renaming the confusingly-named `SugarError` to `DesugaringError` and attaching a variant describing a stage to it. In doing this, two things came up:
  1. In some places, `SugarError` was used where an `InternalError` was more appropriate
  2. In `desugarLAttributes`, dummy positions were used, so I've refactored it to use proper position information now

There are also some other minor refactorings to make things nicer.