### PR TITLE
Disallow alien blocks below top-level

### DIFF
--- a/core/parser.mly
+++ b/core/parser.mly
@@ -901,7 +901,7 @@ binding:
 | exp SEMICOLON                                                { with_pos $loc (Exp $1) }
 | signature linearity VARIABLE arg_lists block                 { fun_binding ~ppos:$loc (Sig $1) ($2, $3, $4, loc_unknown, $5) }
 | linearity VARIABLE arg_lists block                           { fun_binding ~ppos:$loc  NoSig   ($1, $2, $3, loc_unknown, $4) }
-| typedecl SEMICOLON | links_module | alien_block
+| typedecl SEMICOLON | links_module
 | links_open SEMICOLON                                         { $1 }
 
 mutual_binding_block:

--- a/tests/alien.tests
+++ b/tests/alien.tests
@@ -1,0 +1,9 @@
+Alien declaration below toplevel
+if (true) { alien javascript "foo.js" foo : () ~> (); foo() } else { () }
+stderr : @.*
+exit : 1
+
+Alien blocks below toplevel
+if (true) { alien javascript "foo.js" { foo : () ~> (); } foo() } else { () }
+stderr : @.*
+exit : 1


### PR DESCRIPTION
This patch provides an easy fix for #604 by disallowing alien blocks
syntactically below the top-level. Incidentally this makes the alien
and alien blocks more coherent as it is already the case that the
former cannot appear below the top-level.

Note that alien and alien blocks can still appear below the global
top-level if they appear in a local module. However, they are still
syntactically at the "top-level" of the said module.

Fixes #604.