### PR TITLE
[Handlers] Generalise parameterised handlers.

### DIFF
--- a/core/compilePatterns.ml
+++ b/core/compilePatterns.ml
@@ -910,18 +910,18 @@ let handle_parameter_pattern : raw_env -> (Pattern.t * Types.datatype) -> Ir.com
     in
     (pb, Variable p'), (inner_bindings, outer_bindings)
 
-let compile_handle_parameters : raw_env -> (Ir.computation * Pattern.t * Types.datatype) list -> (Ir.binder * Ir.value) list * ((Ir.computation -> Ir.computation) * Ir.binding list)
+let compile_handle_parameters : raw_env -> (Pattern.t * Ir.computation * Types.datatype) list -> (Ir.binder * Ir.value) list * ((Ir.computation -> Ir.computation) * Ir.binding list)
   = fun env parameters ->
-    List.fold_right
-      (fun (body, pat, t) (bvs, (inner, outer)) ->
+    List.fold_left
+      (fun (bvs, (inner, outer)) (pat, body, t) ->
         let (bv, (inner', outer')) =
           handle_parameter_pattern env (pat, t) body
         in
         (bv :: bvs, ((fun comp -> inner' (inner comp)), outer' @ outer)))
-      parameters ([], ((fun x -> x), []))
+      ([], ((fun x -> x), [])) parameters
 
 let compile_handle_cases
-    : raw_env -> (raw_clause list * raw_clause list * (Ir.computation * Pattern.t * Types.datatype) list * Sugartypes.handler_descriptor) -> Ir.computation -> Ir.computation =
+    : raw_env -> (raw_clause list * raw_clause list * (Pattern.t * Ir.computation * Types.datatype) list * Sugartypes.handler_descriptor) -> Ir.computation -> Ir.computation =
   fun (nenv, tenv, eff) (raw_value_clauses, raw_effect_clauses, params, desc) m ->
   (* Observation: reduced continuation patterns are always trivial,
      i.e. a reduced continuation pattern is either a variable or a

--- a/core/sugarConstructorsIntf.ml
+++ b/core/sugarConstructorsIntf.ml
@@ -154,7 +154,7 @@ module type SugarConstructorsSig = sig
   (* Handlers *)
   val untyped_handler
       : ?val_cases:(clause list)
-     -> ?parameters:((phrase * Pattern.with_pos) list)
+     -> ?parameters:((Pattern.with_pos * phrase) list)
      -> phrase -> clause list -> handler_depth
      -> handler
 end

--- a/core/sugarTraversals.ml
+++ b/core/sugarTraversals.ml
@@ -516,9 +516,10 @@ class map =
       fun params ->
       let bindings =
         o#list
-          (fun o (expr, pat) ->
+          (fun o (pat, expr) ->
             let expr = o#phrase expr in
-            let pat = o#pattern pat in (expr, pat))
+            let pat = o#pattern pat in
+            (pat, expr))
           params.shp_bindings
       in
       { params with shp_bindings = bindings }
@@ -1158,7 +1159,7 @@ class fold =
     method handle_params : handler_parameterisation -> 'self_type =
       fun params ->
         o#list
-          (fun o (expr, pat) ->
+          (fun o (pat, expr) ->
             let o = o#phrase expr in
             o#pattern pat)
           params.shp_bindings
@@ -1892,9 +1893,10 @@ class fold_map =
       fun params ->
         let (o, bindings) =
           o#list
-            (fun o (expr, pat) ->
+            (fun o (pat, expr) ->
               let (o, expr) = o#phrase expr in
-              let (o, pat) = o#pattern pat in (o, (expr, pat)))
+              let (o, pat) = o#pattern pat in
+              (o, (pat, expr)))
             params.shp_bindings
         in
         (o, { params with shp_bindings = bindings })

--- a/core/sugartoir.ml
+++ b/core/sugartoir.ml
@@ -694,7 +694,7 @@ struct
   let handle env (m, val_cases, eff_cases, params, desc) =
     let params =
       List.map
-        (fun (body, p, t) -> reify (body env), p, t) params
+        (fun (body, p, t) -> p, reify (body env), t) params
     in
     let val_cases, eff_cases =
       let reify cases =
@@ -889,12 +889,12 @@ struct
                 | None -> empty_env, []
                 | Some { shp_bindings = bindings; shp_types = types } ->
                    let env, bindings =
-                     List.fold_left2
-                       (fun (env, bindings) (body, p) t ->
+                     List.fold_right2
+                       (fun (p, body) t (env, bindings) ->
                          let p, penv = CompilePatterns.desugar_pattern p in
                          let bindings = ((fun env -> eval env body), p, t) :: bindings in
                          ((env ++ penv), bindings))
-                       (empty_env, []) bindings types
+                       bindings types (empty_env, [])
                    in
                    env, List.rev bindings
              in

--- a/core/sugartypes.ml
+++ b/core/sugartypes.ml
@@ -176,7 +176,7 @@ and handler_descriptor =
   ; shd_params  : handler_parameterisation option
   }
 and handler_parameterisation =
-  { shp_bindings : (phrase * Pattern.with_pos) list
+  { shp_bindings : (Pattern.with_pos * phrase) list
   ; shp_types    : Types.datatype list
   }
 and iterpatt =
@@ -443,13 +443,13 @@ struct
                sh_value_cases = val_cases; sh_descr = descr } ->
        let params_bound =
          option_map
-           (fun params -> union_map (snd ->- pattern) params.shp_bindings)
+           (fun params -> union_map (fst ->- pattern) params.shp_bindings)
            descr.shd_params
        in
        union_all [phrase e;
                   union_map case eff_cases;
                   union_map case val_cases;
-                  diff (option_map (fun params -> union_map (fst ->- phrase)
+                  diff (option_map (fun params -> union_map (snd ->- phrase)
                                                     params.shp_bindings)
                           descr.shd_params) params_bound]
     | Switch (p, cases, _)

--- a/core/transformSugar.ml
+++ b/core/transformSugar.ml
@@ -454,14 +454,14 @@ class transform (env : Types.typing_environment) =
            match sh_descr.shd_params with
            | Some params ->
               let (o, bindings) =
-                List.fold_left
-                  (fun (o, bindings) (body, pat) ->
-                    (* let (o, body, _) = o#phrase body in *)
+                List.fold_right
+                  (fun (pat, body) (o, bindings) ->
+                    let (o, body, _) = o#phrase body in
                     let (o, pat) = o#pattern pat in
-                    (o, (body, pat) :: bindings))
-                  (o, []) params.shp_bindings
+                    (o, (pat, body) :: bindings))
+                  params.shp_bindings (o, [])
               in
-              (o, Some { params with shp_bindings = List.rev bindings })
+              (o, Some { params with shp_bindings = bindings })
            | None -> (o, None)
          in
          let (o, val_cases) =

--- a/core/typeSugar.ml
+++ b/core/typeSugar.ml
@@ -3245,25 +3245,25 @@ let rec type_check : context -> phrase -> phrase * Types.datatype * usagemap =
              match descr.shd_params with
              | Some { shp_bindings; _ } ->
                 let _ =
-                  check_for_duplicate_names pos (List.map snd shp_bindings)
+                  check_for_duplicate_names pos (List.map fst shp_bindings)
                 in
-                let type_binding (body, pat) =
+                let type_binding (pat, body) =
                   let body = tc body in
                   let pat = tpc pat in
                   unify ~handle:Gripers.handle_parameter_pattern (ppos_and_typ pat, (pos_and_typ body));
-                  (body, pat)
+                  (pat, body)
                 in
                 let typed_bindings = List.map type_binding shp_bindings in
                 let pat_types =
-                  List.map (snd ->- pattern_typ) typed_bindings
+                  List.map (fst ->- pattern_typ) typed_bindings
                 in
                 let param_env =
                   List.fold_left
                     (fun env p ->
                       env ++ pattern_env p)
-                    henv (List.map snd typed_bindings)
+                    henv (List.map fst typed_bindings)
                 in
-                (param_env, typed_bindings, { descr with shd_params = Some { shp_bindings = List.map (fun (body, pat) -> erase body, erase_pat pat) typed_bindings;
+                (param_env, typed_bindings, { descr with shd_params = Some { shp_bindings = List.map (fun (pat, body) -> erase_pat pat, erase body) typed_bindings;
                                                                              shp_types = pat_types } })
              | None -> (henv, [], descr)
            in
@@ -3500,7 +3500,7 @@ let rec type_check : context -> phrase -> phrase * Types.datatype * usagemap =
            Handle { sh_expr = erase m;
                     sh_effect_cases = erase_cases eff_cases;
                     sh_value_cases = erase_cases val_cases;
-                    sh_descr = descr }, body_type, merge_usages [usage_compat (List.map (fun ((_, _, m),_) -> m) params); usages m; usages_cases eff_cases; usages_cases val_cases]
+                    sh_descr = descr }, body_type, merge_usages [usage_compat (List.map (fun (_,(_, _, m)) -> m) params); usages m; usages_cases eff_cases; usages_cases val_cases]
         | DoOperation (opname, args, _) ->
            (* Strategy:
               1. List.map tc args

--- a/examples/handlers/light_switch.links
+++ b/examples/handlers/light_switch.links
@@ -33,7 +33,7 @@ fun flickering_st(n)() {
 
 # Parameterised (deep) handlers are built-in
 fun evalState(st, m) {
-  handle(m())(st -> st) {
+  handle(m())(st <- st) {
     case Return(x) -> x
     case Get(resume) -> resume(st, st)
     case Put(p, resume) -> resume((), p)
@@ -41,7 +41,7 @@ fun evalState(st, m) {
 }
 
 fun logState(m)() {
-  handle(m())([] -> history) {
+  handle(m())(history <- []) {
     case Return(x) -> (x, history)
     case Put(p,resume) -> resume(put(p), history ++ [p])
   }

--- a/examples/handlers/nim-webversion.links
+++ b/examples/handlers/nim-webversion.links
@@ -462,7 +462,7 @@ fun game(){
 
 sig runState : (() {Get:s, Set:(s) -> () |e}~> a, s) -> () {Get-, Set- |e}~> (a, s)
 fun runState(f, st0)(){
-    handle(f())(st0 -> st){
+    handle(f())(st <- st0){
         case Return(x) -> (x, st)
         case Set(st1, resume) -> resume((), st1)
         case Get(resume) -> resume(st, st)

--- a/examples/handlers/number_games.links
+++ b/examples/handlers/number_games.links
@@ -25,7 +25,7 @@ fun isNil(xs) {
 
 sig input : ([Int], Comp({Read:Int |e}, a)) {Read{_} |e}~> ()
 fun input(guesses, m) {
-  handle(m())(guesses -> guesses) {
+  handle(m())(guesses <- guesses) {
     case Return(x) -> ()
     case Read(resume) ->
        switch(guesses) {
@@ -48,7 +48,7 @@ fun mySecret(secret, m) {
 
 sig logger : (Comp({Guess:(Int) -> Answer|e}, a)) {Guess:(Int) -> Answer|e}~> [(Int,Answer)]
 fun logger(m) {
-  handle(m())([] -> log) {
+  handle(m())(log <- []) {
     case Return(_) -> log
     case Guess(n, resume) ->
        var an = do Guess(n);

--- a/examples/handlers/pi.links
+++ b/examples/handlers/pi.links
@@ -35,7 +35,7 @@ fun randomPoints() {
 # Synchronous take operation
 sig take : (Int, Comp({Yield: (a) -> () |e}, b)) {Yield{_} |e}~> [a]
 fun take(n, m) {
-  handle(m())(n -> n, [] -> st) {
+  handle(m())(n <- n, st <- []) {
     case Return(_) -> st
     case Yield(x, resume) ->
        if (n <= 0) st

--- a/examples/handlers/racing-lines.links
+++ b/examples/handlers/racing-lines.links
@@ -168,7 +168,7 @@ fun schedule(main){
       fun runFiber(fiber, runQ){
           #println("runQ: " ^^ intToString(fiberQueueLength(runQ)));
           #dump(self());
-          handle(fiber.f()) ( (prio=fiber.prio, runQ=runQ, startTime=clientTimeMilliseconds()) -> state){
+          handle(fiber.f()) ( state <- (prio=fiber.prio, runQ=runQ, startTime=clientTimeMilliseconds()) ){
               case Return(x) ->
                   runNext(poll(state.runQ))
               case Fork(f, resume) ->

--- a/examples/handlers/sat.links
+++ b/examples/handlers/sat.links
@@ -437,7 +437,7 @@ mutual {
 
   sig parse : (Parser({ |e}, a), [Char]) -> Comp({Choose-,Satisfies-,Peek-,Fail: Zero |e}, a)
   fun parse(m, input)() {
-    handle(m())(input -> tokens) {
+    handle(m())(tokens <- input) {
       case Return(x) -> x
       case Peek(resume) ->
          switch (tokens) {

--- a/examples/handlers/sierpinski-triangle.links
+++ b/examples/handlers/sierpinski-triangle.links
@@ -244,7 +244,7 @@ fun schedule(main){
 
     fun runFiber(fiber, runQ){
         #dump(self());
-        handle(fiber.f()) ( (prio=fiber.prio, runQ=runQ, startTime=clientTimeMilliseconds()) -> state){
+        handle(fiber.f()) ( state <- (prio=fiber.prio, runQ=runQ, startTime=clientTimeMilliseconds()) ){
             case Return(x) ->
                 runNext(poll(state.runQ))
             case Fork(f, resume) ->
@@ -299,7 +299,7 @@ fun schedule(main){
 }
 
 fun gensymHandler(f){
-    handle(f())(0 -> counter) {
+    handle(f())(counter <- 0) {
         case Gensym(resume) -> resume(counter, counter+1)
     }
 }

--- a/examples/handlers/transaction.links
+++ b/examples/handlers/transaction.links
@@ -38,7 +38,7 @@ fun schedule(main) {
   }
 
   fun withThreads(f, q) {
-    handle(f())(q -> runQ) {
+    handle(f())(runQ <- q) {
       case Return(()) -> runNext(runQ)
       case Yield(resume) ->
          runNext(enqueue(resume, runQ))
@@ -56,7 +56,7 @@ fun put(st) { do Put(st) }
 
 sig runState : (Comp({Get:s, Put: (s) -> () |e}, a), s) {Get{_}, Put{_} |e}~> (a, s)
 fun runState(m, st) {
-  handle(m())(st -> st) {
+  handle(m())(st <- st) {
     case Return(x)      -> (x, st)
     case Get(resume)    -> resume(st, st)
     case Put(p, resume) -> resume((), p)
@@ -70,7 +70,7 @@ fun abort() {
 }
 
 fun beginTransaction(m) {
-  handle(m())(get() -> [alice, bob] as st) {
+  handle(m())([alice, bob] as st <- get()) {
     case Return(()) -> put(st); (st, "Done")
     case Abort -> (get(), "Aborted")
     case Put([acc], resume) ->

--- a/tests/handlers.tests
+++ b/tests/handlers.tests
@@ -177,12 +177,12 @@ stdout : 6 : Int
 args : --enable-handlers
 
 Deep state handling (2)
-{fun state(m)(s) { handle(m())(s -> s) { case Get(k) -> k(s,s) case Put(p,k) -> k((),p) case Return(x) -> x } } fun runState(s0, c) { state(c)(s0) } runState(2, fun() { var s = do Get; do Put(s + 1); var s = do Get; do Put(s + s); do Get }) }
+{fun state(m)(s) { handle(m())(s <- s) { case Get(k) -> k(s,s) case Put(p,k) -> k((),p) case Return(x) -> x } } fun runState(s0, c) { state(c)(s0) } runState(2, fun() { var s = do Get; do Put(s + 1); var s = do Get; do Put(s + s); do Get }) }
 stdout : 6 : Int
 args : --enable-handlers
 
 Deep state handling (3)
-handle({ var s = do Get; do Put(s + 1); var s = do Get; do Put(s + s); do Get })(2 -> s) { case Get(k) -> k(s,s) case Put(p,k) -> k((),p) case Return(x) -> x }
+handle({ var s = do Get; do Put(s + 1); var s = do Get; do Put(s + s); do Get })(s <- 2) { case Get(k) -> k(s,s) case Put(p,k) -> k((),p) case Return(x) -> x }
 stdout : 6 : Int
 args : --enable-handlers
 
@@ -197,17 +197,17 @@ stdout : 0 : Int
 args : --enable-handlers
 
 Shadowing handler parameter (1)
-{ handle({ var s = do Get; do Put(s + 1); var s = do Get; do Put(s + s); do Get })(0 -> s) { case Get(k) -> k(s,s) case Put(s,k) -> k((),s) case Return(x) -> x } }
+{ handle({ var s = do Get; do Put(s + 1); var s = do Get; do Put(s + s); do Get })(s <- 0) { case Get(k) -> k(s,s) case Put(s,k) -> k((),s) case Return(x) -> x } }
 stdout : 2 : Int
 args : --enable-handlers
 
 Shadowing handler parameter (2)
-{ handle({ var s = do Get; do Put(s + 1); var s = do Get; do Put(s + s); do Get })(0 -> s) { case Get(k) -> k(s,s) case Put(p as s,k) -> k((),s) case Return(x) -> x } }
+{ handle({ var s = do Get; do Put(s + 1); var s = do Get; do Put(s + s); do Get })(s <- 0) { case Get(k) -> k(s,s) case Put(p as s,k) -> k((),s) case Return(x) -> x } }
 stdout : 2 : Int
 args : --enable-handlers
 
 Shadowing handler parameter (3)
-{ handle({ var s = do Get; do Put(s + 1); var s = do Get; do Put(s + s); do Get })(0 -> s) { case Get(k) -> k(s,s) case Put(s as p,k) -> k((),s) case Return(x) -> x } }
+{ handle({ var s = do Get; do Put(s + 1); var s = do Get; do Put(s + s); do Get })(s <- 0) { case Get(k) -> k(s,s) case Put(s as p,k) -> k((),s) case Return(x) -> x } }
 stdout : 2 : Int
 args : --enable-handlers
 
@@ -303,49 +303,49 @@ stdout : () : ()
 args : --enable-handlers
 
 Pattern-matching on handler parameter (1)
-handle(true)(100 -> _) { case Return(x) -> x }
+handle(true)(_ <- 100) { case Return(x) -> x }
 stdout : true : Bool
 args : --enable-handlers
 
 Pattern-matching on handler parameter (2)
-handle(true)(100 -> 100) { case Return(x) -> x}
+handle(true)(100 <- 100) { case Return(x) -> x}
 stdout : true : Bool
 args : --enable-handlers
 
 Pattern-matching on handler parameter (2)
-handle(true)(99 -> 100) { case Return(x) -> x}
+handle(true)(99 <- 100) { case Return(x) -> x}
 stderr : @.
 exit : 1
 args : --enable-handlers
 
 Pattern-matching on handler parameter (3)
-handle(true)(Foo(42) -> Foo(s)) { case Return(_) -> s}
+handle(true)(Foo(s) <- Foo(42)) { case Return(_) -> s}
 stdout : 42 : Int
 args : --enable-handlers
 
 Pattern-matching on handler parameter (4)
-handle(true)(Bar(42) -> Foo(s)) { case Return(_) -> s}
+handle(true)(Foo(s) <- Bar(42)) { case Return(_) -> s}
 stderr : @.
 exit : 1
 args : --enable-handlers
 
 Pattern-matching on handler parameter (5)
-handle(true)((2,1) -> (x,y)) { case Return(_) -> x + y}
+handle(true)((x,y) <- (2,1)) { case Return(_) -> x + y}
 stdout : 3 : Int
 args : --enable-handlers
 
 Pattern-matching on handler parameter (6)
-handle(true)("Hello" -> "Hello") { case Return(x) -> x}
+handle(true)("Hello" <- "Hello") { case Return(x) -> x}
 stdout : true : Bool
 args : --enable-handlers
 
 Pattern-matching on handler parameter (7)
-handle(true)((a=44,b=(-2)) -> (a=x, b=y)) { case Return(_) -> x + y}
+handle(true)((a=x, b=y) <- (a=44,b=(-2))) { case Return(_) -> x + y}
 stdout : 42 : Int
 args : --enable-handlers
 
 Pattern-matching on handler parameter (8)
-handle(true)((a=44,b=(-2)) -> r) { case Return(_) -> r.a + r.b}
+handle(true)(r <- (a=44,b=(-2))) { case Return(_) -> r.a + r.b}
 stdout : 42 : Int
 args : --enable-handlers
 
@@ -380,12 +380,12 @@ stdout : 3 : Int
 args : --enable-handlers
 
 Type ascription, parameterised handlers (1)
-{ fun(a : Int)(b : Float)(c : String)(m)() { handle (m())(a -> x, b -> y, c -> z) { case Op(p,k) -> k(c,42,p,"Foo") case Return(_) -> x } } }
+{ fun(a : Int)(b : Float)(c : String)(m)() { handle (m())(x <- a, y <- b, z <- c) { case Op(p,k) -> k(c,42,p,"Foo") case Return(_) -> x } } }
 stdout : fun : (Int) -> (Float) -> (String) -> (() {Op:(Float) {}-> String|d}~> _) -> () {Op{_}|d}~> Int
 args : --enable-handlers
 
 Type ascription, parameterised handlers (2)
-{ fun(a : Float, b : String, c : Int)(m)() { handle(m())(a -> x, b -> y, c -> z) { case Op(p,k) -> k(x,p,"Bar",99) case Return(_) -> y } } }
+{ fun(a : Float, b : String, c : Int)(m)() { handle(m())(x <- a, y <- b, z <- c) { case Op(p,k) -> k(x,p,"Bar",99) case Return(_) -> y } } }
 stdout : fun : (Float, String, Int) -> (() {Op:(Float) {}-> Float|b}~> _) -> () {Op{_}|b}~> String
 args : --enable-handlers
 
@@ -415,12 +415,12 @@ stdout : 42 : Int
 args : --enable-handlers
 
 Parameterised handler with multiple parameters (1)
-handle({do A; do B; do C; do D})(0 -> a, 1 -> b, 2 -> c, 3 -> d) { case A(k) -> k((),a+1,b,c,d) case B(k) -> k((),a,b+1,c,d) case C(k) -> k((),a,b,c+1,d) case D(k) -> k((),a,b,c,d+1) case Return(_) -> (a,b,c,d) }
+handle({do A; do B; do C; do D})(a <- 0, b <- 1, c <- 2, d <- 3) { case A(k) -> k((),a+1,b,c,d) case B(k) -> k((),a,b+1,c,d) case C(k) -> k((),a,b,c+1,d) case D(k) -> k((),a,b,c,d+1) case Return(_) -> (a,b,c,d) }
 stdout : (1, 2, 3, 4) : (Int, Int, Int, Int)
 args : --enable-handlers
 
 Parameterised handler with multiple parameters (2)
-handle({do A; do B; do C; do D})(0 -> a, false -> b, (true,0) -> (c0,c1) as c, "Hello" -> d) { case A(k) -> k((),a+1,b,c,d) case B(k) -> k((),a,not(b),c,d) case C(k) -> k((),a,b,(not(c0), c1+1),d) case D(k) -> k((),a,b,c,d ^^ " World") case Return(_) -> (a,b,c,d) }
+handle({do A; do B; do C; do D})(a <- 0, b <- false, (c0, c1) as c <- (true,0), d <- "Hello") { case A(k) -> k((),a+1,b,c,d) case B(k) -> k((),a,not(b),c,d) case C(k) -> k((),a,b,(not(c0), c1+1),d) case D(k) -> k((),a,b,c,d ^^ " World") case Return(_) -> (a,b,c,d) }
 stdout : (1, true, (false, 1), "Hello World") : (Int, Bool, (Bool, Int), String)
 args : --enable-handlers
 


### PR DESCRIPTION
This patch generalises the kind of expression which is allowed to
appear in the expression position of a parameter binding form in a
parameterised handler. It was necessary to slightly change the syntax
of parameter binding to allow every expression form. Previously the
binding form syntax was

      logical_expression -> pattern

now it is

      pattern <- expression

The syntactic swap between the expression and pattern was necessary to
avoid a parser conflict.

The patch also rectifies a bug with shallow handlers which meant the
empty clause set was not allowed.