### PR TITLE
Nominal modules.

### DIFF
--- a/core/chaser.ml
+++ b/core/chaser.ml
@@ -58,16 +58,17 @@ object(self)
            self
          with
            _ -> self#add_import_candidate lookup_ref)
-    | Module (n, bs) ->
-        let new_path = path @ [n] in
+    | Module (bndr, bs) ->
+        let name = Binder.to_name bndr in
+        let new_path = path @ [name] in
         let fqn = lst_to_path new_path in
-        let o = self#bind_shadow n fqn in
+        let o = self#bind_shadow name fqn in
         let shadow_ht = o#get_shadow_table in
         (* Now, recursively check the module, with this one in scope *)
         let o_bindings =
           List.fold_left (fun o b -> o#binding b) (find_module_refs mt new_path shadow_ht) bs in
         let ics = o_bindings#get_import_candidates in
-        (o#bind_open n fqn)#add_import_candidates ics
+        (o#bind_open name fqn)#add_import_candidates ics
     | bn -> super#bindingnode bn
 end
 
@@ -83,8 +84,9 @@ let rec add_module_bindings deps dep_map =
     | [""]::ys -> add_module_bindings ys dep_map
     | [module_name]::ys ->
       (try
-        let (bindings, _) = StringMap.find module_name dep_map in
-        WithPos.make (Module (module_name, bindings)) :: (add_module_bindings ys dep_map)
+         let (bindings, _) = StringMap.find module_name dep_map in
+         let bndr = SourceCode.WithPos.make (module_name, None) in (* Need to use Binder.make once #646 has landed. *)
+        WithPos.make (Module (bndr, bindings)) :: (add_module_bindings ys dep_map)
       with Notfound.NotFound _ ->
         (raise (Errors.internal_error ~filename:"chaser.ml"
           ~message:(Printf.sprintf "Could not find %s in dependency map containing keys: %s\n"

--- a/core/desugarAlienBlocks.ml
+++ b/core/desugarAlienBlocks.ml
@@ -42,12 +42,12 @@ object(self)
         self#list (fun o ((bnd, dt)) ->
           let name = Binder.to_name bnd in
           o#add_binding (with_dummy_pos (Foreign (bnd, name, lang, lib, dt)))) decls
-    | {node=Module (name, bindings); _} ->
+    | {node=Module ({ members; _ } as module') ; _} ->
         let flattened_bindings =
           List.concat (
-            List.map (fun b -> ((flatten_bindings ())#binding b)#get_bindings) bindings
+            List.map (fun b -> ((flatten_bindings ())#binding b)#get_bindings) members
           ) in
-        self#add_binding (with_dummy_pos (Module (name, flattened_bindings)))
+        self#add_binding (with_dummy_pos (Module { module' with members = flattened_bindings }))
     | b -> self#add_binding ((flatten_simple ())#binding b)
 
   method! program = function

--- a/core/desugarModules.ml
+++ b/core/desugarModules.ml
@@ -242,10 +242,10 @@ end
 let rec desugar_module : ?toplevel:bool -> Epithet.t -> Scope.t -> Sugartypes.binding -> binding list * Scope.t
   = fun ?(toplevel=false) renamer scope binding ->
   match binding.node with
-  | Module (bndr, bs) ->
-     let name = Binder.to_name bndr in
+  | Module { binder; members } ->
+     let name = Binder.to_name binder in
      let visitor = desugar ~toplevel (Epithet.remember ~escapes:(not toplevel) name renamer) (Scope.renew scope) in
-     let bs'    = visitor#bindings bs in
+     let bs'    = visitor#bindings members in
      let scope' = visitor#get_scope in
      let scope'' = Scope.Extend.module' name scope' scope in
      (bs', scope'')

--- a/core/desugarModules.ml
+++ b/core/desugarModules.ml
@@ -242,7 +242,8 @@ end
 let rec desugar_module : ?toplevel:bool -> Epithet.t -> Scope.t -> Sugartypes.binding -> binding list * Scope.t
   = fun ?(toplevel=false) renamer scope binding ->
   match binding.node with
-  | Module (name, bs) ->
+  | Module (bndr, bs) ->
+     let name = Binder.to_name bndr in
      let visitor = desugar ~toplevel (Epithet.remember ~escapes:(not toplevel) name renamer) (Scope.renew scope) in
      let bs'    = visitor#bindings bs in
      let scope' = visitor#get_scope in
@@ -494,7 +495,7 @@ and desugar ?(toplevel=false) (renamer' : Epithet.t) (scope' : Scope.t) =
         (* Affects [scope]. *)
          self#extension_guard pos;
          self#open_module pos names; self#bindings bs
-      | ({ node = Module (_name, _); pos } as module') :: bs ->
+      | ({ node = Module _; pos } as module') :: bs ->
       (* Affects [scope] and hoists [bs'] *)
          self#extension_guard pos;
          let bs', scope' = desugar_module ~toplevel renamer scope module' in

--- a/core/moduleUtils.ml
+++ b/core/moduleUtils.ml
@@ -159,8 +159,9 @@ let create_module_info_map program =
     (* Recursively traverse a list of modules *)
     let rec traverse_modules = function
       | [] -> []
-      | {node=Module (submodule_name, mod_bs);_} :: bs ->
+      | {node=Module (bndr, mod_bs);_} :: bs ->
           (* Recursively process *)
+          let submodule_name = Binder.to_name bndr in
           let new_path = if name = "" then [] else parent_path @ [name] in
           create_and_add_module_info new_path submodule_name mod_bs;
           (* Add the name to the list, process remainder. *)

--- a/core/moduleUtils.ml
+++ b/core/moduleUtils.ml
@@ -159,11 +159,11 @@ let create_module_info_map program =
     (* Recursively traverse a list of modules *)
     let rec traverse_modules = function
       | [] -> []
-      | {node=Module (bndr, mod_bs);_} :: bs ->
+      | {node=Module { binder; members };_} :: bs ->
           (* Recursively process *)
-          let submodule_name = Binder.to_name bndr in
+          let submodule_name = Binder.to_name binder in
           let new_path = if name = "" then [] else parent_path @ [name] in
-          create_and_add_module_info new_path submodule_name mod_bs;
+          create_and_add_module_info new_path submodule_name members;
           (* Add the name to the list, process remainder. *)
           submodule_name :: (traverse_modules bs)
       | _bs -> assert false in (* List should only contain modules *)

--- a/core/parser.mly
+++ b/core/parser.mly
@@ -399,13 +399,10 @@ alien_datatypes:
 | alien_datatype+                                              { $1 }
 
 links_module:
-| MODULE module_name moduleblock                               { with_pos $loc($2) (Module ($2, $3)) }
+| MODULE CONSTRUCTOR moduleblock                               { with_pos $loc($2) (Module (binder ~ppos:$loc($2) $2, $3)) }
 
 alien_block:
 | ALIEN VARIABLE STRING LBRACE alien_datatypes RBRACE          { with_pos $loc (AlienBlock ($2, $3, $5)) }
-
-module_name:
-| CONSTRUCTOR                                                  { $1 }
 
 fun_declarations:
 | fun_declaration+                                             { $1 }

--- a/core/parser.mly
+++ b/core/parser.mly
@@ -399,7 +399,7 @@ alien_datatypes:
 | alien_datatype+                                              { $1 }
 
 links_module:
-| MODULE CONSTRUCTOR moduleblock                               { with_pos $loc($2) (Module (binder ~ppos:$loc($2) $2, $3)) }
+| MODULE name = CONSTRUCTOR members = moduleblock              { module_binding ~ppos:$loc($1) (binder ~ppos:$loc(name) name) members }
 
 alien_block:
 | ALIEN VARIABLE STRING LBRACE alien_datatypes RBRACE          { with_pos $loc (AlienBlock ($2, $3, $5)) }

--- a/core/sugarConstructors.ml
+++ b/core/sugarConstructors.ml
@@ -176,6 +176,9 @@ module SugarConstructors (Position : Pos)
   let val_binding ?(ppos=dp) pat phrase =
     val_binding' ~ppos NoSig (Pat pat, phrase, loc_unknown)
 
+  (* Create a module binding. *)
+  let module_binding ?(ppos=dp) binder members =
+    with_pos ppos (Module { binder; members })
 
   (** Database queries *)
 

--- a/core/sugarConstructorsIntf.ml
+++ b/core/sugarConstructorsIntf.ml
@@ -123,6 +123,10 @@ module type SugarConstructorsSig = sig
       : ?ppos:t -> Pattern.with_pos -> phrase
      -> binding
 
+  val module_binding
+      : ?ppos:t -> Binder.with_pos -> binding list
+     -> binding
+
   (* Database queries *)
   val db_exps
       : ?ppos:t -> (name * phrase) list -> phrase

--- a/core/sugarTraversals.ml
+++ b/core/sugarTraversals.ml
@@ -675,10 +675,10 @@ class map =
           Typenames ts
       | Infix -> Infix
       | Exp _x -> let _x = o#phrase _x in Exp _x
-      | Module (n, bs) ->
-          let n = o#name n in
+      | Module (bndr, bs) ->
+          let bndr = o#binder bndr in
           let bs = o#list (fun o -> o#binding) bs in
-          Module (n, bs)
+          Module (bndr, bs)
       | AlienBlock (lang, lib, dts) ->
           let lang = o#name lang in
           let lib = o#name lib in
@@ -1309,8 +1309,8 @@ class fold =
           o
       | Infix -> o
       | Exp _x -> let o = o#phrase _x in o
-      | Module (n, bs) ->
-          let o = o#name n in
+      | Module (bndr, bs) ->
+          let o = o#binder bndr in
           let o = o#list (fun o -> o#binding) bs in
           o
       | AlienBlock (lang, lib, dts) ->
@@ -2073,10 +2073,10 @@ class fold_map =
           in (o, Typenames ts)
       | Infix -> (o, Infix)
       | Exp _x -> let (o, _x) = o#phrase _x in (o, (Exp _x))
-      | Module (n, bs) ->
-          let (o, n) = o#string n in
+      | Module (bndr, bs) ->
+          let (o, bndr) = o#binder bndr in
           let (o, bs) = o#list (fun o -> o#binding) bs in
-          (o, (Module (n, bs)))
+          (o, (Module (bndr, bs)))
       | AlienBlock (lang, lib, dts) ->
           let (o, lang) = o#name lang in
           let (o, lib) = o#name lib in

--- a/core/sugarTraversals.ml
+++ b/core/sugarTraversals.ml
@@ -675,10 +675,10 @@ class map =
           Typenames ts
       | Infix -> Infix
       | Exp _x -> let _x = o#phrase _x in Exp _x
-      | Module (bndr, bs) ->
-          let bndr = o#binder bndr in
-          let bs = o#list (fun o -> o#binding) bs in
-          Module (bndr, bs)
+      | Module { binder; members } ->
+          let binder = o#binder binder in
+          let members = o#list (fun o -> o#binding) members in
+          Module { binder; members }
       | AlienBlock (lang, lib, dts) ->
           let lang = o#name lang in
           let lib = o#name lib in
@@ -1309,10 +1309,9 @@ class fold =
           o
       | Infix -> o
       | Exp _x -> let o = o#phrase _x in o
-      | Module (bndr, bs) ->
-          let o = o#binder bndr in
-          let o = o#list (fun o -> o#binding) bs in
-          o
+      | Module { binder; members } ->
+          let o = o#binder binder in
+          o#list (fun o -> o#binding) members
       | AlienBlock (lang, lib, dts) ->
           let o = o#name lang in
           let o = o#name lib in
@@ -2073,10 +2072,10 @@ class fold_map =
           in (o, Typenames ts)
       | Infix -> (o, Infix)
       | Exp _x -> let (o, _x) = o#phrase _x in (o, (Exp _x))
-      | Module (bndr, bs) ->
-          let (o, bndr) = o#binder bndr in
-          let (o, bs) = o#list (fun o -> o#binding) bs in
-          (o, (Module (bndr, bs)))
+      | Module { binder; members } ->
+          let (o, binder) = o#binder binder in
+          let (o, members) = o#list (fun o -> o#binding) members in
+          (o, (Module { binder; members }))
       | AlienBlock (lang, lib, dts) ->
           let (o, lang) = o#name lang in
           let (o, lib) = o#name lib in

--- a/core/sugartypes.ml
+++ b/core/sugartypes.ml
@@ -279,7 +279,7 @@ and bindingnode =
   | Typenames of typename list
   | Infix
   | Exp     of phrase
-  | Module  of Binder.with_pos * binding list
+  | Module  of { binder: Binder.with_pos; members: binding list }
   | AlienBlock of name * name * ((Binder.with_pos * datatype') list)
 and binding = bindingnode WithPos.t
 and block_body = binding list * phrase
@@ -505,13 +505,13 @@ struct
               StringSet.add (Binder.to_name bndr) acc)
             (StringSet.empty) decls in
         bound_foreigns, empty
-    | Module (_, bindings) ->
+    | Module { members; _ } ->
        List.fold_left
          (fun (bnd, fvs) b ->
            let bnd', fvs' = binding b in
            let fvs'' = diff fvs' bnd in
            union bnd bnd', union fvs fvs'')
-         (empty, empty) bindings
+         (empty, empty) members
   and funlit (args, body : funlit) : StringSet.t =
     diff (phrase body) (union_map (union_map pattern) args)
   and block (binds, expr : binding list * phrase) : StringSet.t =


### PR DESCRIPTION
This patch changes the representation of modules to emphasise that
they are nominal. Previously modules would just have structural names,
whilst with this patch each module gets its own binder.

This is a prerequisite for #603.