### PR TITLE
[CI] Travis: Upgrade Trusty -> Xenial

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 sudo: required
-dist: trusty
+dist: xenial
 language: c
 services:
   - postgresql


### PR DESCRIPTION
Supposedly Travis supports Ubuntu 16.04 LTS now, let's see...