### PR TITLE
Switch examples to use import

### DIFF
--- a/core/chaser.ml
+++ b/core/chaser.ml
@@ -50,7 +50,7 @@ object(self)
     | b -> self#bindingnode b.node
 
   method! bindingnode = function
-    | Import ns
+    | Import { path = ns; _ }
     | Open ns ->
         (* Try to resolve the import; if not, add to ICs list *)
         let lookup_ref = List.hd ns in

--- a/core/desugarModules.ml
+++ b/core/desugarModules.ml
@@ -481,9 +481,11 @@ and desugar ?(toplevel=false) (renamer : Epithet.t) (scope : Scope.t) =
 
     method bindings = function
       | [] -> []
-      | { node = Import names; pos } :: bs ->
+      | { node = Import { path; pollute }; pos } :: bs ->
          self#extension_guard pos;
-         self#import_module pos names; self#bindings bs
+         self#import_module pos path;
+         (if pollute then self#open_module pos path);
+         self#bindings bs
       | { node = Open names; pos } :: bs ->
         (* Affects [scope]. *)
          self#extension_guard pos;

--- a/core/parser.mly
+++ b/core/parser.mly
@@ -387,7 +387,7 @@ nofun_declaration:
                                                                  with_pos $loc Infix }
 | signature? tlvarbinding SEMICOLON                            { val_binding' ~ppos:$loc($2) (sig_of_opt $1) $2 }
 | typedecl SEMICOLON | links_module | links_open SEMICOLON     { $1 }
-| IMPORT pollute = boption(OPEN) CONSTRUCTOR SEMICOLON         { import ~ppos:$loc($1) ~pollute [$3] }
+| pollute = boption(OPEN) IMPORT CONSTRUCTOR SEMICOLON         { import ~ppos:$loc($2) ~pollute [$3] }
 
 alien_datatype:
 | VARIABLE COLON datatype SEMICOLON                            { (binder ~ppos:$loc($1) $1, datatype $3) }

--- a/core/parser.mly
+++ b/core/parser.mly
@@ -387,7 +387,7 @@ nofun_declaration:
                                                                  with_pos $loc Infix }
 | signature? tlvarbinding SEMICOLON                            { val_binding' ~ppos:$loc($2) (sig_of_opt $1) $2 }
 | typedecl SEMICOLON | links_module | links_open SEMICOLON     { $1 }
-| IMPORT CONSTRUCTOR SEMICOLON                                 { import ~ppos:$loc($2) [$2] }
+| IMPORT pollute = boption(OPEN) CONSTRUCTOR SEMICOLON         { import ~ppos:$loc($1) ~pollute [$3] }
 
 alien_datatype:
 | VARIABLE COLON datatype SEMICOLON                            { (binder ~ppos:$loc($1) $1, datatype $3) }

--- a/core/sugarConstructors.ml
+++ b/core/sugarConstructors.ml
@@ -118,7 +118,7 @@ module SugarConstructors (Position : Pos)
 
   (** Imports **)
 
-  let import ?(ppos=dp) names = with_pos ppos (Import names)
+  let import ?(ppos=dp) ?(pollute=false) names = with_pos ppos (Import { path = names; pollute })
 
   (** Patterns *)
 

--- a/core/sugarConstructorsIntf.ml
+++ b/core/sugarConstructorsIntf.ml
@@ -79,7 +79,7 @@ module type SugarConstructorsSig = sig
   val binder   : ?ppos:t -> ?ty:Types.datatype -> name -> Binder.with_pos
 
   (* Imports *)
-  val import : ?ppos:t -> name list -> binding
+  val import : ?ppos:t -> ?pollute:bool -> name list -> binding
 
   (* Patterns *)
   val variable_pat : ?ppos:t -> ?ty:Types.datatype -> name -> Pattern.with_pos

--- a/core/sugarTraversals.ml
+++ b/core/sugarTraversals.ml
@@ -682,8 +682,8 @@ class map =
           let _x_i3 = o#name _x_i3 in
           let _x_i4 = o#datatype' _x_i4 in
           Foreign ((_x, _x_i1, _x_i2, _x_i3, _x_i4))
-      | Import xs ->
-         Import (o#list (fun o -> o#name) xs)
+      | Import { pollute; path } ->
+         Import { pollute; path = o#list (fun o -> o#name) path }
       | Open _xs ->
           let _xs = o#list (fun o -> o#name) _xs in
           Open _xs
@@ -1342,8 +1342,8 @@ class fold =
           let o = o#name _x_i2 in
           let o = o#name _x_i3 in
           let o = o#datatype' _x_i4 in o
-      | Import xs ->
-         let o = o#list (fun o -> o#name) xs in
+      | Import { path; _ } ->
+         let o = o#list (fun o -> o#name) path in
           o
       | Open _xs ->
           let o = o#list (fun o -> o#name) _xs in
@@ -2132,9 +2132,9 @@ class fold_map =
           let (o, _x_i3) = o#name _x_i3 in
           let (o, _x_i4) = o#datatype' _x_i4
           in (o, (Foreign ((_x, _x_i1, _x_i2, _x_i3, _x_i4))))
-      | Import xs ->
-          let (o, _xs) = o#list (fun o n -> o#name n) xs in
-          (o, Import xs)
+      | Import { pollute; path } ->
+          let (o, path') = o#list (fun o n -> o#name n) path in
+          (o, Import { pollute; path = path' })
       | Open _xs ->
           let (o, _xs) = o#list (fun o n -> o#name n) _xs in
           (o, Open _xs)

--- a/core/sugartypes.ml
+++ b/core/sugartypes.ml
@@ -272,7 +272,7 @@ and bindingnode =
   | Handler of Binder.with_pos * handlerlit * datatype' option
   | Foreign of Binder.with_pos * name * name * name * datatype'
                (* Binder, raw function name, language, external file, type *)
-  | Import of name list
+  | Import of { pollute: bool; path : name list }
   | Open of name list
   | Typenames of typename list
   | Infix

--- a/examples/handlers/tests.links
+++ b/examples/handlers/tests.links
@@ -34,55 +34,55 @@ fun stateExamplesEquals((x,xs),(y,ys)) {
 var stateExamplesToString = pairToString(intToString, listToString(intToString));
 
 fun shallow_state() {
-  open Shallow_state;
+  import Shallow_state;
   assert(stateExamplesEquals, (0, [0,1,2,3,4]), Shallow_state.unitTest(5), stateExamplesToString, "Shallow_state")
 }
 
 fun deep_state() {
-  open Deep_state;
+  import Deep_state;
   assert(stateExamplesEquals, (0, [0,1,2,3,4]), Deep_state.unitTest(5), stateExamplesToString, "Deep_state")
 }
 
 # Pipes tests
 
 # fun deep_pipes() {
-#   open Deep_pipes
+#   import Deep_pipes
 #   assert((==), "199.00", Deep_pipes.unitTest(0), id, "Deep_pipes")
 # }
 
 # Exceptions tests
 fun exceptions() {
-  open Exceptions;
+  import Exceptions;
   assert((==), 60, Exceptions.unitTest(), intToString, "Exceptions")
 }
 
 # Fringe tests
 fun fringe() {
-  open Fringe;
+  import Fringe;
   assert((==), [true, false, false, false, true, true, false, false, true, true], Fringe.unitTest(), listToString(boolToString), "Fringe")
 }
 
 # Parameterised handlers
 fun light_switch() {
-  open Light_switch;
+  import Light_switch;
   assert((==), true, Light_switch.unitTest(6), boolToString, "Light_switch")
 }
 
 # Satisfiability and parsing
 fun sat() {
-  open Sat;
+  import Sat;
   assert((==), [true, true], Sat.unitTest(), listToString(boolToString), "Sat")
 }
 
 # Pi estimation
 # fun pi() {
-#   open Pi
+#   import Pi
 #   assert((==), true, all(fun(pi) { pi > 3.0 && pi < 4.0 }, Pi.unitTest()), boolToString, "Pi")
 # }
 
 # Delimited continuations
 fun delim() {
-  open Shiftreset;
+  import Shiftreset;
   assert((==), [1,2,3], Shiftreset.example(), listToString(intToString), "Shift/reset")
 }
 

--- a/examples/handlers/tests.links
+++ b/examples/handlers/tests.links
@@ -33,13 +33,13 @@ fun stateExamplesEquals((x,xs),(y,ys)) {
 
 var stateExamplesToString = pairToString(intToString, listToString(intToString));
 
+import Shallow_state;
 fun shallow_state() {
-  import Shallow_state;
   assert(stateExamplesEquals, (0, [0,1,2,3,4]), Shallow_state.unitTest(5), stateExamplesToString, "Shallow_state")
 }
 
+import Deep_state;
 fun deep_state() {
-  import Deep_state;
   assert(stateExamplesEquals, (0, [0,1,2,3,4]), Deep_state.unitTest(5), stateExamplesToString, "Deep_state")
 }
 
@@ -51,26 +51,26 @@ fun deep_state() {
 # }
 
 # Exceptions tests
+import Exceptions;
 fun exceptions() {
-  import Exceptions;
   assert((==), 60, Exceptions.unitTest(), intToString, "Exceptions")
 }
 
 # Fringe tests
+import Fringe;
 fun fringe() {
-  import Fringe;
   assert((==), [true, false, false, false, true, true, false, false, true, true], Fringe.unitTest(), listToString(boolToString), "Fringe")
 }
 
 # Parameterised handlers
+import Light_switch;
 fun light_switch() {
-  import Light_switch;
   assert((==), true, Light_switch.unitTest(6), boolToString, "Light_switch")
 }
 
 # Satisfiability and parsing
+import Sat;
 fun sat() {
-  import Sat;
   assert((==), [true, true], Sat.unitTest(), listToString(boolToString), "Sat")
 }
 
@@ -81,8 +81,8 @@ fun sat() {
 # }
 
 # Delimited continuations
+import Shiftreset;
 fun delim() {
-  import Shiftreset;
   assert((==), [1,2,3], Shiftreset.example(), listToString(intToString), "Shift/reset")
 }
 

--- a/examples/sessions/chatserver/chatClient.links
+++ b/examples/sessions/chatserver/chatClient.links
@@ -1,4 +1,4 @@
-open ChatSessions;
+import ChatSessions;
 
 # DOM stuff #
 var nameBoxId = "name_box";

--- a/examples/sessions/chatserver/chatClient.links
+++ b/examples/sessions/chatserver/chatClient.links
@@ -1,4 +1,4 @@
-import ChatSessions;
+import open ChatSessions;
 
 # DOM stuff #
 var nameBoxId = "name_box";

--- a/examples/sessions/chatserver/chatClient.links
+++ b/examples/sessions/chatserver/chatClient.links
@@ -1,4 +1,4 @@
-import open ChatSessions;
+open import ChatSessions;
 
 # DOM stuff #
 var nameBoxId = "name_box";

--- a/examples/sessions/chatserver/chatServer.links
+++ b/examples/sessions/chatserver/chatServer.links
@@ -1,6 +1,6 @@
-open ChatSessions;
-open ChatClient;
-open LinearList;
+import ChatSessions;
+import ChatClient;
+import LinearList;
 
 typename ServerState = (Topic, [Nickname]);
 

--- a/examples/sessions/chatserver/chatServer.links
+++ b/examples/sessions/chatserver/chatServer.links
@@ -1,6 +1,6 @@
-import ChatSessions;
-import ChatClient;
-import LinearList;
+import open ChatSessions;
+import open ChatClient;
+import open LinearList;
 
 typename ServerState = (Topic, [Nickname]);
 

--- a/examples/sessions/chatserver/chatServer.links
+++ b/examples/sessions/chatserver/chatServer.links
@@ -1,6 +1,6 @@
-import open ChatSessions;
-import open ChatClient;
-import open LinearList;
+open import ChatSessions;
+open import ChatClient;
+open import LinearList;
 
 typename ServerState = (Topic, [Nickname]);
 

--- a/examples/sessions/mind/mindClient.links
+++ b/examples/sessions/mind/mindClient.links
@@ -1,4 +1,4 @@
-open MindSessions;
+import MindSessions;
 
 typename ClientState = (nick:Nickname,
                         numPlayers:Int,

--- a/examples/sessions/mind/mindClient.links
+++ b/examples/sessions/mind/mindClient.links
@@ -1,4 +1,4 @@
-import MindSessions;
+import open MindSessions;
 
 typename ClientState = (nick:Nickname,
                         numPlayers:Int,

--- a/examples/sessions/mind/mindClient.links
+++ b/examples/sessions/mind/mindClient.links
@@ -1,4 +1,4 @@
-import open MindSessions;
+open import MindSessions;
 
 typename ClientState = (nick:Nickname,
                         numPlayers:Int,

--- a/examples/sessions/mind/mindServer.links
+++ b/examples/sessions/mind/mindServer.links
@@ -1,6 +1,6 @@
-open MindSessions;
-open MindClient;
-open LinearList;
+import MindSessions;
+import MindClient;
+import LinearList;
 
 # game configuration parameters
 var packSize = 100;

--- a/examples/sessions/mind/mindServer.links
+++ b/examples/sessions/mind/mindServer.links
@@ -1,6 +1,6 @@
-import MindSessions;
-import MindClient;
-import LinearList;
+import open MindSessions;
+import open MindClient;
+import open LinearList;
 
 # game configuration parameters
 var packSize = 100;

--- a/examples/sessions/mind/mindServer.links
+++ b/examples/sessions/mind/mindServer.links
@@ -1,6 +1,6 @@
-import open MindSessions;
-import open MindClient;
-import open LinearList;
+open import MindSessions;
+open import MindClient;
+open import LinearList;
 
 # game configuration parameters
 var packSize = 100;

--- a/examples/webserver/examples-nodb.links
+++ b/examples/webserver/examples-nodb.links
@@ -1,20 +1,20 @@
-open Draggable;
-open Progress;
+import Draggable;
+import Progress;
 
-open Buttons;
-open FormsTest;
-open Validate;
+import Buttons;
+import FormsTest;
+import Validate;
 
-open LoginFlow;
-open Mandelbrot;
-open Mandelcolor;
-open Todo;
-open Crop;
+import LoginFlow;
+import Mandelbrot;
+import Mandelcolor;
+import Todo;
+import Crop;
 
-open Twentyfortyeight;
-open Breakout;
-open Tetris;
-open Pacman;
+import Twentyfortyeight;
+import Breakout;
+import Tetris;
+import Pacman;
 
 fun main() {
   addStaticRoute("/examples/", "examples/", [("links", "text/plain")]);

--- a/examples/webserver/examples.links
+++ b/examples/webserver/examples.links
@@ -1,31 +1,31 @@
-open DictSuggestUpdate;
-open Draggable;
-open Progress;
+import DictSuggestUpdate;
+import Draggable;
+import Progress;
 
-open Factorial;
-open DictSuggest;
-open DictSuggestLite;
-open DraggableDb;
+import Factorial;
+import DictSuggest;
+import DictSuggestLite;
+import DraggableDb;
 
-open Buttons;
-open FormsTest;
-open Validate;
+import Buttons;
+import FormsTest;
+import Validate;
 
-open LoginFlow;
-open Paginate;
-open Mandelbrot;
-open Mandelcolor;
-open Todo;
-open TodoDb;
-open Crop;
-open Wine;
-open Filter;
-open Citations;
+import LoginFlow;
+import Paginate;
+import Mandelbrot;
+import Mandelcolor;
+import Todo;
+import TodoDb;
+import Crop;
+import Wine;
+import Filter;
+import Citations;
 
-open Twentyfortyeight;
-open Breakout;
-open Tetris;
-open Pacman;
+import Twentyfortyeight;
+import Breakout;
+import Tetris;
+import Pacman;
 
 fun main() {
   addStaticRoute("/examples/", "examples/", [("links", "text/plain")]);

--- a/links-mode.el
+++ b/links-mode.el
@@ -71,6 +71,7 @@
     "handle"
     "handler"
     "if"
+    "import"
     "in"
     "on"
     "open"


### PR DESCRIPTION
This patch changes the examples such that they use `import` rather than `open` to require external modules. Currently, `open` subsumes `import`, but not vice versa. In a subsequent patch I will change the semantics of `open` such that it can no longer be used to require an external module.