### PR TITLE
Add tests CTRL+C trap

### DIFF
--- a/run-tests
+++ b/run-tests
@@ -12,6 +12,12 @@ ret=0                              # Return code. If <> 0 then some tests failed
 STARTCOLOR="\e[31m"                # Control sequence to enable red text
 ENDCOLOR="\e[0m"                   # Control sequence to enable normal text
 
+# If the user presses CTRL+C then kill the script as well
+control_c() {
+	exit
+}
+trap control_c SIGINT
+
 prepare_database_config () {
     # Check if database configuration exists. If not the creating from
     # a default config.sample file

--- a/run-tests
+++ b/run-tests
@@ -14,7 +14,7 @@ ENDCOLOR="\e[0m"                   # Control sequence to enable normal text
 
 # If the user presses CTRL+C then kill the script as well
 control_c() {
-	exit
+	exit 130
 }
 trap control_c SIGINT
 


### PR DESCRIPTION
I often find myself accidentally running the wrong set of links tests, and end up having to mash Ctrl+C until all the tests have been killed. This patch causes the first CTRL+C to kill the script as well.