### PR TITLE
[CI] macOS database installation regression

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -32,10 +32,7 @@ steps:
   - bash: |
       case $AGENT_OS in
         "Linux") sudo apt-get update ;;
-        "Darwin") brew doctor
-                  brew upgrade
-                  brew cleanup
-                  brew update ;;
+        "Darwin") brew update ;;
         *) exit 1 ;;
       esac
     displayName: Initialise system package managers
@@ -71,9 +68,9 @@ steps:
                  sudo systemctl reload postgresql &&
                  sudo -u postgres createuser -s $(whoami) &&
                  sudo -u postgres createdb -O $(whoami) links ;;
-        "Darwin") brew install postgres libpq sqlite3 &&
-                  brew services start postgres &&
-                  sleep 3 &&
+        "Darwin") brew install postgresql libpq sqlite3 &&
+                  pg_ctl -D /usr/local/var/postgres start &&
+                  sleep 5 &&
                   /usr/local/opt/postgres/bin/createdb -O $(whoami) links ;;
         *) exit 1 ;;
       esac

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -29,12 +29,14 @@ steps:
       make rule-check
     displayName: 'Rule check'
 
-# The ownership change command in the Darwin case is a terrible hack
-# to make `brew' function correctly. DO NOT TRY THIS AT HOME.
+# Hack: the uninstall and reinstall of `brew' is intended to fix the
+# permissions bug on macOS. It's at best silly, but really, it's
+# ridiculous.
   - bash: |
       case $AGENT_OS in
         "Linux") sudo apt-get update ;;
-        "Darwin") sudo chown -R $(whoami) $(brew --prefix)/*
+        "Darwin") /usr/bin/ruby -e "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/uninstall)"
+                  /usr/bin/ruby -e "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/install)"
                   brew update ;;
         *) exit 1 ;;
       esac

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -29,10 +29,13 @@ steps:
       make rule-check
     displayName: 'Rule check'
 
+# The ownership change command in the Darwin case is a terrible hack
+# to make `brew' function correctly. DO NOT TRY THIS AT HOME.
   - bash: |
       case $AGENT_OS in
         "Linux") sudo apt-get update ;;
-        "Darwin") brew update ;;
+        "Darwin") sudo chown -R $(whoami) $(brew --prefix)/*
+                  brew update ;;
         *) exit 1 ;;
       esac
     displayName: Initialise system package managers
@@ -68,9 +71,7 @@ steps:
                  sudo systemctl reload postgresql &&
                  sudo -u postgres createuser -s $(whoami) &&
                  sudo -u postgres createdb -O $(whoami) links ;;
-        "Darwin") chown -R $(whoami) /Users/$(whoami) &&
-                  brew update &&
-                  brew install postgres libpq sqlite3 &&
+        "Darwin") brew install postgres libpq sqlite3 &&
                   brew services start postgres &&
                   sleep 3 &&
                   /usr/local/opt/postgres/bin/createdb -O $(whoami) links ;;

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -29,14 +29,12 @@ steps:
       make rule-check
     displayName: 'Rule check'
 
-# Hack: the uninstall and reinstall of `brew' is intended to fix the
-# permissions bug on macOS. It's at best silly, but really, it's
-# ridiculous.
   - bash: |
       case $AGENT_OS in
         "Linux") sudo apt-get update ;;
-        "Darwin") /usr/bin/ruby -e "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/uninstall)"
-                  /usr/bin/ruby -e "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/install)"
+        "Darwin") brew doctor
+                  brew upgrade
+                  brew cleanup
                   brew update ;;
         *) exit 1 ;;
       esac

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -68,7 +68,8 @@ steps:
                  sudo systemctl reload postgresql &&
                  sudo -u postgres createuser -s $(whoami) &&
                  sudo -u postgres createdb -O $(whoami) links ;;
-        "Darwin") brew update &&
+        "Darwin") chown -R $(whoami) /Users/$(whoami) &&
+                  brew update &&
                   brew install postgres libpq sqlite3 &&
                   brew services start postgres &&
                   sleep 3 &&


### PR DESCRIPTION
It seems that the `brew` package manager might be somewhat unstable. An update to `brew` overnight has introduced a regression on the CI image for macOS, which means the postgresql service no longer starts.

What follows is a series of ridiculous attempts to fix the macOS database installation regression.

Related #584.