### PR TITLE
Syntactic sugar for effect variables in higher-order functions

### DIFF
--- a/core/basicsettings.ml
+++ b/core/basicsettings.ml
@@ -225,6 +225,7 @@ end
 module Types = struct
   let show_mailbox_annotations = Settings.add_bool("show_mailbox_annotations", true, `User)
   let show_raw_type_vars = Settings.add_bool("show_raw_type_vars", false, `User)
+  let shared_effect_vars = Settings.add_bool ("shared_effect_vars", false, `User)
   module Print = struct
     let show_quantifiers     = Settings.add_bool   ("show_quantifiers"    , false    , `User)
     let show_flavours        = Settings.add_bool   ("show_flavours"       , false    , `User)

--- a/core/basicsettings.ml
+++ b/core/basicsettings.ml
@@ -225,7 +225,7 @@ end
 module Types = struct
   let show_mailbox_annotations = Settings.add_bool("show_mailbox_annotations", true, `User)
   let show_raw_type_vars = Settings.add_bool("show_raw_type_vars", false, `User)
-  let shared_effect_vars = Settings.add_bool ("shared_effect_vars", false, `User)
+  let effect_sugar = Settings.add_bool ("effect_sugar", false, `User)
   module Print = struct
     let show_quantifiers     = Settings.add_bool   ("show_quantifiers"    , false    , `User)
     let show_flavours        = Settings.add_bool   ("show_flavours"       , false    , `User)

--- a/core/desugarDatatypes.ml
+++ b/core/desugarDatatypes.ml
@@ -48,7 +48,7 @@ class basic_freshener = object
   method! known_type_variable =
     let module SC = SugarConstructors.SugartypesPositions in
     function
-    | (("_" | "_anon"), None, freedom) ->
+    | (("$" | "$anon"), None, freedom) ->
        SC.fresh_known_type_variable freedom
        |> super#known_type_variable
     | v ->  super#known_type_variable v
@@ -59,7 +59,7 @@ let freshen_vars =
   (* Determine if this is an "anonymous" effect type variable, and so introduced
      within a simple arrow (->, ~>, -@, ~>) *)
   let is_anon_effect = function
-    | Datatype.Open ("_anon", None, `Rigid) -> true
+    | Datatype.Open ("$anon", None, `Rigid) -> true
     | _ -> false in
   (* If this function type is exclusively composed of anonymous effect type
      variables. Or rather, there are no explicitly mentioned effect variables. *)

--- a/core/desugarDatatypes.ml
+++ b/core/desugarDatatypes.ml
@@ -64,10 +64,10 @@ let freshen_vars =
   (* If this function type is exclusively composed of anonymous effect type
      variables. Or rather, there are no explicitly mentioned effect variables. *)
   let all_anon_effects = object
-    inherit SugarTraversals.fold as super
+    inherit SugarTraversals.predicate as super
 
     val all_anon = true
-    method all_anon = all_anon
+    method satisfied = all_anon
 
     method! datatypenode = let open Datatype in
       function
@@ -93,12 +93,12 @@ let freshen_vars =
     method! datatypenode = let open Datatype in
       function
       | (Function _ | Lolli _) as dt ->
-         (* If shared_effect_vars is enabled, and all variables are fresh (and so
-            not explicitly named), then we will substitute the same variable
-            across all arrows. Otherwise every arrow gets its own row
-            variable, as normal. *)
-         if Settings.get_value Basicsettings.Types.shared_effect_vars
-            && (all_anon_effects#datatypenode dt)#all_anon then
+         (* If effect_sugar is enabled, and all variables are fresh (and so not
+            explicitly named), then we will substitute the same variable across
+            all arrows. Otherwise every arrow gets its own row variable, as
+            normal. *)
+         if Settings.get_value Basicsettings.Types.effect_sugar
+            && (all_anon_effects#datatypenode dt)#satisfied then
            let var = Datatype.Open (SC.fresh_known_type_variable `Rigid) in
            (shared_refresh var)#datatypenode dt
          else

--- a/core/lib.ml
+++ b/core/lib.ml
@@ -402,7 +402,7 @@ let env : (string * (located_primitive * Types.datatype * pure)) list = [
 
   "spawnWait",
   (`PFun (fun _ -> assert false),
-   datatype "(() ~> a) ~> a",
+   datatype "(() ~_~> a) ~> a",
    IMPURE);
 
   "spawnWait'",
@@ -902,7 +902,7 @@ let env : (string * (located_primitive * Types.datatype * pure)) list = [
   (* what effect annotation should the inner arrow have? *)
   "registerEventHandlers",
   (`PFun (fun _ -> assert false),
-  datatype "([(String, (Event) ~> ())]) ~> String",
+  datatype "([(String, (Event) ~_~> ())]) ~> String",
   IMPURE);
 
   (* getPageX : (Event) -> Int *)
@@ -1296,7 +1296,7 @@ let env : (string * (located_primitive * Types.datatype * pure)) list = [
      in the prelude and is just a wrapper for this function.
    *)
    (`Server (p1 (Value.marshal_value ->- Value.box_string)),
-    datatype "(() -> a) ~> String",
+    datatype "(() -_-> a) ~> String",
     IMPURE));
 
   (* REDUNDANT *)

--- a/core/lib.ml
+++ b/core/lib.ml
@@ -402,7 +402,7 @@ let env : (string * (located_primitive * Types.datatype * pure)) list = [
 
   "spawnWait",
   (`PFun (fun _ -> assert false),
-   datatype "(() ~_~> a) ~> a",
+   datatype "(() { |_}~> a) ~> a",
    IMPURE);
 
   "spawnWait'",
@@ -902,7 +902,7 @@ let env : (string * (located_primitive * Types.datatype * pure)) list = [
   (* what effect annotation should the inner arrow have? *)
   "registerEventHandlers",
   (`PFun (fun _ -> assert false),
-  datatype "([(String, (Event) ~_~> ())]) ~> String",
+  datatype "([(String, (Event) { |_}~> ())]) ~> String",
   IMPURE);
 
   (* getPageX : (Event) -> Int *)
@@ -1296,7 +1296,7 @@ let env : (string * (located_primitive * Types.datatype * pure)) list = [
      in the prelude and is just a wrapper for this function.
    *)
    (`Server (p1 (Value.marshal_value ->- Value.box_string)),
-    datatype "(() -_-> a) ~> String",
+    datatype "(() { |_}-> a) ~> String",
     IMPURE));
 
   (* REDUNDANT *)

--- a/core/parser.mly
+++ b/core/parser.mly
@@ -171,8 +171,8 @@ let parseRegexFlags f =
               | 'g' -> RegexGlobal
               | _ -> assert false) (asList f 0 [])
 
