### PR TITLE
Abstract binders

### DIFF
--- a/core/chaser.ml
+++ b/core/chaser.ml
@@ -82,15 +82,15 @@ let rec add_module_bindings deps dep_map =
     | [] -> []
     (* Don't re-inline bindings of base module *)
     | [""]::ys -> add_module_bindings ys dep_map
-    | [module_name]::ys ->
+    | [name]::ys ->
       (try
-         let (members, _) = StringMap.find module_name dep_map in
-         let binder = SourceCode.WithPos.make (module_name, None) in (* Need to use Binder.make once #646 has landed. *)
+         let (members, _) = StringMap.find name dep_map in
+         let binder = SourceCode.WithPos.make (Binder.make ~name ()) in
         WithPos.make (Module { binder; members }) :: (add_module_bindings ys dep_map)
       with Notfound.NotFound _ ->
         (raise (Errors.internal_error ~filename:"chaser.ml"
           ~message:(Printf.sprintf "Could not find %s in dependency map containing keys: %s\n"
-          module_name (print_list (List.map fst (StringMap.bindings dep_map)))))));
+          name (print_list (List.map fst (StringMap.bindings dep_map)))))));
     | _ ->
         raise (Errors.internal_error ~filename:"chaser.ml"
           ~message:"Impossible pattern in add_module_bindings")

--- a/core/compilePatterns.ml
+++ b/core/compilePatterns.ml
@@ -101,7 +101,7 @@ let rec desugar_pattern : Sugartypes.Pattern.with_pos -> Pattern.t * raw_env =
     let fresh_binder (nenv, tenv, eff) bndr =
       assert (Sugartypes.Binder.has_type bndr);
       let name = Sugartypes.Binder.to_name bndr in
-      let t = Sugartypes.Binder.to_type_exn bndr in
+      let t = Sugartypes.Binder.to_type bndr in
       let xb, x = Var.fresh_var (t, name, Scope.Local) in
       xb, (NEnv.bind nenv (name, x), TEnv.bind tenv (x, t), eff)
     in

--- a/core/desugarFuns.ml
+++ b/core/desugarFuns.ml
@@ -54,8 +54,9 @@ open SugarConstructors.DummyPositions
 (* unwrap a curried function definition as
    a collection of nested functions
 *)
-let unwrap_def ({node=f, ft; _}, linearity, (tyvars, lam), location, t) =
-  let ft = val_of ft in
+let unwrap_def (bndr, linearity, (tyvars, lam), location, t) =
+  let f = Binder.to_name bndr in
+  let ft = Binder.to_type bndr in
   let rt = TypeUtils.return_type ft in
   let lam =
     let rec make_lam t : funlit -> funlit =

