### PR TITLE
Semantics of `open` is not `include`.

### DIFF
--- a/tests/modules.tests
+++ b/tests/modules.tests
@@ -218,3 +218,9 @@ filemode : true
 args : -m --path=tests/modules
 stderr : @.*
 exit : 1
+
+Open is not include
+./tests/modules/open_is_not_include2.links
+filemode : true
+args : -m --path=tests/modules
+stdout : [1, 2] : [Int]

--- a/tests/modules/open_is_not_include0.links
+++ b/tests/modules/open_is_not_include0.links
@@ -1,0 +1,4 @@
+# c.f. issue #606
+fun concat(xs) {
+  fold_right((^^), "", xs)
+}

--- a/tests/modules/open_is_not_include1.links
+++ b/tests/modules/open_is_not_include1.links
@@ -1,0 +1,7 @@
+# c.f. issue #606
+import Open_is_not_include0;
+open Open_is_not_include0;
+
+fun foo() {
+  concat(["Hello", "World"])
+}

--- a/tests/modules/open_is_not_include2.links
+++ b/tests/modules/open_is_not_include2.links
@@ -1,0 +1,9 @@
+# c.f. issue #606
+import Open_is_not_include1;
+open Open_is_not_include1;
+
+fun main() {
+  concat([[1], [2], []])
+}
+
+main()


### PR DESCRIPTION
The desugar modules patch inadvertently changed the semantics of
`open` to be that of `include`. This regression was spotted by
@SimonJF in #606. From reading the generated code I mistakenly
concluded that it was a loader problem. However, as pointed out by
@SimonJF, the chaser is supposed to lift dependencies into "synthetic"
modules in the combined program.

With that in mind, it became clear to that the desugar modules patch
inadvertently changed the semantics of `open`, because I heedlessly
added the bindings resulting from an `open` to the module scope that
was being built. As a result they would correctly shadow the current
bindings in scope, but they would also inadvertently become part of
the module.

This patch rectifies this mistake. The implementation still makes use
of two-level scope data structure, however, now it only keeps track of
the current scope and its "delta", where the delta consists of all the
bindings defined in the current immediate scope. Bindings resulting
from an `open` are not added to the delta, and thus, do not become
part of the module's implicit signature.

Fixes #606.