### PR TITLE
Frontend.ml refactoring

### DIFF
--- a/core/basicsettings.ml
+++ b/core/basicsettings.ml
@@ -219,6 +219,10 @@ module TypeSugar = struct
   let show_pre_sugar_typing = Settings.add_bool("show_pre_sugar_typing", false, `User)
   let show_post_sugar_typing = Settings.add_bool("show_post_sugar_typing", false, `User)
   let dodgey_type_isomorphism = Settings.add_bool("dodgey_type_isomorphism", false, `User)
+
+  (* Shall we re-run the frontend type-checker after each TransformSugar transformation? *)
+  let check_frontend_transformations =
+    Settings.add_bool("recheck_frontend_transformations", false, `User)
 end
 
 (* Types stuff *)

--- a/core/desugarCP.ml
+++ b/core/desugarCP.ml
@@ -116,3 +116,9 @@ object (o : 'self_type)
 end
 
 let desugar_cp env = ((new desugar_cp env) : desugar_cp :> TransformSugar.transform)
+
+let desugar_program : TransformSugar.program_transformer =
+  fun env program -> snd3 ((desugar_cp env)#program program)
+
+let desugar_sentence : TransformSugar.sentence_transformer =
+  fun env sentence -> snd ((desugar_cp env)#sentence sentence)

--- a/core/desugarCP.mli
+++ b/core/desugarCP.mli
@@ -1,1 +1,2 @@
-val desugar_cp : Types.typing_environment -> TransformSugar.transform
+val desugar_program : TransformSugar.program_transformer
+val desugar_sentence : TransformSugar.sentence_transformer

--- a/core/desugarDatatypes.ml
+++ b/core/desugarDatatypes.ml
@@ -635,24 +635,23 @@ let toplevel_bindings alias_env bs =
   in (alias_env, List.rev bnds)
 
 let program typing_env (bindings, p : Sugartypes.program) :
-    (Types.typing_environment * Sugartypes.program) =
+    Sugartypes.program =
   let alias_env = typing_env.tycon_env in
   let alias_env, bindings =
     toplevel_bindings alias_env bindings in
-  let typing_env = { typing_env with tycon_env = alias_env } in
-  (typing_env, (bindings, opt_map ((phrase alias_env) ->- snd) p))
+  (* let typing_env = { typing_env with tycon_env = alias_env } in *)
+  (bindings, opt_map ((phrase alias_env) ->- snd) p)
 
 let sentence typing_env = function
   | Definitions bs ->
-      let alias_env, bs' = toplevel_bindings typing_env.tycon_env bs in
-        {typing_env with tycon_env = alias_env}, Definitions bs'
-  | Expression  p  -> let o, p = phrase typing_env.tycon_env p in
-      {typing_env with tycon_env = o#aliases}, Expression p
-  | Directive   d  -> typing_env, Directive d
+      let _alias_env, bs' = toplevel_bindings typing_env.tycon_env bs in
+        Definitions bs'
+  | Expression  p  -> let _o, p = phrase typing_env.tycon_env p in
+      Expression p
+  | Directive   d  -> Directive d
 
 let read ~aliases s =
   let dt, _ = parse_string ~in_context:(LinksLexer.fresh_context ()) datatype s in
   let vars, var_env = Desugar.generate_var_mapping (typevars#datatype dt)#tyvar_list in
   let () = List.iter Generalise.rigidify_quantifier vars in
     (Types.for_all (vars, Desugar.datatype var_env aliases dt))
-

--- a/core/desugarDatatypes.mli
+++ b/core/desugarDatatypes.mli
@@ -3,11 +3,11 @@ val read : aliases:Types.tycon_environment -> string -> Types.datatype
 val sentence :
   Types.typing_environment ->
   Sugartypes.sentence ->
-    Types.typing_environment * Sugartypes.sentence
+    Sugartypes.sentence
 
 val program :
   Types.typing_environment ->
   Sugartypes.program ->
-    Types.typing_environment * Sugartypes.program
+    Sugartypes.program
 
 val all_datatypes_desugared : SugarTraversals.predicate

--- a/core/desugarFormlets.ml
+++ b/core/desugarFormlets.ml
@@ -191,6 +191,12 @@ end
 
 let desugar_formlets env = ((new desugar_formlets env) : desugar_formlets :> TransformSugar.transform)
 
+let desugar_program : TransformSugar.program_transformer =
+  fun env program -> snd3 ((desugar_formlets env)#program program)
+
+let desugar_sentence : TransformSugar.sentence_transformer =
+  fun env sentence -> snd ((desugar_formlets env)#sentence sentence)
+
 let has_no_formlets =
 object
   inherit SugarTraversals.predicate as super

--- a/core/desugarFormlets.mli
+++ b/core/desugarFormlets.mli
@@ -1,3 +1,5 @@
-val desugar_formlets : Types.typing_environment -> TransformSugar.transform
+val desugar_program : TransformSugar.program_transformer
+val desugar_sentence : TransformSugar.sentence_transformer
+
 (* val desugar_formlets : SugarTraversals.map *)
 val has_no_formlets  : SugarTraversals.predicate

--- a/core/desugarFors.ml
+++ b/core/desugarFors.ml
@@ -196,6 +196,12 @@ end
 let desugar_fors env = ((new desugar_fors env)
                           : desugar_fors :> TransformSugar.transform)
 
+let desugar_program : TransformSugar.program_transformer =
+  fun env program -> snd3 ((desugar_fors env)#program program)
+
+let desugar_sentence : TransformSugar.sentence_transformer =
+  fun env sentence -> snd ((desugar_fors env)#sentence sentence)
+
 let has_no_fors =
 object
   inherit SugarTraversals.predicate as super

--- a/core/desugarFors.mli
+++ b/core/desugarFors.mli
@@ -1,2 +1,3 @@
-val desugar_fors : Types.typing_environment -> TransformSugar.transform
+val desugar_program : TransformSugar.program_transformer
+val desugar_sentence : TransformSugar.sentence_transformer
 val has_no_fors  : SugarTraversals.predicate

--- a/core/desugarFuns.ml
+++ b/core/desugarFuns.ml
@@ -161,6 +161,12 @@ end
 
 let desugar_funs env = ((new desugar_funs env) : desugar_funs :> TransformSugar.transform)
 
+let desugar_program : TransformSugar.program_transformer =
+  fun env program -> snd3 ((desugar_funs env)#program program)
+
+let desugar_sentence : TransformSugar.sentence_transformer =
+  fun env sentence -> snd ((desugar_funs env)#sentence sentence)
+
 let has_no_funs =
 object
   inherit SugarTraversals.predicate as super

--- a/core/desugarFuns.mli
+++ b/core/desugarFuns.mli
@@ -1,2 +1,4 @@
-val desugar_funs : Types.typing_environment -> TransformSugar.transform
+val desugar_program : TransformSugar.program_transformer
+val desugar_sentence : TransformSugar.sentence_transformer
+
 val has_no_funs  : SugarTraversals.predicate

--- a/core/desugarInners.ml
+++ b/core/desugarInners.ml
@@ -132,6 +132,12 @@ end
 
 let desugar_inners env = ((new desugar_inners env) : desugar_inners :> TransformSugar.transform)
 
+let desugar_program : TransformSugar.program_transformer =
+  fun env program -> snd3 ((desugar_inners env)#program program)
+
+let desugar_sentence : TransformSugar.sentence_transformer =
+  fun env sentence -> snd ((desugar_inners env)#sentence sentence)
+
 let has_no_inners =
 object
   inherit SugarTraversals.predicate as super

--- a/core/desugarInners.mli
+++ b/core/desugarInners.mli
@@ -1,2 +1,4 @@
-val desugar_inners : Types.typing_environment -> TransformSugar.transform
+val desugar_program : TransformSugar.program_transformer
+val desugar_sentence : TransformSugar.sentence_transformer
+
 val has_no_inners  : SugarTraversals.predicate

--- a/core/desugarPages.ml
+++ b/core/desugarPages.ml
@@ -1,3 +1,4 @@
+open Utility
 open CommonTypes
 open Sugartypes
 open SugarConstructors.DummyPositions
@@ -71,6 +72,12 @@ object
           (o, e.node, page_type)
     | e -> super#phrasenode e
 end
+
+let desugar_program : TransformSugar.program_transformer =
+  fun env program -> snd3 ((desugar_pages env)#program program)
+
+let desugar_sentence : TransformSugar.sentence_transformer =
+  fun env sentence -> snd ((desugar_pages env)#sentence sentence)
 
 let is_pageless =
 object

--- a/core/desugarPages.mli
+++ b/core/desugarPages.mli
@@ -1,2 +1,3 @@
-val desugar_pages : Types.typing_environment -> TransformSugar.transform
+val desugar_program : TransformSugar.program_transformer
+val desugar_sentence : TransformSugar.sentence_transformer
 val is_pageless : SugarTraversals.predicate

--- a/core/desugarProcesses.ml
+++ b/core/desugarProcesses.ml
@@ -84,6 +84,12 @@ end
 
 let desugar_processes env = ((new desugar_processes env) : desugar_processes :> TransformSugar.transform)
 
+let desugar_program : TransformSugar.program_transformer =
+  fun env program -> snd3 ((desugar_processes env)#program program)
+
+let desugar_sentence : TransformSugar.sentence_transformer =
+  fun env sentence -> snd ((desugar_processes env)#sentence sentence)
+
 let has_no_processes =
 object
   inherit SugarTraversals.predicate as super

--- a/core/desugarProcesses.mli
+++ b/core/desugarProcesses.mli
@@ -1,2 +1,4 @@
-val desugar_processes : Types.typing_environment -> TransformSugar.transform
+val desugar_program : TransformSugar.program_transformer
+val desugar_sentence : TransformSugar.sentence_transformer
+
 val has_no_processes  : SugarTraversals.predicate

--- a/core/desugarRegexes.ml
+++ b/core/desugarRegexes.ml
@@ -1,3 +1,4 @@
+open Utility
 open Operators
 open SourceCode.WithPos
 open Sugartypes
@@ -96,6 +97,12 @@ object(self)
     | _ -> super#phrase ph
 end
 
+let desugar_program : TransformSugar.program_transformer =
+  fun env program -> snd3 ((desugar_regexes env)#program program)
+
+let desugar_sentence : TransformSugar.sentence_transformer =
+  fun env sentence -> snd ((desugar_regexes env)#sentence sentence)
+
 let has_no_regexes =
 object
   inherit SugarTraversals.predicate
@@ -104,4 +111,3 @@ object
   method satisfied = no_regexes
   method! regex _ = {< no_regexes = false >}
 end
-

--- a/core/desugarRegexes.mli
+++ b/core/desugarRegexes.mli
@@ -1,2 +1,3 @@
-val desugar_regexes : Types.typing_environment -> TransformSugar.transform
+val desugar_program : TransformSugar.program_transformer
+val desugar_sentence : TransformSugar.sentence_transformer
 val has_no_regexes : SugarTraversals.predicate

--- a/core/desugarSessionExceptions.ml
+++ b/core/desugarSessionExceptions.ml
@@ -1,3 +1,4 @@
+open Utility
 open SourceCode.WithPos
 open Sugartypes
 open SugarConstructors.DummyPositions
@@ -203,7 +204,10 @@ let desugar_session_exceptions env =
   ((new desugar_session_exceptions env) :
     desugar_session_exceptions :> TransformSugar.transform)
 
+let desugar_program : TransformSugar.program_transformer =
+  fun env program -> snd3 ((desugar_session_exceptions env)#program program)
+
+
 let show prog =
   Printf.printf "%s\n\n" (Sugartypes.show_program prog);
   prog
-

--- a/core/desugarSessionExceptions.mli
+++ b/core/desugarSessionExceptions.mli
@@ -1,5 +1,6 @@
 val insert_toplevel_handlers : Types.typing_environment -> TransformSugar.transform
 val desugar_session_exceptions : Types.typing_environment -> TransformSugar.transform
+val desugar_program : TransformSugar.program_transformer
 val wrap_linear_handlers : Sugartypes.program -> Sugartypes.program
 val show : Sugartypes.program -> Sugartypes.program
 val settings_check : Sugartypes.program -> unit

--- a/core/frontend.ml
+++ b/core/frontend.ml
@@ -25,89 +25,168 @@ struct
 
   let session_exceptions = Settings.get_value Basicsettings.Sessions.exceptions_enabled
 
-  (* (These functions correspond to 'first' in an arrow) *)
-  let after_typing f (a, b, c) = (f a, b, c)
-  let _after_alias_expansion f (a, b) = (f a, b)
-  let extension enabled f g (a, b, c) =
-    if enabled
-    then f g (a, b, c)
-    else (a, b, c)
 
-  let after_typing_ext enabled = extension enabled after_typing
-  let before_typing_ext enabled f x = if enabled then f x else x
+  let for_side_effects ignored_transformer program  =
+    let _ = ignored_transformer program in
+    program
 
-  let program_pipeline =
-    fun tyenv pos_context program ->
-      let program = (ResolvePositions.resolve_positions pos_context)#program program in
-      let _program = CheckXmlQuasiquotes.checker#program program in
-      let () = DesugarSessionExceptions.settings_check program in
-      let apply =
-        ( DesugarModules.desugar_program
-          ->- before_typing_ext session_exceptions DesugarSessionExceptions.wrap_linear_handlers
-          ->- DesugarLAttributes.desugar_lattributes#program
-          ->- LiftRecursive.lift_funs#program
-          ->- DesugarDatatypes.program tyenv
-          ->- uncurry TypeSugar.Check.program
-          (*->- after_typing ((FixTypeAbstractions.fix_type_abstractions tyenv)#program ->- snd3)*)
-          ->- after_typing ((DesugarCP.desugar_cp tyenv)#program ->- snd3)
-          ->- after_typing ((DesugarInners.desugar_inners tyenv)#program ->- snd3)
-          ->- after_typing_ext session_exceptions ((DesugarSessionExceptions.insert_toplevel_handlers tyenv)#program ->- snd3)
-          ->- after_typing_ext session_exceptions ((DesugarSessionExceptions.desugar_session_exceptions tyenv)#program ->- snd3)
-          ->- after_typing ((DesugarProcesses.desugar_processes tyenv)#program ->- snd3)
-          ->- after_typing ((DesugarFors.desugar_fors tyenv)#program ->- snd3)
-          ->- after_typing ((DesugarRegexes.desugar_regexes tyenv)#program ->- snd3)
-          ->- after_typing ((DesugarFormlets.desugar_formlets tyenv)#program ->- snd3)
-          ->- after_typing ((DesugarPages.desugar_pages tyenv)#program ->- snd3)
-          ->- after_typing ((DesugarFuns.desugar_funs tyenv)#program ->- snd3))
-      in
-      let (program, _typ, _tenv) as result = apply program in
-      (result, ModuleUtils.get_ffi_files program)
+  type pre_typing_program_transformer =
+    Sugartypes.program -> Sugartypes.program
+
+  type post_typing_program_transformer =
+    Types.typing_environment -> Sugartypes.program -> Sugartypes.program
 
 
-let program tyenv pos_context program =
+  (* Program transformations before type-checking on programs (i.e., non-REPL mode *)
+  let program_pre_typing_transformers
+    (pos_context : SourceCode.source_code)
+    (prev_tyenv : Types.typing_environment) (* type env before checking current program *)
+      : pre_typing_program_transformer list =
+    let only_if enabled f x =
+      if enabled then f x else x in
+    [
+      (ResolvePositions.resolve_positions pos_context)#program;
+      for_side_effects
+        CheckXmlQuasiquotes.checker#program;
+      for_side_effects
+        (DesugarSessionExceptions.settings_check);
+      DesugarModules.desugar_program;
+      only_if session_exceptions
+        DesugarSessionExceptions.wrap_linear_handlers;
+      DesugarLAttributes.desugar_lattributes#program;
+      LiftRecursive.lift_funs#program;
+      DesugarDatatypes.program prev_tyenv;
+    ]
+
+
+
+  (* Program transformations after type-checking programs (i.e., non-REPL mode *)
+  let program_post_typing_transformers
+      : post_typing_program_transformer list =
+    let only_if enabled f x y =
+      if enabled then f x y else y in
+    [
+      DesugarCP.desugar_program;
+      DesugarInners.desugar_program;
+      (*only_if session_exceptions
+        DesugarSessionExceptions.insert_toplevel_handlers; TODO*)
+      only_if session_exceptions
+        DesugarSessionExceptions.desugar_program;
+      DesugarProcesses.desugar_program;
+      DesugarFors.desugar_program;
+      DesugarRegexes.desugar_program;
+      DesugarFormlets.desugar_program;
+      DesugarPages.desugar_program;
+      DesugarFuns.desugar_program;
+    ]
+
+
+
+
+let program prev_tyenv pos_context program =
   if Settings.get_value Basicsettings.show_pre_frontend_ast then
     Debug.print ("Pre-Frontend AST:\n" ^ Sugartypes.show_program program);
 
-  let ((post_program, _, _), _) as result = program_pipeline tyenv pos_context program in
+
+  let pre_transformers =
+    program_pre_typing_transformers pos_context prev_tyenv in
+  let apply_pre_tc_transformer program transformer =
+    transformer program in
+  let pre_tc_program =
+    List.fold_left
+      apply_pre_tc_transformer
+      program
+      pre_transformers in
+
+  let post_tc_program, t, cur_tyenv =
+    TypeSugar.Check.program prev_tyenv pre_tc_program in
+
+
+  let apply_post_tc_transformer program transformer =
+    transformer prev_tyenv program in
+  let result_program =
+    List.fold_left
+      apply_post_tc_transformer
+      post_tc_program
+      program_post_typing_transformers in
+
+  let ffi_files = ModuleUtils.get_ffi_files result_program in
 
   if Settings.get_value Basicsettings.show_post_frontend_ast then
-    Debug.print ("Post-Frontend AST:\n" ^ Sugartypes.show_program post_program);
+    Debug.print ("Post-Frontend AST:\n" ^ Sugartypes.show_program result_program);
 
-  result
+  (result_program, t, cur_tyenv), ffi_files
 
 
-  let interactive_pipeline =
-    fun tyenv pos_context sentence ->
-    let sentence = (ResolvePositions.resolve_positions pos_context)#sentence sentence in
-    let _sentence = CheckXmlQuasiquotes.checker#sentence sentence in
-    let apply =
-      ( DesugarModules.desugar_sentence
-        ->- DesugarLAttributes.desugar_lattributes#sentence
-        ->- LiftRecursive.lift_funs#sentence
-        ->- DesugarDatatypes.sentence tyenv
-        ->- uncurry TypeSugar.Check.sentence
-        (*  ->- after_typing ((FixTypeAbstractions.fix_type_abstractions tyenv)#sentence ->- snd)*)
-        ->- after_typing ((DesugarCP.desugar_cp tyenv)#sentence ->- snd)
-        ->- after_typing ((DesugarInners.desugar_inners tyenv)#sentence ->- snd)
-        ->- after_typing ((DesugarProcesses.desugar_processes tyenv)#sentence ->- snd)
-        ->- after_typing ((DesugarFors.desugar_fors tyenv)#sentence ->- snd)
-        ->- after_typing ((DesugarRegexes.desugar_regexes tyenv)#sentence ->- snd)
-        ->- after_typing ((DesugarFormlets.desugar_formlets tyenv)#sentence ->- snd)
-        ->- after_typing ((DesugarPages.desugar_pages tyenv)#sentence ->- snd)
-        ->- after_typing ((DesugarFuns.desugar_funs tyenv)#sentence ->- snd))
-    in
-    apply sentence
 
-let interactive tyenv pos_context sentence =
+
+
+  type pre_typing_sentence_transformer =
+    Sugartypes.sentence -> Sugartypes.sentence
+
+  type post_typing_sentence_transformer =
+    Types.typing_environment -> Sugartypes.sentence -> Sugartypes.sentence
+
+  (* Program transformations before type-checking on sentences (i.e., REPL mode *)
+  let interactive_pre_typing_transformers
+    (pos_context : SourceCode.source_code)
+    (prev_tyenv : Types.typing_environment) (* type env before checking current program *)
+      : pre_typing_sentence_transformer list =
+    [
+      (ResolvePositions.resolve_positions pos_context)#sentence;
+      for_side_effects
+        CheckXmlQuasiquotes.checker#sentence;
+      DesugarModules.desugar_sentence;
+      DesugarLAttributes.desugar_lattributes#sentence;
+      LiftRecursive.lift_funs#sentence;
+      DesugarDatatypes.sentence prev_tyenv;
+    ]
+
+
+  (* Program transformations after type-checking sentences (i.e., REPL mode *)
+  let interactive_post_typing_transformers
+      : post_typing_sentence_transformer list =
+    [
+      DesugarCP.desugar_sentence;
+      DesugarInners.desugar_sentence;
+      DesugarProcesses.desugar_sentence;
+      DesugarFors.desugar_sentence;
+      DesugarRegexes.desugar_sentence;
+      DesugarFormlets.desugar_sentence;
+      DesugarPages.desugar_sentence;
+      DesugarFuns.desugar_sentence;
+    ]
+
+
+let interactive prev_tyenv pos_context sentence =
   if Settings.get_value Basicsettings.show_pre_frontend_ast then
     Debug.print ("Pre-Frontend AST:\n" ^ Sugartypes.show_sentence sentence);
 
-  let (post_sentence, _, _) as result = interactive_pipeline tyenv pos_context sentence in
+  let pre_transformers =
+    interactive_pre_typing_transformers pos_context prev_tyenv in
+  let apply_pre_tc_transformer sentence transformer =
+    transformer sentence in
+  let pre_tc_sentence =
+    List.fold_left
+      apply_pre_tc_transformer
+      sentence
+      pre_transformers in
+
+  let (post_tc_sentence, t, post_tyenv) =
+    TypeSugar.Check.sentence prev_tyenv pre_tc_sentence in
+
+  let apply_post_tc_transformer sentence transformer =
+    transformer prev_tyenv sentence in
+  let result_sentence =
+    List.fold_left
+      apply_post_tc_transformer
+      post_tc_sentence
+      interactive_post_typing_transformers in
 
   if Settings.get_value Basicsettings.show_post_frontend_ast then
-    Debug.print ("Post-Frontend AST:\n" ^ Sugartypes.show_sentence post_sentence);
+    Debug.print ("Post-Frontend AST:\n" ^ Sugartypes.show_sentence result_sentence);
 
-  result
+   (result_sentence, t, post_tyenv)
 
 
 end

--- a/core/frontend.ml
+++ b/core/frontend.ml
@@ -25,6 +25,10 @@ struct
 
   let session_exceptions = Settings.get_value Basicsettings.Sessions.exceptions_enabled
 
+  let repeat_type_check =
+    Settings.get_value
+      Basicsettings.TypeSugar.check_frontend_transformations
+
 
   let for_side_effects ignored_transformer program  =
     let _ = ignored_transformer program in
@@ -103,7 +107,13 @@ let program prev_tyenv pos_context program =
 
 
   let apply_post_tc_transformer program transformer =
-    transformer prev_tyenv program in
+    let post = transformer prev_tyenv program in
+    if repeat_type_check then
+      let _ = fst3 (TypeSugar.Check.program prev_tyenv post) in
+      post
+    else
+      post
+  in
   let result_program =
     List.fold_left
       apply_post_tc_transformer
@@ -176,7 +186,13 @@ let interactive prev_tyenv pos_context sentence =
     TypeSugar.Check.sentence prev_tyenv pre_tc_sentence in
 
   let apply_post_tc_transformer sentence transformer =
-    transformer prev_tyenv sentence in
+    let post = transformer prev_tyenv sentence in
+    if repeat_type_check then
+      let _ = fst3 (TypeSugar.Check.sentence prev_tyenv post) in
+      post
+    else
+      post
+  in
   let result_sentence =
     List.fold_left
       apply_post_tc_transformer

--- a/core/frontend.ml
+++ b/core/frontend.ml
@@ -63,7 +63,6 @@ struct
     ]
 
 
-
   (* Program transformations after type-checking programs (i.e., non-REPL mode *)
   let program_post_typing_transformers
       : post_typing_program_transformer list =
@@ -83,8 +82,6 @@ struct
       DesugarPages.desugar_program;
       DesugarFuns.desugar_program;
     ]
-
-
 
 
 let program prev_tyenv pos_context program =
@@ -126,9 +123,6 @@ let program prev_tyenv pos_context program =
     Debug.print ("Post-Frontend AST:\n" ^ Sugartypes.show_program result_program);
 
   (result_program, t, cur_tyenv), ffi_files
-
-
-
 
 
   type pre_typing_sentence_transformer =

--- a/core/transformSugar.ml
+++ b/core/transformSugar.ml
@@ -7,6 +7,9 @@ open Utility
 
 module TyEnv = Env.String
 
+type program_transformer = Types.typing_environment -> Sugartypes.program -> Sugartypes.program
+type sentence_transformer = Types.typing_environment -> Sugartypes.sentence -> Sugartypes.sentence
+
 let internal_error message =
   Errors.internal_error ~filename:"transformSugar.ml" ~message
 

--- a/core/transformSugar.mli
+++ b/core/transformSugar.mli
@@ -109,3 +109,6 @@ object ('self)
 end
 
 val fun_effects : Types.datatype -> Sugartypes.Pattern.with_pos list list -> Types.row
+
+type program_transformer = Types.typing_environment -> Sugartypes.program -> Sugartypes.program
+type sentence_transformer = Types.typing_environment -> Sugartypes.sentence -> Sugartypes.sentence


### PR DESCRIPTION
This PR does three things:

1. The pipelines in `Frontend` were previously expressed as big, composed functions. I replaced this with lists of functions.

2. The types of the transformations are simplified. Many of the transformations that run after type-checking returned a triple, where only one value was actually relevant. In addition, there was some awkward logic in place to make sure that the type environment determined by `TypeSugar` is the one returned by the overall pipeline.

3. There is now a setting `recheck_frontend_transformations`, which if enabled repeats type-checking after each transformation that happens after type-checking. This is something @slindley was particularly interested in.


Note that the functions `program` and `interactive` share quite some overall logic, but they differ just enough so that in my opinion readability would suffer if we tried to unify them.