### PR TITLE
Allow primes/single-quotes in identifier names

### DIFF
--- a/core/errors.ml
+++ b/core/errors.ml
@@ -160,8 +160,11 @@ let format_exception =
      | None -> pos_prefix message
      end
   | PrimeAlien pos ->
-     let pos, _ = Position.resolve_start_expr pos in
-     pos_prefix ~pos "Foreign binders cannot contain single quotes `'`."
+     let pos, expr = Position.resolve_start_expr pos in
+     let message =
+       Printf.sprintf "Syntax error: Foreign binders cannot contain single quotes `'`.\nIn expression: %s." expr
+     in
+     pos_prefix ~pos message
   | Sys.Break -> "Caught interrupt"
   | exn -> pos_prefix ("Error: " ^ Printexc.to_string exn)
 

--- a/core/errors.ml
+++ b/core/errors.ml
@@ -47,6 +47,7 @@ exception SettingsError of string
 exception DynlinkError of string
 exception ModuleError of string * Position.t option
 exception DisabledExtension of Position.t option * (string * bool) option * string option * string
+exception PrimeAlien of Position.t
 
 
 let prefix_lines prefix s =
@@ -158,6 +159,9 @@ let format_exception =
         pos_prefix ~pos message
      | None -> pos_prefix message
      end
+  | PrimeAlien pos ->
+     let pos, _ = Position.resolve_start_expr pos in
+     pos_prefix ~pos "Foreign binders cannot contain single quotes `'`."
   | Sys.Break -> "Caught interrupt"
   | exn -> pos_prefix ("Error: " ^ Printexc.to_string exn)
 
@@ -186,3 +190,4 @@ let dynlink_error message = (DynlinkError message)
 let module_error ?pos message = (ModuleError (message, pos))
 let disabled_extension ?pos ?setting ?flag name =
   DisabledExtension (pos, setting, flag, name)
+let prime_alien pos = PrimeAlien pos

--- a/core/errors.mli
+++ b/core/errors.mli
@@ -49,3 +49,4 @@ val runtime_error: string -> exn
 val dynlink_error: string -> exn
 val module_error : ?pos:Position.t -> string -> exn
 val disabled_extension : ?pos:Position.t -> ?setting:(string * bool) -> ?flag:string -> string -> exn
+val prime_alien : Position.t -> exn

--- a/core/js.ml
+++ b/core/js.ml
@@ -23,7 +23,8 @@ struct
         '-', "hyphen";
         '.', "fullstop";
         '|', "pipe";
