### PR TITLE
Escape carriage returns in JSON-quoted strings

### DIFF
--- a/core/json.ml
+++ b/core/json.ml
@@ -48,8 +48,9 @@ let js_dq_escape_string str =
   (* escape for placement in double-quoted string *)
   Str.global_replace (Str.regexp_string "\"") "\\\""
     (Str.global_replace (Str.regexp_string "\n") "\\n"
+      (Str.global_replace (Str.regexp_string "\r") "\\r"
        (Str.global_replace (Str.regexp_string "\\") "\\\\"
-          str))
+          str)))
 
 (** Escape the argument for inclusion in a double-quoted string. *)
 let js_dq_escape_char =


### PR DESCRIPTION
Carriage returns ("\r") were not being correctly escaped, leading to runtime errors.

I tried using `String.escaped` (as with `irtojs`), but some intricacies seemed to be getting in the way there (I think `String.escaped` was doing more than we wanted it to / was safe to do).