-let fresh_typevar freedom = ("_", None, freedom)
-let fresh_effects = ([], Datatype.Open ("_anon", None, `Rigid))
+let fresh_typevar freedom = ("$", None, freedom)
+let fresh_effects = ([], Datatype.Open ("$anon", None, `Rigid))
 
 module MutualBindings = struct
 

--- a/core/parser.mly
+++ b/core/parser.mly
@@ -972,8 +972,8 @@ squiggly_arrow:
   squig_arrow_prefix SQUIGRARROW datatype                      { Datatype.Function ($1, row_with_wp $2, $4) }
 | parenthesized_datatypes
   squig_arrow_prefix SQUIGLOLLI datatype                       { Datatype.Lolli    ($1, row_with_wp $2, $4) }
-| parenthesized_datatypes SQUIGRARROW datatype                 { Datatype.Function ($1, row_with_wp (fresh_effects), $3) }
-| parenthesized_datatypes SQUIGLOLLI datatype                  { Datatype.Lolli    ($1, row_with_wp (fresh_effects), $3) }
+| parenthesized_datatypes SQUIGRARROW datatype                 { Datatype.Function ($1, row_with_wp fresh_effects, $3) }
+| parenthesized_datatypes SQUIGLOLLI datatype                  { Datatype.Lolli    ($1, row_with_wp fresh_effects, $3) }
 
 mu_datatype:
 | MU VARIABLE DOT mu_datatype                                  { Datatype.Mu ($2, with_pos $loc($4) $4) }

--- a/core/parser.mly
+++ b/core/parser.mly
@@ -172,7 +172,7 @@ let parseRegexFlags f =
               | _ -> assert false) (asList f 0 [])
 
 let fresh_typevar freedom = ("_", None, freedom)
-let fresh_effects = ([], Datatype.Open (fresh_typevar `Rigid))
+let fresh_effects = ([], Datatype.Open ("_anon", None, `Rigid))
 
 module MutualBindings = struct
 

--- a/core/parser.mly
+++ b/core/parser.mly
@@ -171,6 +171,9 @@ let parseRegexFlags f =
               | 'g' -> RegexGlobal
               | _ -> assert false) (asList f 0 [])
 