-        '_', "underscore"]
+        '_', "underscore";
+        '\'', "prime"]
 
   let js_keywords= ["break";"else";"new";"var";"case";"finally";"return";"void";
                     "catch";"for";"switch";"while";"continue";"function";"this";

--- a/core/lexer.mll
+++ b/core/lexer.mll
@@ -238,7 +238,7 @@ let keywords = [
 exception LexicalError of (string * Lexing.position)
 }
 
-let def_id = (['a'-'z' 'A'-'Z'] ['a'-'z' 'A'-'Z' '_' '0'-'9']*)
+let def_id = (['a'-'z' 'A'-'Z'] ['a'-'z' 'A'-'Z' '_' '0'-'9' '\'']*)
 let module_name = (['A'-'Z'] (['A'-'Z' 'a'-'z'])*)
 let octal_code = (['0'-'3']['0'-'7']['0'-'7'])
 let hex_code   = (['0'-'9''a'-'f''A'-'F']['0'-'9''a'-'f''A'-'F'])

--- a/core/typeSugar.ml
+++ b/core/typeSugar.ml
@@ -3912,6 +3912,7 @@ and type_binding : context -> binding -> binding * context * usagemap =
             Funs defs, {empty_context with var_env = outer_env}, (StringMap.filter (fun v _ -> not (List.mem v defined)) (merge_usages used))
 
       | Foreign (bndr, raw_name, language, file, (dt1, Some datatype)) ->
+          ignore (if String.contains (Binder.to_name bndr) '\'' then raise (Errors.prime_alien pos));
           (* Ensure that we quantify FTVs *)
           let (_tyvars, _args), datatype = Utils.generalise context.var_env datatype in
           let datatype = Instantiate.freshen_quantifiers datatype in

--- a/links-mode.el
+++ b/links-mode.el
@@ -132,13 +132,13 @@
    ;; special operations
    `(,(regexp-opt links-keywords 'words) . font-lock-keyword-face)
    ;; types & variant tags
-   '("\\<[A-Z][A-Za-z0-9_]*\\>" . font-lock-type-face)
+   '("\\<[A-Z][A-Za-z0-9_']*\\>" . font-lock-type-face)
    ;; variable names
-   '("\\<\\(var\\) +\\([a-z][A-Za-z0-9_]*\\)\\>"
+   '("\\<\\(var\\) +\\([a-z][A-Za-z0-9_']*\\)\\>"
      (1 font-lock-keyword-face)
      (2 font-lock-variable-name-face))
    ;; function names
-   '("\\<\\(fun\\|sig\\) +\\([a-z][A-Za-z0-9_]*\\)\\>"
+   '("\\<\\(fun\\|sig\\) +\\([a-z][A-Za-z0-9_']*\\)\\>"
      (1 font-lock-keyword-face)
      (2 font-lock-function-name-face))
    ;; type operators

--- a/tests/alien.tests
+++ b/tests/alien.tests
@@ -20,3 +20,12 @@ Alien functions may not be applied in the interpreter
 alien javascript "fun.js" f : () ~> (); f()
 exit : 1
 stderr : @.*Can't make alien call on the server\..*
+
+Alien binders cannot contain primes
+alien javascript "" f' : () -> ();
+exit : 1
+stderr : @.*
+
+Alien type variables can contain primes
+alien javascript "" f : (a', b') -> c';
+stdout : () : ()

--- a/tests/bindings.tests
+++ b/tests/bindings.tests
@@ -104,3 +104,11 @@ Function names may contain primes (3)
 fun 'f() { () }
 exit : 1
 stderr : @.*
+
+Function names may contain primes (4)
+fun f'(x) { x } f'("f'")
+stdout : "f'" : String
+
+A character not a variable name.
+var a' = 42; 'a'
+stdout : 'a' : Char

--- a/tests/bindings.tests
+++ b/tests/bindings.tests
@@ -78,3 +78,29 @@ stdout : () : ()
 Bug in interaction between pattern-matching and anonymous functions
 (fun (l) { switch (l) { case x::xs -> fun (x) { x } } })([1])(2)
 stdout : 2 : Int
+
+Variable names may contain primes (1)
+var x' = 42; x'
+stdout : 42 : Int
+
+Variable names may contain primes (2)
+var x'''y = 128; x'''y
+stdout : 128 : Int
+
+Variable names may contain primes (3)
+var 'x = 42;
+exit : 1
+stderr : @.*
+
+Function names may contain primes (1)
+fun f'() { 42 } f'()
+stdout : 42 : Int
+
+Function names may contain primes (2)
+sig f'''y : (a') -> a' fun f'''y(x) { x } f'''y(128)
+stdout : 128 : Int
+
+Function names may contain primes (3)
+fun 'f() { () }
+exit : 1
+stderr : @.*

--- a/tests/variants.tests
+++ b/tests/variants.tests
@@ -99,3 +99,16 @@ stdout : 2 : Int
 Closure at top-level (issue #422) [2]
 switch(Foo(fun(x) { x })) { case Foo(id) -> fun(x) { id(x) } }
 stdout : fun : (a::Any) -> a::Any
+
+Constructor names with primes (1)
+Foo'
+stdout : Foo' : [|Foo'|_::Any|]
+
+Constructor names with primes (2)
+Foo'''''bar
+stdout : Foo'''''bar : [|Foo'''''bar|_::Any|]
+
+Constructor names with primes (3)
+'Foo
+exit : 1
+stderr : @.*


### PR DESCRIPTION
This patch extends the definition of `def_id` such that identifier names may contain primes/single-quotes. However, the initial character of an identifier may not be a prime. Thus one may write `var x' = 42;` but not `var 'x = 42;`.

There is one exception: identifiers for alien things may not contain primes, this restriction is due to our current compilation scheme for aliens, where we expect their Links source names to be the same as their JavaScript source names, but sadly JavaScript does not permit primes in identifier names (yet).