### PR TITLE
Upgrade Websocket dependency

### DIFF
--- a/core/dune
+++ b/core/dune
@@ -12,7 +12,7 @@
   (synopsis "Links compiler library")
   (modes native)
   (libraries str yojson ppx_deriving_yojson.runtime unix safepass base64
-             ANSITerminal linenoise cohttp lwt websocket websocket-lwt.cohttp
+             ANSITerminal linenoise cohttp lwt websocket websocket-lwt-unix.cohttp
              findlib menhirLib links.lens)
   (preprocess (pps ppx_deriving.std ppx_deriving_yojson)))
 

--- a/core/lib.ml
+++ b/core/lib.ml
@@ -1730,6 +1730,7 @@ let prim_appln name args = Ir.Apply( Ir.Variable(Env.String.lookup nenv name),
                                   args)
 
 let cohttp_server_response headers body req_data =
+  let open Lwt in
   (* Debug.print (Printf.sprintf "Attempting to return:\n%s\n" body); *)
   let resp_headers = RequestData.get_http_response_headers req_data in
   let resp_code = RequestData.get_http_response_code req_data in
@@ -1738,7 +1739,7 @@ let cohttp_server_response headers body req_data =
     ?headers:(Some h)
     ~status:(Cohttp.Code.status_of_code resp_code)
     ~body:body
-    ()
+    () >>= fun resp -> Lwt.return (`Response resp)
 
 (** Output the headers and content to stdout *)
 let print_http_response headers body req_data =

--- a/core/lib.mli
+++ b/core/lib.mli
@@ -31,7 +31,7 @@ val primitive_name : Var.var -> string
 val primitive_location : string -> CommonTypes.Location.t
 val primitive_arity : string -> int option
 
-val cohttp_server_response : (string * string) list -> string -> RequestData.request_data -> (Cohttp.Response.t * Cohttp_lwt.Body.t) Lwt.t
+val cohttp_server_response : (string * string) list -> string -> RequestData.request_data -> Cohttp_lwt_unix.Server.response_action Lwt.t
 val print_http_response : (string * string) list -> string -> RequestData.request_data -> unit
 
 val prim_appln : Env.String.name -> Ir.value list -> Ir.tail_computation

--- a/core/proc.ml
+++ b/core/proc.ml
@@ -313,7 +313,6 @@ module type WEBSOCKETS =
     val accept :
       client_id ->
       Cohttp.Request.t ->
-      Conduit_lwt_unix.flow ->
       (Cohttp.Response.t * Cohttp_lwt.Body.t) Lwt.t
 
     (** Sends a message to the given PID. *)
@@ -427,11 +426,10 @@ end
 
 module rec Websockets : WEBSOCKETS =
 struct
-  open Websocket_cohttp_lwt
 
   type links_websocket = {
     client_id : client_id;
-    send_fn : Websocket_cohttp_lwt.Frame.t option -> unit
+    send_fn : Websocket.Frame.t option -> unit
   }
 
   let client_websockets : (client_id, links_websocket) Hashtbl.t =
@@ -464,7 +462,7 @@ struct
 
   let send_message wsocket str_msg =
     Lwt.wrap1 (wsocket.send_fn) @@ (
-      Some (Websocket_cohttp_lwt.Frame.create ~content:str_msg ())
+      Some (Websocket.Frame.create ~content:str_msg ())
     )
 
   let send_buffered_messages cid wsocket =
@@ -508,7 +506,7 @@ struct
           Session.handle_remote_cancel ~notify_ep:notify_ep ~cancelled_ep:cancelled_ep
 
     let recvLoop client_id frame =
-    let open Frame in
+    let open Websocket.Frame in
     let rec loop () =
       match frame.opcode with
         | Opcode.Close ->
@@ -534,15 +532,17 @@ struct
       in
     loop ()
 
-  let accept client_id req flow =
+  let accept client_id req =
       Websocket_cohttp_lwt.upgrade_connection
-        req flow (recvLoop client_id)
-      >>= fun (resp, body, send_fn) ->
+        req (recvLoop client_id)
+      >>= fun (resp, send_fn) ->
       let links_ws = make_links_websocket client_id send_fn in
       Debug.print @@ "Registering websocket for client " ^ (ClientID.to_string client_id);
       register_websocket client_id links_ws;
       send_buffered_messages client_id links_ws >>= fun _ ->
-      Lwt.return (resp, body)
+      match resp with
+      | `Response resp -> Lwt.return resp
+      | `Expert _ -> assert false
 
   let send_or_buffer_message cid msg =
     match lookup_websocket_safe cid with

--- a/core/proc.ml
+++ b/core/proc.ml
@@ -313,7 +313,7 @@ module type WEBSOCKETS =
     val accept :
       client_id ->
       Cohttp.Request.t ->
-      (Cohttp.Response.t * Cohttp_lwt.Body.t) Lwt.t
+      Cohttp_lwt_unix.Server.response_action Lwt.t
 
     (** Sends a message to the given PID. *)
     val deliver_process_message :
@@ -540,9 +540,7 @@ struct
       Debug.print @@ "Registering websocket for client " ^ (ClientID.to_string client_id);
       register_websocket client_id links_ws;
       send_buffered_messages client_id links_ws >>= fun _ ->
-      match resp with
-      | `Response resp -> Lwt.return resp
-      | `Expert _ -> assert false
+      Lwt.return resp
 
   let send_or_buffer_message cid msg =
     match lookup_websocket_safe cid with

--- a/core/proc.mli
+++ b/core/proc.mli
@@ -49,7 +49,6 @@ module type WEBSOCKETS =
     val accept :
       client_id ->
       Cohttp.Request.t ->
-      Conduit_lwt_unix.flow ->
       (Cohttp.Response.t * Cohttp_lwt.Body.t) Lwt.t
 
     (** Sends a message to the given PID. *)

--- a/core/proc.mli
+++ b/core/proc.mli
@@ -49,7 +49,7 @@ module type WEBSOCKETS =
     val accept :
       client_id ->
       Cohttp.Request.t ->
-      (Cohttp.Response.t * Cohttp_lwt.Body.t) Lwt.t
+      Cohttp_lwt_unix.Server.response_action Lwt.t
 
     (** Sends a message to the given PID. *)
     val deliver_process_message :

--- a/core/utility.ml
+++ b/core/utility.ml
@@ -924,16 +924,16 @@ let xml_unescape s =
 
 (** (0 base64 Routines) *)
 let base64decode s =
-  try B64.decode (Str.global_replace (Str.regexp " ") "+" s)
+  try Base64.decode_exn (Str.global_replace (Str.regexp " ") "+" s)
   with Invalid_argument s as e ->
     if s = "B64.decode" then
       raise (Invalid_argument ("base64 decode gave error: " ^ s))
     else
       raise e
 
-let base64encode =
-  (* We may want to use B64.uri_safe_alphabet rather than the default alphabet *)
-  B64.encode ~alphabet:B64.default_alphabet ~pad:true
+let base64encode s =
+  (* We may want to use Base64.uri_safe_alphabet rather than the default alphabet *)
+  Base64.encode_exn ~alphabet:Base64.default_alphabet ~pad:true s
 
 let gensym_counter = ref 0
 

--- a/core/webserver.ml
+++ b/core/webserver.ml
@@ -223,13 +223,16 @@ struct
                    loop rest in
             loop mime_types in
           Debug.print (Printf.sprintf "Responding to static request;\n    Requested: %s\n    Providing: %s\n" path fname);
-          Cohttp_lwt_unix.Server.respond_file ~headers ~fname () in
+          Cohttp_lwt_unix.Server.respond_file ~headers ~fname () >>= fun resp ->
+          Lwt.return (`Response resp) in
 
       let is_websocket_request = is_prefix_of ws_url in
 
       let route rt =
         let rec up = function