+let fresh_typevar freedom = ("_", None, freedom)
+let fresh_effects = ([], Datatype.Open (fresh_typevar `Rigid))
+
 module MutualBindings = struct
 
   type mutual_bindings =
@@ -961,16 +964,16 @@ straight_arrow:
   straight_arrow_prefix RARROW datatype                        { Datatype.Function ($1, $2, $4) }
 | parenthesized_datatypes
   straight_arrow_prefix LOLLI datatype                         { Datatype.Lolli    ($1, $2, $4) }
-| parenthesized_datatypes RARROW datatype                      { Datatype.Function ($1, fresh_row (), $3) }
-| parenthesized_datatypes LOLLI datatype                       { Datatype.Lolli    ($1, fresh_row (), $3) }
+| parenthesized_datatypes RARROW datatype                      { Datatype.Function ($1, fresh_effects, $3) }
+| parenthesized_datatypes LOLLI datatype                       { Datatype.Lolli    ($1, fresh_effects, $3) }
 
 squiggly_arrow:
 | parenthesized_datatypes
   squig_arrow_prefix SQUIGRARROW datatype                      { Datatype.Function ($1, row_with_wp $2, $4) }
 | parenthesized_datatypes
   squig_arrow_prefix SQUIGLOLLI datatype                       { Datatype.Lolli    ($1, row_with_wp $2, $4) }
-| parenthesized_datatypes SQUIGRARROW datatype                 { Datatype.Function ($1, row_with_wp (fresh_row ()), $3) }
-| parenthesized_datatypes SQUIGLOLLI datatype                  { Datatype.Lolli    ($1, row_with_wp (fresh_row ()), $3) }
+| parenthesized_datatypes SQUIGRARROW datatype                 { Datatype.Function ($1, row_with_wp (fresh_effects), $3) }
+| parenthesized_datatypes SQUIGLOLLI datatype                  { Datatype.Lolli    ($1, row_with_wp (fresh_effects), $3) }
 
 mu_datatype:
 | MU VARIABLE DOT mu_datatype                                  { Datatype.Mu ($2, with_pos $loc($4) $4) }
@@ -1042,8 +1045,8 @@ primary_datatype:
 type_var:
 | VARIABLE                                                     { Datatype.TypeVar ($1, None, `Rigid)    }
 | PERCENTVAR                                                   { Datatype.TypeVar ($1, None, `Flexible) }
-| UNDERSCORE                                                   { fresh_rigid_type_variable ()   }
-| PERCENT                                                      { fresh_type_variable ()         }
+| UNDERSCORE                                                   { Datatype.TypeVar (fresh_typevar `Rigid)    }
+| PERCENT                                                      { Datatype.TypeVar (fresh_typevar `Flexible) }
 
 kinded_type_var:
 | type_var subkind                                             { attach_subkind ($1, $2) }
@@ -1133,14 +1136,14 @@ fieldspec:
 | LBRACE MINUS RBRACE                                          { Datatype.Absent }
 | LBRACE VARIABLE RBRACE                                       { Datatype.Var ($2, None, `Rigid) }
 | LBRACE PERCENTVAR RBRACE                                     { Datatype.Var ($2, None, `Flexible) }
-| LBRACE UNDERSCORE RBRACE                                     { fresh_rigid_presence_variable () }
-| LBRACE PERCENT RBRACE                                        { fresh_presence_variable ()       }
+| LBRACE UNDERSCORE RBRACE                                     { Datatype.Var (fresh_typevar `Rigid)    }
+| LBRACE PERCENT RBRACE                                        { Datatype.Var (fresh_typevar `Flexible) }
 
 nonrec_row_var:
 | VARIABLE                                                     { Datatype.Open ($1, None, `Rigid   ) }
 | PERCENTVAR                                                   { Datatype.Open ($1, None, `Flexible) }
-| UNDERSCORE                                                   { fresh_rigid_row_variable () }
-| PERCENT                                                      { fresh_row_variable ()       }
+| UNDERSCORE                                                   { Datatype.Open (fresh_typevar `Rigid)    }
+| PERCENT                                                      { Datatype.Open (fresh_typevar `Flexible) }
 
 /* FIXME:
  *

--- a/core/sugarConstructors.ml
+++ b/core/sugarConstructors.ml
@@ -25,30 +25,9 @@ module SugarConstructors (Position : Pos)
 
   let type_variable_counter = ref 0
 
-  let fresh_type_variable () : Datatype.t =
+  let fresh_known_type_variable freedom : known_type_variable =
     incr type_variable_counter;
-    Datatype.TypeVar ("_" ^ string_of_int (!type_variable_counter), None, `Flexible)
-
-  let fresh_rigid_type_variable () : Datatype.t =
-    incr type_variable_counter;
-    Datatype.TypeVar ("_" ^ string_of_int (!type_variable_counter), None, `Rigid)
-
-  let fresh_row_variable () : Datatype.row_var =
-    incr type_variable_counter;
-    Datatype.Open ("_" ^ string_of_int (!type_variable_counter), None, `Flexible)
-
-  let fresh_rigid_row_variable () : Datatype.row_var =
-    incr type_variable_counter;
-    Datatype.Open ("_" ^ string_of_int (!type_variable_counter), None, `Rigid)
-
-  let fresh_presence_variable () : Datatype.fieldspec =
-    incr type_variable_counter;
-    Datatype.Var ("_" ^ string_of_int (!type_variable_counter), None, `Flexible)
-
-  let fresh_rigid_presence_variable () : Datatype.fieldspec =
-    incr type_variable_counter;
-    Datatype.Var ("_" ^ string_of_int (!type_variable_counter), None, `Rigid)
-
+    ("_" ^ string_of_int (!type_variable_counter), None, freedom)
 
   (** Helper data types and functions for passing arguments to smart
       constructors. *)
@@ -141,7 +120,6 @@ module SugarConstructors (Position : Pos)
 
   (** Rows *)
 
-  let fresh_row   unit                    = ([], fresh_rigid_row_variable unit)
   let row_with    field (fields, row_var) = (field::fields, row_var)
   let row_with_wp fields                  = row_with wild_present fields
   let hear_arrow_prefix presence fields =

--- a/core/sugarConstructorsIntf.ml
+++ b/core/sugarConstructorsIntf.ml
@@ -40,12 +40,7 @@ module type SugarConstructorsSig = sig
   val with_dummy_pos : 'a -> 'a WithPos.t
 
   (* Fresh type variables. *)
-  val fresh_type_variable           : unit -> Datatype.t
-  val fresh_rigid_type_variable     : unit -> Datatype.t
-  val fresh_row_variable            : unit -> Datatype.row_var
-  val fresh_rigid_row_variable      : unit -> Datatype.row_var
-  val fresh_presence_variable       : unit -> Datatype.fieldspec
-  val fresh_rigid_presence_variable : unit -> Datatype.fieldspec
+  val fresh_known_type_variable  : freedom -> known_type_variable
 
   (* Helper data types and functions for passing arguments to smart
      constructors.  *)
@@ -90,7 +85,6 @@ module type SugarConstructorsSig = sig
   val present : Datatype.fieldspec
 
   (* Rows *)
-  val fresh_row         : unit -> Datatype.row
   val row_with_wp       : Datatype.row -> Datatype.row
   val hear_arrow_prefix : Datatype.with_pos -> Datatype.row -> Datatype.row
 

--- a/core/types.ml
+++ b/core/types.ml
@@ -1953,6 +1953,8 @@ struct
      from rigid type variables. *)
   type policy = {quantifiers:bool; flavours:bool; hide_fresh:bool; kinds:string; shared_effect_vars:bool}
   type names  = (int, string * Vars.spec) Hashtbl.t
+  type shared_effect = Unknown | Shared of int | Distinct
+  type context = { bound_vars: TypeVarSet.t; shared_effect: shared_effect }
 
   let default_policy () =
     {quantifiers=Settings.get_value show_quantifiers;
@@ -1961,10 +1963,79 @@ struct
      kinds=Settings.get_value show_kinds;
      shared_effect_vars=Settings.get_value shared_effect_vars}
 
+  let empty_context = { bound_vars = TypeVarSet.empty; shared_effect = Unknown }
+
   let has_kind =
     function
     | "" -> ""
     | s -> "::" ^ s
+
+  (** Checks that a field environment contains exactly the values passed in a
+     list *)
+  let fields_present_in fields values =
+    FieldEnv.size fields = List.length values &&
+      List.for_all (fun v -> FieldEnv.mem v fields
+                             && is_present (FieldEnv.find v fields))
+        values
+
+  let find_shared_effect { bound_vars; shared_effect } vars args fields row_var ret =
+    let var_eq known resolve=
+      match Unionfind.find resolve with
+      | `Var (var, _, _) when var = known -> true
+      | _ -> false
+    in
+    match shared_effect with
+    | Distinct -> Distinct
+    | Shared var ->
+       (* If we encounter a row variable, it /must/ be equivalent to our shared one. *)
+       assert (var_eq var row_var);
+       Shared var
+    | Unknown -> (
+      match Unionfind.find row_var with
+      | `Var (var, _, _) when not (TypeVarSet.mem var bound_vars) ->
+          let obj =
+            object (self)
+              inherit Transform.visitor as super
+
+              val all_same = true
+              val count = 1
+              method all_same = all_same
+              method count = count
+
+              method! typ =
+                function
+                | typ when not all_same -> (typ, self)
+                | (`Function (args, effects, ret) | `Lolli (args, effects, ret)) as typ ->
+                    let fields, row_var, _ = unwrap_row effects |> fst in
+                    if
+                      (fields_present_in fields [] || fields_present_in fields [ "wild" ])
+                      && var_eq var row_var
+                    then
+                      let (_, self) = self#typ args in
+                      let (_, self) = self#typ ret in
+                      let (_, self) = self#field_spec_map fields in
+                      (typ, {<count = count + 1; all_same = self#all_same>})
+                    else (
+                      (typ, {<all_same = false>})
+                    )
+                | `Alias ((_, args), _) as ty ->
+                    let self = List.fold_left (fun o arg -> o#type_arg arg |> snd) self args in
+                    (ty, self)
+                | typ -> super#typ typ
+
+              method! row_var row_var =
+                if var_eq var row_var then
+                  (row_var, {<all_same = false>})
+                else
+                  super#row_var row_var
+            end
+          in
+          let (_, obj) = obj#typ args in
+          let (_, obj) = obj#typ ret in
+          let (_, obj) = obj#field_spec_map fields in
+          let _, (_, _, count) = Vars.find_spec var vars in
+          if obj#all_same && obj#count = count then Shared var else Distinct
+      | _ -> Distinct )
 
   let subkind : (policy * names) -> subkind -> string =
     let full (l, r) = "(" ^ Linearity.to_string l ^ "," ^
@@ -2021,9 +2092,9 @@ struct
       in
         prefix ^ Vars.find (var_of_quantifier q) vars ^ has_kind (kind (policy, vars) k)
 
-  let rec datatype : TypeVarSet.t -> policy * names -> datatype -> string =
-    fun bound_vars ((policy, vars) as p) t ->
-      let sd = datatype bound_vars p in
+  let rec datatype : context -> policy * names -> datatype -> string =
+    fun ({ bound_vars; _ } as context) ((policy, vars) as p) t ->
+      let sd = datatype context p in
       let sk k = has_kind (subkind p k) in
 
       let hide_fresh_check var (flavour, _, count) =
@@ -2032,7 +2103,7 @@ struct
 
       let unwrap = fst -<- unwrap_row in
         (* precondition: the row is unwrapped *)
-      let string_of_tuple (field_env, _, _) =
+      let string_of_tuple context (field_env, _, _) =
         let tuple_env =
           FieldEnv.fold
             (fun i f tuple_env ->
@@ -2041,7 +2112,7 @@ struct
                  | (`Absent | `Var _) -> assert false)
             field_env
             IntMap.empty in
-        let ss = List.rev (IntMap.fold (fun _ t ss -> (sd t) :: ss) tuple_env []) in
+        let ss = List.rev (IntMap.fold (fun _ t ss -> (datatype context p t) :: ss) tuple_env []) in
           "(" ^ String.concat ", " ss ^  ")" in
 
       (* If type variable names are hidden return a generic name n1.
@@ -2052,15 +2123,16 @@ struct
         if hide_fresh_check var spec then n1 else (n2 name) in
 
       (* Pretty-prints a row variable *)
-      let ppr_row_var args to_match closed (flex_name_hidden, flex_name)
-                           (name_hidden, name) =
+      let ppr_row_var context args to_match closed
+            (flex_name_hidden, flex_name)
+            (name_hidden, name) =
         match Unionfind.find to_match with
         | `Var (var, _, `Flexible) when policy.flavours ->
            name_of_type var flex_name_hidden flex_name
         | `Var (var, _, _) ->
            name_of_type var name_hidden name
         | `Closed      -> closed
-        | `Body t'     -> sd (`Function (args, t', t))
+        | `Body t'     -> datatype context p (`Function (args, t', t))
         | `Recursive _ -> assert false in
 
       (* Pretty-prints function spaces.
@@ -2070,59 +2142,37 @@ struct
        let (fields, row_var, dual) = unwrap effects in
        assert (not dual);
 
-       (* Checks that field environment contains exactly the values passed in in
-          a list *)
-       let fields_present_in fields values =
-         FieldEnv.size fields = List.length values &&
-         List.for_all (fun v -> FieldEnv.mem v fields
-                            && is_present (FieldEnv.find v fields))
-                        values in
        let fields_present = fields_present_in fields in
 
-       let policy =
-         let get_var var = match Unionfind.find var with
-           | `Var (var, _, _) -> Some var
-           | _ -> None in
-         let row_var = get_var row_var in
-         if policy.shared_effect_vars && policy.hide_fresh && not policy.quantifiers && OptionUtils.is_some row_var then
-           let obj = object(self)
-             inherit Transform.visitor as super
-
-             val all_same = true
-             method all_same = all_same
-
-             method! typ =
-               function
-               | typ when not all_same -> (typ, self)
-               | (`Function (_, effects, _) | `Lolli (_, effects, _)) as typ ->
-                  let fields', row_var', _ = unwrap effects in
-                  if (fields_present_in fields' [] || fields_present_in fields' ["wild"]) && get_var row_var' = row_var then
-                    super#typ typ
-                  else
-                    (typ, {<all_same = false>})
-               | typ -> super#typ typ
-           end in
-           { policy with shared_effect_vars = (obj#typ t |> snd)#all_same }
-         else { policy with shared_effect_vars = false } in
-       let p = (policy, vars) in
-       let sd = datatype bound_vars p in
+       let context =
+         if policy.shared_effect_vars then
+           let shared_effect = find_shared_effect context vars args fields row_var t in
+           { context with shared_effect }
+         else context in
+       let is_shared =
+         match context.shared_effect with
+         | Shared _ -> true
+         | _ -> false in
+       let hidden line =
+         if policy.shared_effect_vars then line ^ "_" ^ line ^ ah else line ^ ah in
+       let sd = datatype context p in
 
        let ppr_arrow () =
-         if policy.shared_effect_vars && fields_present [] then "-" ^ ah
-         else if policy.shared_effect_vars && fields_present ["wild"] then "~" ^ ah
-         else if fields_present [] then
-           ppr_row_var args row_var ("{}-" ^ ah)
+         if fields_present [] then
+           if policy.hide_fresh && is_shared then "-" ^ ah else
+           ppr_row_var context args row_var ("{}-" ^ ah)
                ("-%-" ^ ah, fun name -> "-%" ^ name ^ "-" ^ ah)
-               ("-"   ^ ah, fun name -> "-"  ^ name ^ "-" ^ ah)
+               (hidden "-", fun name -> "-"  ^ name ^ "-" ^ ah)
          else if fields_present ["wild"]
          then
-           ppr_row_var args row_var ("{}~" ^ ah)
+           if policy.hide_fresh && is_shared then "~" ^ ah else
+           ppr_row_var context args row_var ("{}~" ^ ah)
                ("~%~" ^ ah, fun name -> "~%" ^ name ^ "~" ^ ah)
-               ("~"   ^ ah, fun name -> "~"  ^ name ^ "~" ^ ah)
+               (hidden "~", fun name -> "~"  ^ name ^ "~" ^ ah)
          else if fields_present ["hear"; "wild"]
          then
            let ht' = ht fields in
-           ppr_row_var args row_var ("{:" ^ ht' ^ "}~" ^ ah)
+           ppr_row_var context args row_var ("{:" ^ ht' ^ "}~" ^ ah)
                ("{:" ^ ht' ^ "|%}~" ^ ah, fun name -> "{:" ^ ht' ^ "|%" ^ name ^ "}~" ^ ah)
                ("{:" ^ ht' ^ "|_}~" ^ ah, fun name -> "{:" ^ ht' ^ "|"  ^ name ^ "}~" ^ ah)
          else
@@ -2131,15 +2181,15 @@ struct
                 the effect row *)
            if FieldEnv.mem "wild" fields &&
              is_present (FieldEnv.find "wild" fields) then
-             "{" ^ row ~strip_wild:true "," bound_vars p effects ^ "}~" ^ ah
+             "{" ^ row ~strip_wild:true "," context p effects ^ "}~" ^ ah
            else
-             "{" ^ row "," bound_vars p effects ^ "}-" ^ ah
+             "{" ^ row "," context p effects ^ "}-" ^ ah
          in begin match concrete_type args with
             | `Record row when is_tuple ~allow_onetuples:true row ->
                (* Let bindings are needed here to ensure left-to-right
                   generation of type variable names.
                   See Note [Variable names in error messages] *)
-               let row_str   = string_of_tuple row in
+               let row_str   = string_of_tuple context row in
                let arrow_str = ppr_arrow () in
                let sd_str    = sd t in
                row_str ^ " " ^ arrow_str ^ " " ^ sd_str
@@ -2161,7 +2211,7 @@ struct
                         Vars.find var vars
                       else
                         "mu " ^ Vars.find var vars ^ " . " ^
-                          datatype (TypeVarSet.add var bound_vars) p body
+                          datatype { context with bound_vars = TypeVarSet.add var bound_vars } p body
                   | `Body t -> sd t
               end
           | `Function (args, effects, t) ->
@@ -2178,10 +2228,10 @@ struct
              in ppr_function_type args effects t "@" ht
           | `Record r ->
               let ur = unwrap r in
-                (if is_tuple ur then string_of_tuple r
-                 else "(" ^ row "," bound_vars p r ^ ")")
-          | `Variant r -> "[|" ^ row "|" bound_vars p r ^ "|]"
-          | `Effect r -> "{" ^ row "," bound_vars p r ^ "}"
+                (if is_tuple ur then string_of_tuple context r
+                 else "(" ^ row "," context p r ^ ")")
+          | `Variant r -> "[|" ^ row "|" context p r ^ "|]"
+          | `Effect r -> "{" ^ row "," context p r ^ "}"
           | `ForAll (tyvars, body) ->
               let tyvars = unbox_quantifiers tyvars in
               let bound_vars =
@@ -2193,23 +2243,23 @@ struct
                 if not (policy.flavours) then
                   let tyvars = List.filter is_rigid_quantifier tyvars in
                     match tyvars with
-                      | [] -> datatype bound_vars p body
+                      | [] -> datatype { context with bound_vars } p body
                       | _ ->
-                          "forall "^ mapstrcat "," (quantifier p) tyvars ^"."^ datatype bound_vars p body
+                          "forall "^ mapstrcat "," (quantifier p) tyvars ^"."^ datatype { context with bound_vars } p body
                 else
-                  "forall "^ mapstrcat "," (quantifier p) tyvars ^"."^ datatype bound_vars p body
-          | `Input  (t, s) -> "?(" ^ datatype bound_vars p t ^ ")." ^ datatype bound_vars p s
-          | `Output (t, s) -> "!(" ^ datatype bound_vars p t ^ ")." ^ datatype bound_vars p s
-          | `Select bs -> "[+|" ^ row "," bound_vars p bs ^ "|+]"
-          | `Choice bs -> "[&|" ^ row "," bound_vars p bs ^ "|&]"
-          | `Dual s -> "~" ^ datatype bound_vars p s
+                  "forall "^ mapstrcat "," (quantifier p) tyvars ^"."^ datatype { context with bound_vars } p body
+          | `Input  (t, s) -> "?(" ^ sd t ^ ")." ^ sd s
+          | `Output (t, s) -> "!(" ^ sd t ^ ")." ^ sd s
+          | `Select bs -> "[+|" ^ row "," context p bs ^ "|+]"
+          | `Choice bs -> "[&|" ^ row "," context p bs ^ "|&]"
+          | `Dual s -> "~" ^ sd s
           | `End -> "End"
           | `Table (r, w, n)   ->
              (* TODO: pretty-print this using constraints? *)
              "TableHandle(" ^
-               datatype bound_vars p r ^ "," ^
-               datatype bound_vars p w ^ "," ^
-               datatype bound_vars p n ^ ")"
+               sd r ^ "," ^
+               sd w ^ "," ^
+               sd n ^ ")"
           | `Lens typ ->
             let sort = Lens.Type.sort typ in
             let cols = Lens.Sort.cols sort in
@@ -2223,24 +2273,24 @@ struct
           | `Alias ((s,ts), _) ->
              Printf.sprintf "%s (%s)"
                (Module_hacks.Name.prettify s)
-               (String.concat "," (List.map (type_arg bound_vars p) ts))
-          | `Application (l, [elems]) when Abstype.equal l list ->  "["^ (type_arg bound_vars p) elems ^"]"
+               (String.concat "," (List.map (type_arg context p) ts))
+          | `Application (l, [elems]) when Abstype.equal l list ->  "["^ (type_arg context p) elems ^"]"
           | `Application (s, []) -> Abstype.name s
           | `Application (s, ts) ->
-              let vars = String.concat "," (List.map (type_arg bound_vars p) ts) in
+              let vars = String.concat "," (List.map (type_arg context p) ts) in
               Printf.sprintf "%s (%s)" (Abstype.name s) vars
           | `RecursiveApplication { r_name; r_args; _ } when r_args = [] -> Module_hacks.Name.prettify r_name
           | `RecursiveApplication { r_name; r_args; _ } ->
              Printf.sprintf "%s (%s)"
                (Module_hacks.Name.prettify r_name)
-               (String.concat "," (List.map (type_arg bound_vars p) r_args))
-  and presence bound_vars ((policy, vars) as p) =
+               (String.concat "," (List.map (type_arg context p) r_args))
+  and presence ({ bound_vars; _ } as context) ((policy, vars) as p) =
     function
       | `Present t ->
         begin
           match concrete_type t with
           | `Record row when is_empty_row row -> ""
-          | _                                 -> ":" ^ datatype bound_vars p t
+          | _                                 -> ":" ^ datatype context p t
         end
       | `Absent -> "-"
       | `Var point ->
@@ -2255,10 +2305,10 @@ struct
               | `Var (var, _, _) ->
                  name_of_type var "{_}" (fun name -> "{" ^ name ^ "}")
               | `Body f ->
-                  presence bound_vars p f
+                  presence context p f
           end
 
-  and row ?(strip_wild=false) sep bound_vars p (field_env, rv, dual) =
+  and row ?(strip_wild=false) sep context p (field_env, rv, dual) =
     (* FIXME:
 
        should quote labels when necessary, i.e., when they
@@ -2270,17 +2320,17 @@ struct
           if strip_wild && label = "wild" then
             field_strings
           else
-            (label ^ presence bound_vars p f) :: field_strings)
+            (label ^ presence context p f) :: field_strings)
         field_env [] in
 
-    let row_var_string = row_var sep bound_vars p rv in
+    let row_var_string = row_var sep context p rv in
       String.concat sep (List.rev (field_strings)) ^
         begin
           match row_var_string with
             | None -> ""
             | Some s -> "|"^ (if dual then "~" else "") ^ s
         end
-  and row_var sep bound_vars ((policy, vars) as p) rv =
+  and row_var sep ({ bound_vars; _ } as context) ((policy, vars) as p) rv =
     let name_of_type var k n1 n2 =
      let name, (_, _, count) = Vars.find_spec var vars in
      Some ((if policy.hide_fresh && count = 1 && not (IntSet.mem var bound_vars)
@@ -2298,16 +2348,16 @@ struct
             Some (Vars.find var vars)
           else
             Some ("(mu " ^ Vars.find var vars ^ " . " ^
-                    row sep (TypeVarSet.add var bound_vars) p r ^ ")")
-      | `Body r -> Some (row sep bound_vars p r)
+                    row sep { context with bound_vars = TypeVarSet.add var bound_vars } p r ^ ")")
+      | `Body r -> Some (row sep context p r)
 
-  and type_arg bound_vars p =
+  and type_arg context p =
     function
-      | `Type t -> datatype bound_vars p t
-      | `Row r -> "{ " ^ row "," bound_vars p r ^ " }"
-      | `Presence f -> "::Presence (" ^ presence bound_vars p f ^ ")"
+      | `Type t -> datatype context p t
+      | `Row r -> "{ " ^ row "," context p r ^ " }"
+      | `Presence f -> "::Presence (" ^ presence context p f ^ ")"
 
-  let tycon_spec bound_vars p =
+  let tycon_spec ({ bound_vars; _ } as context) p =
     let bound_vars tyvars =
       List.fold_left
         (fun bound_vars tyvar ->
@@ -2316,11 +2366,11 @@ struct
 
     function
       | `Alias (tyvars, body) ->
-          let bvs = bound_vars tyvars in
+          let ctx = { context with bound_vars = bound_vars tyvars } in
           begin
             match tyvars with
-              | [] -> datatype bvs p body
-              | _ -> mapstrcat "," (quantifier p) tyvars ^"."^ datatype bvs p body
+              | [] -> datatype ctx p body
+              | _ -> mapstrcat "," (quantifier p) tyvars ^"."^ datatype ctx p body
           end
       | `Mutual _ -> "mutual"
       | `Abstract _ -> "abstract"
@@ -2476,7 +2526,7 @@ let string_of_datatype ?(policy=Print.default_policy) ?(refresh_tyvar_names=true
     let t = if policy.Print.quantifiers then t
             else Print.strip_quantifiers t in
     if refresh_tyvar_names then build_tyvar_names (fun x -> free_bound_type_vars x) [t];
-    Print.datatype TypeVarSet.empty (policy, Vars.tyvar_name_map) t
+    Print.datatype Print.empty_context (policy, Vars.tyvar_name_map) t
   else
     show_datatype (DecycleTypes.datatype t)
 
@@ -2484,7 +2534,7 @@ let string_of_row ?(policy=Print.default_policy) ?(refresh_tyvar_names=true) row
   if Settings.get_value Basicsettings.print_types_pretty then
     begin
     if refresh_tyvar_names then build_tyvar_names (fun x -> free_bound_row_type_vars x) [row];
-    Print.row "," TypeVarSet.empty (policy (), Vars.tyvar_name_map) row
+    Print.row "," Print.empty_context (policy (), Vars.tyvar_name_map) row
     end
   else
     show_row (DecycleTypes.row row)
@@ -2493,25 +2543,25 @@ let string_of_presence ?(policy=Print.default_policy) ?(refresh_tyvar_names=true
                        (f : field_spec) =
   if refresh_tyvar_names then
     build_tyvar_names (fun x -> free_bound_field_spec_type_vars x) [f];
-  Print.presence TypeVarSet.empty (policy (), Vars.tyvar_name_map) f
+  Print.presence Print.empty_context (policy (), Vars.tyvar_name_map) f
 
 let string_of_type_arg ?(policy=Print.default_policy) ?(refresh_tyvar_names=true)
                        (arg : type_arg) =
   if refresh_tyvar_names then
     build_tyvar_names (fun x -> free_bound_type_arg_type_vars x) [arg];
-  Print.type_arg TypeVarSet.empty (policy (), Vars.tyvar_name_map) arg
+  Print.type_arg Print.empty_context (policy (), Vars.tyvar_name_map) arg
 
 let string_of_row_var ?(policy=Print.default_policy) ?(refresh_tyvar_names=true) row_var =
   if refresh_tyvar_names then
     build_tyvar_names (fun x -> free_bound_row_var_vars x) [row_var];
-  match Print.row_var "," TypeVarSet.empty (policy (), Vars.tyvar_name_map) row_var
+  match Print.row_var "," Print.empty_context (policy (), Vars.tyvar_name_map) row_var
   with | None -> ""
        | Some s -> s
 
 let string_of_tycon_spec ?(policy=Print.default_policy) ?(refresh_tyvar_names=true) (tycon : tycon_spec) =
   if refresh_tyvar_names then
     build_tyvar_names (fun x -> free_bound_tycon_type_vars x) [tycon];
-  Print.tycon_spec TypeVarSet.empty (policy (), Vars.tyvar_name_map) tycon
+  Print.tycon_spec Print.empty_context (policy (), Vars.tyvar_name_map) tycon
 
 let string_of_quantifier ?(policy=Print.default_policy) ?(refresh_tyvar_names=true) (quant : quantifier) =
   if refresh_tyvar_names then

--- a/core/types.ml
+++ b/core/types.ml
@@ -1946,12 +1946,12 @@ struct
   let show_flavours        = BS.Types.Print.show_flavours
   let show_kinds           = BS.Types.Print.show_kinds
   let hide_fresh_type_vars = BS.Types.Print.hide_fresh_type_vars
-  let shared_effect_vars   = BS.Types.shared_effect_vars
+  let effect_sugar         = BS.Types.effect_sugar
 
   (* Set the quantifiers to be true to display any outer quantifiers.
      Set flavours to be true to distinguish flexible type variables
      from rigid type variables. *)
-  type policy = {quantifiers:bool; flavours:bool; hide_fresh:bool; kinds:string; shared_effect_vars:bool}
+  type policy = {quantifiers:bool; flavours:bool; hide_fresh:bool; kinds:string; effect_sugar:bool}
   type names  = (int, string * Vars.spec) Hashtbl.t
   type shared_effect = Unknown | Shared of int | Distinct
   type context = { bound_vars: TypeVarSet.t; shared_effect: shared_effect }
@@ -1961,7 +1961,7 @@ struct
      flavours=Settings.get_value show_flavours;
      hide_fresh=Settings.get_value hide_fresh_type_vars;
      kinds=Settings.get_value show_kinds;
-     shared_effect_vars=Settings.get_value shared_effect_vars}
+     effect_sugar=Settings.get_value effect_sugar}
 
   let empty_context = { bound_vars = TypeVarSet.empty; shared_effect = Unknown }
 
@@ -2145,7 +2145,7 @@ struct
        let fields_present = fields_present_in fields in
 
        let context =
-         if policy.shared_effect_vars then
+         if policy.effect_sugar then
            let shared_effect = find_shared_effect context vars args fields row_var t in
            { context with shared_effect }
          else context in
@@ -2154,7 +2154,7 @@ struct
          | Shared _ -> true
          | _ -> false in
        let hidden line =
-         if policy.shared_effect_vars then line ^ "_" ^ line ^ ah else line ^ ah in
+         if policy.effect_sugar then line ^ "_" ^ line ^ ah else line ^ ah in
        let sd = datatype context p in
 
        let ppr_arrow () =

--- a/core/types.mli
+++ b/core/types.mli
@@ -47,7 +47,7 @@ module Vars : sig
 end
 
 module Print : sig
-  type policy = {quantifiers:bool; flavours:bool; hide_fresh:bool; kinds:string; shared_effect_vars:bool}
+  type policy = {quantifiers:bool; flavours:bool; hide_fresh:bool; kinds:string; effect_sugar:bool}
 
   val default_policy : unit -> policy
 end

--- a/core/types.mli
+++ b/core/types.mli
@@ -47,7 +47,7 @@ module Vars : sig
 end
 
 module Print : sig
-  type policy = {quantifiers:bool; flavours:bool; hide_fresh:bool; kinds:string}
+  type policy = {quantifiers:bool; flavours:bool; hide_fresh:bool; kinds:string; shared_effect_vars:bool}
 
   val default_policy : unit -> policy
 end

--- a/prelude.links
+++ b/prelude.links
@@ -692,7 +692,7 @@ typename CheckedFormBuilder = (MultiXmlContext, RecForms, Int) {}~> Xml;
 typename Page = (Int, MultiXmlContext, (Gen) {}~> ([CheckedFormBuilder], Gen));
 typename Handler (a) = (a) {}~> Page;
 
-sig pickleCont : (() -> Page) ~> String
+sig pickleCont : (() -_-> Page) ~> String
 fun pickleCont(cont) {unsafePickleCont(fun () {cont()})}
 
 sig unitP : Page
@@ -726,7 +726,7 @@ fun plugP(context, (i, k, fs)) {
   (i, fun (xs) {context(k(xs))}, fs)
 }
 
-sig mkForm : ((Env) ~> Page, Xml, Attributes) ~> Xml
+sig mkForm : ((Env) ~_~> Page, Xml, Attributes) ~> Xml
 fun mkForm(cont, contents, attributes) {
   <form enctype="application/x-www-form-urlencoded"
         action="#" method="POST" {attributes}>
@@ -754,7 +754,7 @@ fun validate(c, h, k, zs, i, attributes) (env) {
   }
 }
 
-sig mkCheckedFormBuilder : (Xml, CheckedCollector(a), Handler(a), Attributes) -> (MultiXmlContext, RecForms, Int) ~> Xml
+sig mkCheckedFormBuilder : (Xml, CheckedCollector(a), Handler(a), Attributes) -_-> (MultiXmlContext, RecForms, Int) ~> Xml
 fun mkCheckedFormBuilder(x, c, h, attributes)(k, zs, i) {
   mkForm(validate(c, h, k, zs, i, attributes), x, attributes)
 }
@@ -977,7 +977,7 @@ fun preludeOptionKeyed (key, (data,text), selected) {
   }
 }
 
-sig preludeOptionsKeyed : ([(String,(a,String))], a) ~>
+sig preludeOptionsKeyed : ([(String,(a,String))], a) ~_~>
                          (Xml, (String) -> [a])
 fun preludeOptionsKeyed(items, def) {
   switch (items) {
@@ -990,7 +990,7 @@ fun preludeOptionsKeyed(items, def) {
 }
 
 sig preludeMultiOptionsKeyed
-    : ([(String, (a,String,Bool))]) ~> (Xml, (String) -> [a])
+    : ([(String, (a,String,Bool))]) ~_~> (Xml, (String) -> [a])
 fun preludeMultiOptionsKeyed(items) {
   switch (items) {
      case [] -> ((<#/>, fun (_) { [] }))

--- a/prelude.links
+++ b/prelude.links
@@ -692,7 +692,7 @@ typename CheckedFormBuilder = (MultiXmlContext, RecForms, Int) {}~> Xml;
 typename Page = (Int, MultiXmlContext, (Gen) {}~> ([CheckedFormBuilder], Gen));
 typename Handler (a) = (a) {}~> Page;
 
-sig pickleCont : (() -_-> Page) ~> String
+sig pickleCont : (() { |_}-> Page) ~> String
 fun pickleCont(cont) {unsafePickleCont(fun () {cont()})}
 
 sig unitP : Page
@@ -726,7 +726,7 @@ fun plugP(context, (i, k, fs)) {
   (i, fun (xs) {context(k(xs))}, fs)
 }
 
-sig mkForm : ((Env) ~_~> Page, Xml, Attributes) ~> Xml
+sig mkForm : ((Env) { |_}~> Page, Xml, Attributes) ~> Xml
 fun mkForm(cont, contents, attributes) {
   <form enctype="application/x-www-form-urlencoded"
         action="#" method="POST" {attributes}>
@@ -754,7 +754,7 @@ fun validate(c, h, k, zs, i, attributes) (env) {
   }
 }
 
-sig mkCheckedFormBuilder : (Xml, CheckedCollector(a), Handler(a), Attributes) -_-> (MultiXmlContext, RecForms, Int) ~> Xml
+sig mkCheckedFormBuilder : (Xml, CheckedCollector(a), Handler(a), Attributes) { |_}-> (MultiXmlContext, RecForms, Int) ~> Xml
 fun mkCheckedFormBuilder(x, c, h, attributes)(k, zs, i) {
   mkForm(validate(c, h, k, zs, i, attributes), x, attributes)
 }
@@ -977,7 +977,7 @@ fun preludeOptionKeyed (key, (data,text), selected) {
   }
 }
 
-sig preludeOptionsKeyed : ([(String,(a,String))], a) ~_~>
+sig preludeOptionsKeyed : ([(String,(a,String))], a) { |_}~>
                          (Xml, (String) -> [a])
 fun preludeOptionsKeyed(items, def) {
   switch (items) {
@@ -990,7 +990,7 @@ fun preludeOptionsKeyed(items, def) {
 }
 
 sig preludeMultiOptionsKeyed
-    : ([(String, (a,String,Bool))]) ~_~> (Xml, (String) -> [a])
+    : ([(String, (a,String,Bool))]) { |_}~> (Xml, (String) -> [a])
 fun preludeMultiOptionsKeyed(items) {
   switch (items) {
      case [] -> ((<#/>, fun (_) { [] }))

--- a/tests/functions.tests
+++ b/tests/functions.tests
@@ -55,25 +55,25 @@ Infers effect variables
 fun (f, x: Int) { f(x) + 0 }
 stdout : @fun : \(\(Int\) -a-> Int, Int\) -a-> Int
 
-Parser shares implicit effect variables
+Parser supports sugar for shared effect variables
 fun (f, x: Int) { f(x) + 0 }
 stdout : @fun : \(\(Int\) -> Int, Int\) -> Int
-args : --config=tests/functions.tests.shared_effect_vars.config
+args : --config=tests/functions.tests.effect_sugar.config
 
-Printer shares effect variables
+Printer supports sugar for shared effect variables
 fun (f, x: Int) { f(x) + 0 } : ((Int) -> Int, Int) -> Int
 stdout : @fun : \(\(Int\) -> Int, Int\) -> Int
-args : --config=tests/functions.tests.shared_effect_vars.config
+args : --config=tests/functions.tests.effect_sugar.config
 
 Printer shows non-shared, single-use variables
 pickleCont
 stdout : @fun : \(\(\) -_-> Page\) ~_~> String
-args : --config=tests/functions.tests.shared_effect_vars.config
+args : --config=tests/functions.tests.effect_sugar.config
 
 Printer shows shared effect variables used elsewhere
 typename Ty (a::Eff) = Int; (fun(){}, 0) : (() -e-> (), Ty({ |e}))
 stdout : @\(fun, 0\) : \(\(\) -a-> \(\), Ty \(\{ \|a \}\)\)
-args : --config=tests/functions.tests.shared_effect_vars.config
+args : --config=tests/functions.tests.effect_sugar.config
 
 Typename [1]
 typename Foo = Int; fun f(x:Foo) {x} f(1)

--- a/tests/functions.tests
+++ b/tests/functions.tests
@@ -55,14 +55,24 @@ Infers effect variables
 fun (f, x: Int) { f(x) + 0 }
 stdout : @fun : \(\(Int\) -a-> Int, Int\) -a-> Int
 
-Printer shares type variables
+Parser shares implicit effect variables
 fun (f, x: Int) { f(x) + 0 }
 stdout : @fun : \(\(Int\) -> Int, Int\) -> Int
 args : --config=tests/functions.tests.shared_effect_vars.config
 
-Parser shares type variables
+Printer shares effect variables
 fun (f, x: Int) { f(x) + 0 } : ((Int) -> Int, Int) -> Int
 stdout : @fun : \(\(Int\) -> Int, Int\) -> Int
+args : --config=tests/functions.tests.shared_effect_vars.config
+
+Printer shows non-shared, single-use variables
+pickleCont
+stdout : @fun : \(\(\) -_-> Page\) ~_~> String
+args : --config=tests/functions.tests.shared_effect_vars.config
+
+Printer shows shared effect variables used elsewhere
+typename Ty (a::Eff) = Int; (fun(){}, 0) : (() -e-> (), Ty({ |e}))
+stdout : @\(fun, 0\) : \(\(\) -a-> \(\), Ty \(\{ \|a \}\)\)
 args : --config=tests/functions.tests.shared_effect_vars.config
 
 Typename [1]

--- a/tests/functions.tests
+++ b/tests/functions.tests
@@ -51,6 +51,20 @@ fun (x) {x:a} : a
 stderr : @.*
 exit : 1
 
+Infers effect variables
+fun (f, x: Int) { f(x) + 0 }
+stdout : @fun : \(\(Int\) -a-> Int, Int\) -a-> Int
+
+Printer shares type variables
+fun (f, x: Int) { f(x) + 0 }
+stdout : @fun : \(\(Int\) -> Int, Int\) -> Int
+args : --config=tests/functions.tests.shared_effect_vars.config
+
+Parser shares type variables
+fun (f, x: Int) { f(x) + 0 } : ((Int) -> Int, Int) -> Int
+stdout : @fun : \(\(Int\) -> Int, Int\) -> Int
+args : --config=tests/functions.tests.shared_effect_vars.config
+
 Typename [1]
 typename Foo = Int; fun f(x:Foo) {x} f(1)
 stdout : 1 : Foo

--- a/tests/functions.tests.effect_sugar.config
+++ b/tests/functions.tests.effect_sugar.config
@@ -1,0 +1,1 @@
+effect_sugar=true

--- a/tests/functions.tests.shared_effect_vars.config
+++ b/tests/functions.tests.shared_effect_vars.config
@@ -1,0 +1,1 @@
+shared_effect_vars=true

--- a/tests/functions.tests.shared_effect_vars.config
+++ b/tests/functions.tests.shared_effect_vars.config
@@ -1,1 +1,0 @@
-shared_effect_vars=true


### PR DESCRIPTION
See #566 for a bit of a deeper explanation.

 - Remove fresh name generation from the parser, just generating a placeholder variable. Fresh variable names are now generated as part of `DesugarDatatypes`.
 - Add a `shared_effect_vars` flag. When enabled, functions with no explicit effect variables will use the same effect variable. For example, `map : ((a) -e-> b, [a]) -e-> [b]` can be written as `map : ((a) -> b, [a]) -> [b]`.
 - Start some work on allowing printing types as above. This requires a bit more thought before it's actually usable, so happy to revert it for now.

A couple of things worth mentioning/I'm not entirely happy with:

 - `shared_effect_vars` isn't a fantastic name, so any ideas are appreciated.
 - We need to disambiguate between "explicit but unnamed" effect variables (`-_->`) and "implicit" ones (`->`). I'm currently doing this by naming the placeholder variables `_` and `_anon`, but that's not especially pleasant.
  - I've removed most of the fresh name generation from `SugarConstructors`, as it's no longer used - happy to revert this if it may be useful again though.