### PR TITLE
Resolves issue #576

### DIFF
--- a/core/desugarFormlets.ml
+++ b/core/desugarFormlets.ml
@@ -127,7 +127,7 @@ object (o : 'self_type)
                         let base : phrase =
                           fn_appl pure_str [`Type ft; mb]
                             [fun_lit ~args:(List.rev args) dl_unl (List.rev pss)
-                                     (tuple vs)] in
+                                     (tuple ~one_tuple_hack:false vs)] in
                         let p, et =
                           List.fold_right
                             (fun arg (base, ft) ->

--- a/core/sugarConstructors.ml
+++ b/core/sugarConstructors.ml
@@ -92,8 +92,8 @@ module SugarConstructors (Position : Pos)
   let record ?(ppos=dp) ?exp lbls = with_pos ppos (RecordLit (lbls, exp))
 
   (* Create a tuple.  Preserves 1-tuples. *)
-  let tuple ?(ppos=dp) = function
-    | [e] -> record ~ppos [("1", e)]
+  let tuple ?(one_tuple_hack=true) ?(ppos=dp) = function
+    | [e] when one_tuple_hack -> record ~ppos [("1", e)]
     | es  -> with_pos ppos (TupleLit es)
 
   let cp_unit ppos = with_pos ppos (CPUnquote ([], tuple ~ppos []))

--- a/core/sugarConstructorsIntf.ml
+++ b/core/sugarConstructorsIntf.ml
@@ -64,7 +64,7 @@ module type SugarConstructorsSig = sig
   val datatype    : Datatype.with_pos -> Datatype.with_pos * 'a option
   val cp_unit     : t -> cp_phrase
   val record      : ?ppos:t -> ?exp:phrase -> (name * phrase) list -> phrase
-  val tuple       : ?ppos:t -> phrase list -> phrase
+  val tuple       : ?one_tuple_hack:bool -> ?ppos:t -> phrase list -> phrase
   val list        :
     ?ppos:t -> ?ty:Types.datatype -> phrase list -> phrase
   val constructor :


### PR DESCRIPTION
The "smart" constructor `tuple' has a rather hacky method for
preserving 1-tuples, which is not always correct. In particular, it
introduced a soundness regression for formlets.

This commit augments the interface of `tuple' with an optional boolean
flag to enable or disable the said hack. By default the hack is on.

Resolves #576.