-          | [], _ -> Cohttp_lwt_unix.Server.respond_string ~status:`Not_found ~body:"<html><body><h1>Nope</h1></body></html>" ()
+          | [], _ ->
+              Cohttp_lwt_unix.Server.respond_string ~status:`Not_found ~body:"<html><body><h1>Nope</h1></body></html>" () >>= fun resp ->
+              Lwt.return (`Response resp)
           | ([] as remaining, { as_page = Some (Left (file_path, mime_types)); _ }) :: _, true
           | (remaining, { as_directory = Some (Left (file_path, mime_types)); _ }) :: _, true ->
              serve_static file_path (String.concat "/" remaining) mime_types
@@ -304,7 +307,8 @@ struct
       Conduit_lwt_unix.init ~src:host () >>= fun ctx ->
       let ctx = Cohttp_lwt_unix.Net.init ~ctx () in
       Debug.print ("Starting server (2)?\n");
-      Cohttp_lwt_unix.Server.create ~ctx ~mode:(`TCP (`Port port)) (Cohttp_lwt_unix.Server.make ~callback:(callback rt render_cont) ()) in
+      Cohttp_lwt_unix.Server.create ~ctx ~mode:(`TCP (`Port port))
+        (Cohttp_lwt_unix.Server.make_response_action ~callback:(callback rt render_cont) ()) in
 
     Debug.print ("Starting server?\n");
     Lwt.async_exception_hook :=

--- a/core/webserver.ml
+++ b/core/webserver.ml
@@ -147,7 +147,7 @@ struct
         | Not_found -> s,"" in
       List.map one_assoc assocs in
 
-    let callback rt render_cont conn req body =
+    let callback rt render_cont _conn req body =
       let req_hs = Request.headers req in
       let content_type = Header.get req_hs "content-type" in
       Cohttp_lwt.Body.to_string body >>= fun body_string ->
@@ -284,7 +284,7 @@ struct
         Debug.print (Printf.sprintf "Creating websocket for client with ID %s\n"
           (ClientID.to_string client_id));
         Cohttp_lwt.Body.drain_body body >>= fun () ->
-        Proc.Websockets.accept client_id req (fst conn)
+        Proc.Websockets.accept client_id req
       else
         route rt in
 

--- a/links.opam
+++ b/links.opam
@@ -25,7 +25,7 @@ depends: [
   "ANSITerminal"
   "lwt" {>= "3.1.0"}
   "cohttp"
-  "websocket-lwt"
+  "websocket-lwt-unix"
   "safepass"
   "ocamlfind"
   "menhir"


### PR DESCRIPTION
This patch replaces `websocket-lwt` with `websocket-lwt-unix` to
enable Links to work with the latest versions of its dependencies.

Links depends on [OCaml Websocket library](https://github.com/vbmithr/ocaml-websocket) and its
sublibrary `websocket-lwt`. However, `websocket-lwt` has become stale,
meaning that packages which share common dependencies with
`websocket-lwt` no longer can be upgraded.

It seems that `websocket-lwt` has been superseeded by
`websocket-lwt-unix`, which happens to provide a slightly different
interface.