### PR TITLE
Sound types for the `addRoute'-family of functions.

### DIFF
--- a/core/lib.ml
+++ b/core/lib.ml
@@ -1530,7 +1530,11 @@ let env : (string * (located_primitive * Types.datatype * pure)) list = [
      IMPURE);
     "unsafeAddRoute",
     (`PFun (fun _ -> assert false),
-     datatype "(String, (String, Location) ~> a, (String, String, Location) ~> a) ~> ()",
+     (* The `hear' effects on the second argument (request handler)
+        and third argument (error handler) should have different
+        presence variables as they are executed in different
+        contexts. *)
+     datatype "(String, (String, Location) {hear{_}}~> a, (String, String, Location) {hear{_}}~> a) ~> ()",
      IMPURE);
     "servePages",
     (`PFun (fun _ -> assert false),

--- a/prelude.links
+++ b/prelude.links
@@ -1352,7 +1352,7 @@ fun assertEq (actual, expected) server {
 
 #### APP SERVER ####
 
-sig defaultErrorPage : (String, String, Location) ~> Page
+sig defaultErrorPage : (String, String, Location) {}~> Page
 fun defaultErrorPage(_, error_string, _) {
   bodyP(<html>
         <body>
@@ -1362,25 +1362,25 @@ fun defaultErrorPage(_, error_string, _) {
         </html>)
 }
 
-sig addLocatedRouteWithErrors : (String, (String, Location) ~> Page, (String, String, Location) ~> Page) ~> ()
+sig addLocatedRouteWithErrors : (String, (String, Location) {hear{_}}~> Page, (String, String, Location) {hear{_}}~> Page) ~> ()
 fun addLocatedRouteWithErrors(path, f, error_handler) { unsafeAddRoute(path, f, error_handler) }
 
-sig addLocatedRouteHandler : (String, (String, Location) ~> Page) ~> ()
+sig addLocatedRouteHandler : (String, (String, Location) {hear{_}}~> Page) ~> ()
 fun addLocatedRouteHandler(path,f) { addLocatedRouteWithErrors(path, fun(p, l){f(p, l)}, defaultErrorPage) }
 
-sig addRoute : (String, (String) ~> Page) ~> ()
+sig addRoute : (String, (String) {hear{_}}~> Page) ~> ()
 fun addRoute(path, f) { addLocatedRouteHandler(path, fun(p, _){f(p)}) }
 
-sig addSimpleRouteHandler : (String, (String) ~> Page) ~> ()
+sig addSimpleRouteHandler : (String, (String) {hear{_}}~> Page) ~> ()
 fun addSimpleRouteHandler(path,f) { addRoute(path,f) }
 
-sig serveThis : (() ~> Page) ~> ()
+sig serveThis : (() {hear{_}}~> Page) ~> ()
 fun serveThis(p) {
   addRoute("/",fun (_) {p()});
   servePages()
 }
 
-sig serveThese : ([(String,() ~> Page)]) ~> ()
+sig serveThese : ([(String,() {hear{_}}~> Page)]) ~> ()
 fun serveThese(routes) {
   var _ = map(fun ((s,p)) {addRoute(s,fun (_) {p()})}, routes);
   servePages()

--- a/tests/page.tests
+++ b/tests/page.tests
@@ -1,0 +1,24 @@
+Empty page
+addRoute("/", fun(_) { page <#></#> })
+stdout : () : ()
+
+Raising request handler
+addRoute("/", fun(_) { receive { case _ -> raise } } )
+stdout : () : ()
+args : --enable-handlers --session-exceptions
+
+Raising request handler and error handler
+addLocatedRouteWithErrors("/", fun (_, _) { receive { case Foo -> raise } }, fun (_, _, _) { receive { case Bar -> raise } })
+stdout : () : ()
+args : --enable-handlers --session-exceptions
+
+Unhandled operation
+addRoute("/", fun(_) {do Fail})
+stderr : @..*
+args : --enable-handlers
+exit : 1
+
+Handled operation
+addRoute("/", fun(_) { handle({do Fail}) { case Fail -> page <#>{stringToXml("Caught")}</#> case Return(_) -> page <#>{stringToXml("Success")}</#> } })
+stdout : () : ()
+args : --enable-handlers


### PR DESCRIPTION
This patch refines the type of `unsafeAddRoute`, and its relatives, in
particular `addRoute`, which previously had the type

    addRoute : (String, (String) ~> Page) ~> ()

which elaborates to

    addRoute : (String, (String) ~e~> Page) ~f~> ()

where `e` and `f` are distinct effect variables. Consequently the
invariant that all user-definable effectful operations are handled
prior to reaching the toplevel is broken, for instance

    addRoute("/", fun(_) {do Fail})

would cause a "no handler installed for Fail" error to occur at
runtime when visiting the root page, even though one might have
wrapped the `addRoute` in a handler, i.e.

    handle(addRoute("/", fun(_) {do Fail})) {
      case Fail -> ()
    }

This does not handle the effects of the anonymous function, because the function
gets executed in a separate context where the handler is not
installed.

To ensure that all user-definable computational effects are handled,
this patch "corrects" the type of `unsafeAddRoute` and its associated
functions, as a result the type of `addRoute` is now

    addRoute : (String, (String) {hear{_}}~> Page) ~> ()

which elaborates to

    addRoute : (String, (String) {hear{p}}~> Page) ~f~> ()

In other words, a page generating function must handle all of its
effects -- save for the two built-in effects `hear` and `wild`.