--- a/core/desugarSessionExceptions.ml
+++ b/core/desugarSessionExceptions.ml
@@ -29,7 +29,8 @@ object (o: 'self_type)
         super#phrasenode sw
     | Spawn (k, spawn_loc, {node=body;_}, Some inner_effects) ->
         let as_var = Utility.gensym ~prefix:"spawn_aspat" () in
-        let as_pat = variable_pat ~ty:`Not_typed as_var in
+        let bogus_type = `Primitive CommonTypes.Primitive.Bool in (* temporary hack until Simon lands #621. *)
+        let as_pat = variable_pat ~ty:bogus_type as_var in
         let unit_phr = with_dummy_pos (RecordLit ([], None)) in
 
         let (o, spawn_loc) = o#given_spawn_location spawn_loc in
@@ -69,7 +70,8 @@ object (o : 'self_type)
          * we'll never use the continuation (and this is invoked after pattern
          * deanonymisation in desugarHandlers), generate a fresh name for the
          * continuation argument. *)
-        let cont_pat = variable_pat ~ty:`Not_typed (Utility.gensym ~prefix:"dsh" ()) in
+        let bogus_type = `Primitive CommonTypes.Primitive.Bool in (* temporary hack until Simon lands #621. *)
+        let cont_pat = variable_pat ~ty:bogus_type (Utility.gensym ~prefix:"dsh" ()) in
 
         let otherwise_pat : Sugartypes.Pattern.with_pos =
           with_dummy_pos (Pattern.Effect (failure_op_name, [], cont_pat)) in

--- a/core/dumpTypes.ml
+++ b/core/dumpTypes.ml
@@ -33,10 +33,11 @@ let program =
         Env.String.lookup env x
 
       method! binder =
-        fun {node=x,t; pos} ->
-          o#option
-            (fun o t -> o#bind (x, t, pos))
-            t
+        let open Sugartypes in
+        fun bndr ->
+        if Binder.has_type bndr
+        then o#bind (Binder.to_name bndr, Binder.to_type bndr, pos bndr)
+        else o
 
       method! phrase =
         function

--- a/core/sugarConstructors.ml
+++ b/core/sugarConstructors.ml
@@ -93,7 +93,10 @@ module SugarConstructors (Position : Pos)
 
   (** Binders **)
 
-  let binder ?(ppos=dp) ?ty name = with_pos ppos (name, ty)
+  let binder ?(ppos=dp) ?ty name =
+    match ty with
+    | None -> with_pos ppos (Binder.make ~name ())
+    | Some ty -> with_pos ppos (Binder.make ~name ~ty ())
 
   (** Imports **)
 

--- a/core/sugarTraversals.ml
+++ b/core/sugarTraversals.ml
@@ -53,8 +53,8 @@ class map =
         let name = o#name (Binder.to_name bndr) in
         let ty  = Binder.to_type bndr in
         let pos = WithPos.pos bndr |> o#position in
-        let bndr' = Binder.make ~name ~ty () in
-        WithPos.make ~pos bndr'
+        let bndr' = Binder.(set_type (set_name bndr name) ty) in
+        WithPos.map2 bndr' ~f_pos:(fun _ -> pos) ~f_node:(fun x -> x)
 
     method sentence : sentence -> sentence =
       function

--- a/core/sugarTraversals.ml
+++ b/core/sugarTraversals.ml
@@ -51,9 +51,10 @@ class map =
     method binder : Binder.with_pos -> Binder.with_pos =
       fun bndr ->
         let name = o#name (Binder.to_name bndr) in
-        let ty  = o#option (fun o -> o#unknown) (Binder.to_type bndr) in
+        let ty  = Binder.to_type bndr in
         let pos = WithPos.pos bndr |> o#position in
-        WithPos.make ~pos (name,ty)
+        let bndr' = Binder.make ~name ~ty () in
+        WithPos.make ~pos bndr'
 
     method sentence : sentence -> sentence =
       function
@@ -736,7 +737,6 @@ class fold =
     method binder : Binder.with_pos -> 'self_type =
       fun bndr ->
         let o = o#name (Binder.to_name bndr) in
-        let o = o#option (fun o -> o#unknown) (Binder.to_type bndr) in
         let o = o#position (WithPos.pos bndr) in o
 
     method sentence : sentence -> 'self_type =
@@ -2097,7 +2097,7 @@ class fold_map =
         ~o
         ~f_pos:(fun o v -> o#position v)
         ~f_name:(fun o v -> o#name v)
-        ~f_ty:(fun o v -> o#option (fun o -> o#unknown) v)
+        ~f_ty:(fun o v -> o, v)
 
     method unknown : 'a. 'a -> ('self_type * 'a) = fun x -> (o, x)
   end

--- a/core/sugartoir.ml
+++ b/core/sugartoir.ml
@@ -788,7 +788,7 @@ struct
                                  [ev e; ev (WithPos.make ~pos (ListLit (es, Some t)))]))
           | Escape (bndr, body) when Binder.has_type bndr ->
              let k  = Binder.to_name bndr in
-             let kt = Binder.to_type_exn bndr in
+             let kt = Binder.to_type bndr in
              I.escape ((kt, k, Scope.Local), eff, fun v -> eval (extend [k] [(v, kt)] env) body)
           | Section (Section.Minus) -> cofv (lookup_var "-")
           | Section (Section.FloatMinus) -> cofv (lookup_var "-.")
@@ -1076,7 +1076,7 @@ struct
                 | Val ({node=Pattern.Variable bndr; _}, (_, body), _, _)
                      when Binder.has_type bndr ->
                     let x  = Binder.to_name bndr in
-                    let xt = Binder.to_type_exn bndr in
+                    let xt = Binder.to_type bndr in
                     let x_info = (xt, x, scope) in
                       I.letvar
                         (x_info,
@@ -1092,7 +1092,7 @@ struct
                 | Fun (bndr, _, (tyvars, ([ps], body)), location, _)
                      when Binder.has_type bndr ->
                     let f  = Binder.to_name bndr in
-                    let ft = Binder.to_type_exn bndr in
+                    let ft = Binder.to_type bndr in
                     let ps, body_env =
                       List.fold_right
                         (fun p (ps, body_env) ->
@@ -1112,7 +1112,7 @@ struct
                       List.fold_right
                         (fun (bndr, _, ((_tyvars, inner_opt), _), _, _, _) (fs, inner_fts, outer_fts) ->
                           let f = Binder.to_name bndr in
-                          let outer  = Binder.to_type_exn bndr in
+                          let outer  = Binder.to_type bndr in
                           let (inner, _) = OptionUtils.val_of inner_opt in
                               (f::fs, inner::inner_fts, outer::outer_fts))
                         defs
@@ -1122,7 +1122,7 @@ struct
                         (fun (bndr, _, ((tyvars, _), (pss, body)), location, _, _) ->
                           assert (List.length pss = 1);
                           let f  = Binder.to_name bndr in
-                          let ft = Binder.to_type_exn bndr in
+                          let ft = Binder.to_type bndr in
                           let ps = List.hd pss in
                            let ps, body_env =
                              List.fold_right
@@ -1139,7 +1139,7 @@ struct
                 | Foreign (bndr, raw_name, language, _file, _)
                      when Binder.has_type bndr ->
                     let x  = Binder.to_name bndr in
-                    let xt = Binder.to_type_exn bndr in
+                    let xt = Binder.to_type bndr in
                     I.alien ((xt, x, scope), raw_name, language, fun v -> eval_bindings scope (extend [x] [(v, xt)] env) bs e)
                 | Typenames _
                 | Infix ->

--- a/core/transformSugar.ml
+++ b/core/transformSugar.ml
@@ -777,7 +777,7 @@ class transform (env : Types.typing_environment) =
       | Fun (bndr, lin, (tyvars, lam), location, t) when Binder.has_type bndr ->
          let outer_tyvars = o#backup_quantifiers in
          let (o, tyvars) = o#quantifiers tyvars in
-         let inner_effects = fun_effects (Binder.to_type_exn bndr) (fst lam) in
+         let inner_effects = fun_effects (Binder.to_type bndr) (fst lam) in
          let (o, lam, _) = o#funlit inner_effects lam in
          let o = o#restore_quantifiers outer_tyvars in
          let (o, bndr) = o#binder bndr in
@@ -823,7 +823,7 @@ class transform (env : Types.typing_environment) =
     method binder : Binder.with_pos -> ('self_type * Binder.with_pos) =
       fun bndr ->
       assert (Binder.has_type bndr);
-      let var_env = TyEnv.bind var_env (Binder.to_name bndr, Binder.to_type_exn bndr) in
+      let var_env = TyEnv.bind var_env (Binder.to_name bndr, Binder.to_type bndr) in
       ({< var_env=var_env >}, bndr)
 
     method cp_phrase : cp_phrase -> ('self_type * cp_phrase * Types.datatype) =
@@ -883,12 +883,13 @@ class transform (env : Types.typing_environment) =
            | _ -> assert false
          end
       | CPLink (c, d) -> o, CPLink (c, d), Types.unit_type
-      | CPComp ({node = c, Some s; _} as bndr, left, right) ->
+      | CPComp (bndr, left, right) ->
+         let c = Binder.to_name bndr in
+         let s = Binder.to_type bndr in
          let envs = o#backup_envs in
          let (o, left, _typ) = {< var_env = TyEnv.bind (o#get_var_env ()) (c, s) >}#cp_phrase left in
          let whiny_dual_type s = try Types.dual_type s with Invalid_argument _ -> raise (Invalid_argument ("Attempted to dualize non-session type " ^ Types.string_of_datatype s)) in
          let (o, right, t) = {< var_env = TyEnv.bind (o#get_var_env ()) (c, whiny_dual_type s) >}#cp_phrase right in
          let o = o#restore_envs envs in
          o, CPComp (bndr, left, right), t
-      | CPComp _ -> assert false
   end

--- a/core/typeSugar.ml
+++ b/core/typeSugar.ml
@@ -1981,10 +1981,9 @@ let rec pattern_env : Pattern.with_pos -> Types.datatype Env.t =
     | Cons (h,t) -> Env.extend (pattern_env h) (pattern_env t)
     | List ps
     | Tuple ps -> List.fold_right (pattern_env ->- Env.extend) ps Env.empty
-    | Variable {node=v, Some t; _} -> Env.bind Env.empty (v, t)
-    | Variable {node=_, None; _} -> assert false
-    | As       ({node=v, Some t; _}, p) -> Env.bind (pattern_env p) (v, t)
-    | As       ({node=_, None; _}, _) -> assert false
+    | Variable bndr ->
+       Env.bind Env.empty Binder.(to_name bndr, to_type bndr)
+    | As (bndr, p) -> Env.bind (pattern_env p) Binder.(to_name bndr, to_type bndr)
 
 
 let update_pattern_vars env =

--- a/core/types.ml
+++ b/core/types.ml
@@ -144,7 +144,8 @@ and rec_appl = {
   r_unwind: type_arg list -> bool -> typ;
   r_linear: unit -> bool option
 }
-and typ =    [ `Not_typed
+and typ =
+    [ `Not_typed
     | `Primitive of Primitive.t
     | `Function of (typ * row * typ)
     | `Lolli of (typ * row * typ)


### PR DESCRIPTION
This patch makes the frontend representation of binders abstract. It
turns out that an abstract representation is convenient for enabling
the proper module system (#603) to live along side the current module
system as the former benefits from a slightly richer notion of
binders.

I also changed the internal representation of binders, as before the
type component was an option type. There is no need to have an option
type, since we can use the dummy type **\`Not_typed** to denote
absence. The dummy type should never occur in an actual program, but
it turns out not to be true in the current implementation of session
exceptions, however @SimonJF's patch #621 seems to rectify this.

Related #603.