### PR TITLE
Introduce syntax for imports

### DIFF
--- a/core/chaser.ml
+++ b/core/chaser.ml
@@ -39,7 +39,8 @@ object(self)
     {< shadow_table = shadow_table >}
 
   method! bindingnode = function
-    | QualifiedImport ns ->
+    | Import ns
+    | Open ns ->
         (* Try to resolve the import; if not, add to ICs list *)
         let lookup_ref = List.hd ns in
         (try

--- a/core/lexer.mll
+++ b/core/lexer.mll
@@ -190,6 +190,7 @@ let keywords = [
  "lensselect", LENSSELECT;
  "lensjoin" , LENSJOIN;
  "yields"   , YIELDS;
+ "import"   , IMPORT;
  "insert"   , INSERT;
  "linfun"   , LINFUN;
  "module"   , MODULE;

--- a/core/moduleUtils.ml
+++ b/core/moduleUtils.ml
@@ -56,7 +56,7 @@ object
   method satisfied = has_no_modules
 
   method! bindingnode = function
-    | QualifiedImport _
+    | Open _
     | Module _ -> {< has_no_modules = false >}
     | b -> super#bindingnode b
 

--- a/core/parser.mly
+++ b/core/parser.mly
@@ -915,7 +915,7 @@ record_labels:
 | separated_list(COMMA, record_label)                          { $1 }
 
 links_open:
-| OPEN separated_nonempty_list(DOT, CONSTRUCTOR)               { with_pos $loc (QualifiedImport $2) }
+| OPEN separated_nonempty_list(DOT, CONSTRUCTOR)               { with_pos $loc (Open $2) }
 
 binding:
 | VAR pattern EQ exp SEMICOLON                                 { val_binding ~ppos:$loc $2 $4 }

--- a/core/parser.mly
+++ b/core/parser.mly
@@ -275,8 +275,8 @@ end
 %token <string> VARIABLE CONSTRUCTOR KEYWORD PERCENTVAR
 %token <string> LXML ENDTAG
 %token RXML SLASHRXML
-%token MU FORALL ALIEN SIG OPEN
-%token MODULE MUTUAL
+%token MU FORALL ALIEN SIG
+%token MODULE MUTUAL OPEN IMPORT
 %token BANG QUESTION
 %token PERCENT EQUALSTILDE PLUS STAR ALTERNATE SLASH SSLASH CARET DOLLAR
 %token <char*char> RANGE
@@ -387,6 +387,7 @@ nofun_declaration:
                                                                  with_pos $loc Infix }
 | signature? tlvarbinding SEMICOLON                            { val_binding' ~ppos:$loc($2) (sig_of_opt $1) $2 }
 | typedecl SEMICOLON | links_module | links_open SEMICOLON     { $1 }
+| IMPORT CONSTRUCTOR SEMICOLON                                 { import ~ppos:$loc($2) [$2] }
 
 alien_datatype:
 | VARIABLE COLON datatype SEMICOLON                            { (binder ~ppos:$loc($1) $1, datatype $3) }

--- a/core/sugarConstructors.ml
+++ b/core/sugarConstructors.ml
@@ -116,6 +116,9 @@ module SugarConstructors (Position : Pos)
 
   let binder ?(ppos=dp) ?ty name = with_pos ppos (name, ty)
 
+  (** Imports **)
+
+  let import ?(ppos=dp) names = with_pos ppos (Import names)
 
   (** Patterns *)
 

--- a/core/sugarConstructorsIntf.ml
+++ b/core/sugarConstructorsIntf.ml
@@ -78,6 +78,9 @@ module type SugarConstructorsSig = sig
   (* Binders *)
   val binder   : ?ppos:t -> ?ty:Types.datatype -> name -> Binder.with_pos
 
+  (* Imports *)
+  val import : ?ppos:t -> name list -> binding
+
   (* Patterns *)
   val variable_pat : ?ppos:t -> ?ty:Types.datatype -> name -> Pattern.with_pos
   val tuple_pat    : ?ppos:t -> Pattern.with_pos list -> Pattern.with_pos

--- a/core/sugarTraversals.ml
+++ b/core/sugarTraversals.ml
@@ -682,9 +682,11 @@ class map =
           let _x_i3 = o#name _x_i3 in
           let _x_i4 = o#datatype' _x_i4 in
           Foreign ((_x, _x_i1, _x_i2, _x_i3, _x_i4))
-      | QualifiedImport _xs ->
+      | Import xs ->
+         Import (o#list (fun o -> o#name) xs)
+      | Open _xs ->
           let _xs = o#list (fun o -> o#name) _xs in
-          QualifiedImport _xs
+          Open _xs
       | Typenames (ts) ->
           let ts = o#list (fun o (_x, _x_i1, _x_i2, _x_i3) ->
             let _x = o#name _x in
@@ -1340,7 +1342,10 @@ class fold =
           let o = o#name _x_i2 in
           let o = o#name _x_i3 in
           let o = o#datatype' _x_i4 in o
-      | QualifiedImport _xs ->
+      | Import xs ->
+         let o = o#list (fun o -> o#name) xs in
+          o
+      | Open _xs ->
           let o = o#list (fun o -> o#name) _xs in
           o
       | Typenames (ts) ->
@@ -2127,9 +2132,12 @@ class fold_map =
           let (o, _x_i3) = o#name _x_i3 in
           let (o, _x_i4) = o#datatype' _x_i4
           in (o, (Foreign ((_x, _x_i1, _x_i2, _x_i3, _x_i4))))
-      | QualifiedImport _xs ->
+      | Import xs ->
+          let (o, _xs) = o#list (fun o n -> o#name n) xs in
+          (o, Import xs)
+      | Open _xs ->
           let (o, _xs) = o#list (fun o n -> o#name n) _xs in
-          (o, QualifiedImport _xs)
+          (o, Open _xs)
       | Typenames (ts) ->
           let (o, ts) = o#list (fun o (_x, _x_i1, _x_i2, _x_i3) ->
             let (o, _x) = o#name _x in

--- a/core/sugartoir.ml
+++ b/core/sugartoir.ml
@@ -1147,7 +1147,7 @@ struct
                     (* Ignore type alias and infix declarations - they
                        shouldn't be needed in the IR *)
                     eval_bindings scope env bs e
-                | Handler _ | QualifiedImport _ | Fun _ | Foreign _
+                | Handler _ | Import _ | Open _ | Fun _ | Foreign _
                 | AlienBlock _ | Module _  -> assert false
             end
 

--- a/core/sugartypes.ml
+++ b/core/sugartypes.ml
@@ -272,7 +272,8 @@ and bindingnode =
   | Handler of Binder.with_pos * handlerlit * datatype' option
   | Foreign of Binder.with_pos * name * name * name * datatype'
                (* Binder, raw function name, language, external file, type *)
-  | QualifiedImport of name list
+  | Import of name list
+  | Open of name list
   | Typenames of typename list
   | Infix
   | Exp     of phrase
@@ -495,7 +496,8 @@ struct
             (empty, []) in
           names, union_map (fun rhs -> diff (funlit rhs) names) rhss
     | Foreign (bndr, _, _, _, _) -> singleton (Binder.to_name bndr), empty
-    | QualifiedImport _
+    | Import _
+    | Open _
     | Typenames _
     | Infix -> empty, empty
     | Exp p -> empty, phrase p

--- a/core/transformSugar.ml
+++ b/core/transformSugar.ml
@@ -828,7 +828,8 @@ class transform (env : Types.typing_environment) =
       | Exp e -> let (o, e, _) = o#phrase e in (o, Exp e)
       | AlienBlock _ -> assert false
       | Module _ -> assert false
-      | QualifiedImport _ -> assert false
+      | Import _ -> assert false
+      | Open _ -> assert false
 
     method binding : binding -> ('self_type * binding) =
       WithPos.traverse_map

--- a/core/typeSugar.ml
+++ b/core/typeSugar.ml
@@ -111,7 +111,8 @@ struct
     | DBUpdate _ -> false
   and is_pure_binding ({node ; _ }: binding) = match node with
       (* need to check that pattern matching cannot fail *)
-    | QualifiedImport _
+    | Import _
+    | Open _
     | AlienBlock _
     | Module _
     | Fun _
@@ -3909,7 +3910,8 @@ and type_binding : context -> binding -> binding * context * usagemap =
             (pos_and_typ e, no_pos Types.unit_type) in
           Exp (erase e), empty_context, usages e
       | Handler _
-      | QualifiedImport _
+      | Import _
+      | Open _
       | AlienBlock _
       | Module _ -> assert false
     in


### PR DESCRIPTION
This patch is a step towards the implementation of #571.

This patch introduces the syntax for imports, at the moment they are operationally equivalent to opens, however, that will change in a subsequent patch.