### PR TITLE
Improve the REPL efficacy when using modules.

### DIFF
--- a/bin/repl.ml
+++ b/bin/repl.ml
@@ -124,7 +124,7 @@ let rec directives
               let name =
                 if Settings.get_value Debug.debugging_enabled
                 then Printf.sprintf "%s(%d)" name var
-                else name
+                else (Module_hacks.Name.prettify name)
               in
                Printf.fprintf stderr " %-16s : %s\n"
                  name ty)
@@ -257,6 +257,7 @@ let evaluate_parse_result envs parse_result =
 
 (** Interactive loop *)
 let interact envs =
+  Settings.set_value Basicsettings.interactive_mode true;
   (* Ensure we retain history *)
   let history_path = Basicsettings.Readline.readline_history_path () in
   ignore (LNoise.history_load ~filename:history_path);

--- a/core/basicsettings.ml
+++ b/core/basicsettings.ml
@@ -4,6 +4,9 @@ let debugging_enabled = Settings.add_bool ("debug", false, `User)
 (** [true] if we're in web mode *)
 let web_mode = Settings.add_bool ("web_mode", false, `System)
 
+(** [true] if we're in interactive mode *)
+let interactive_mode = Settings.add_bool ("interactive_mode", false, `System)
+
 (** If [true], then wait for all child processes to finish before
     terminating *)
 let wait_for_child_processes = Settings.add_bool ("wait_for_child_processes", false, `User)


### PR DESCRIPTION
The REPL directive `@load` loads a source file and pulls its contents
into the current scope. If the source file defines any modules the
user cannot access them following a load, because the state of module
desugarer is not preserved between `@load` directives when in
interactive mode.

This patch rectifies this issue such that the state is preserved
between subsequent invocations of the module desugarer. The state is
only preserved when Links is operating is interactive mode.

#### Meta
Depends on #609.