### PR TITLE
Remove some additional useless debug information

### DIFF
--- a/core/irtojs.ml
+++ b/core/irtojs.ml
@@ -56,8 +56,6 @@ module VariableInspection = struct
 
     let get_vars () =
       let res = StringSet.diff (!vars) (!binders) |> StringSet.elements in
-      Debug.print "affected client vars: \n";
-      List.iter (Debug.print) res;
       res in
 
     let rec go cmd =


### PR DESCRIPTION
This was some more debug information used when implementing session exceptions that shouldn't have made it into the main branch, and thus clutters our debug output.