### PR TITLE
Fix CI for MVU and address bug in harness

### DIFF
--- a/examples/mvu/mousetest.links
+++ b/examples/mvu/mousetest.links
@@ -77,7 +77,7 @@ fun subscriptions(model) {
 
 fun mainPage(_) {
   var evtHandler =
-    run("placeholder", Nothing, view, updt(msg, model), subscriptions);
+    run("placeholder", Nothing, view, updt, subscriptions);
   page
   <html>
     <head>

--- a/test-harness
+++ b/test-harness
@@ -64,13 +64,16 @@ def check_expected(name, item, got, expected, errors):
 
 def evaluate(name, code, config_file, stdout='', stderr='', exit = '0', env = None, filemode='', args='', ignore = None):
     arg_array = str.split(args)
+    global failures
+
     if config_file != None:
         for arg in arg_array:
             if arg.startswith("--config"):
                 print(
-                    "Test \"%s\" comes with an args entry to specify the config file," % name +
+                    "FAILURE: Test \"%s\" comes with an args entry to specify the config file," % name +
                     " but a config file was also passed as a command-line argument to the test harness" )
-                exit(1)
+                failures += 1
+                return
 
         arg_array += ["--config=" + config_file]
 
@@ -97,7 +100,6 @@ def evaluate(name, code, config_file, stdout='', stderr='', exit = '0', env = No
                         ignored += 1
                         print('?IGNORED: %s (%s)' % (name, ignore))
                 else:
-                    global failures
                     with the_lock:
                         failures += 1
                         print('!FAILURE: %s' % name)

--- a/tests/typecheck_examples.tests
+++ b/tests/typecheck_examples.tests
@@ -726,7 +726,7 @@ filemode : true
 Typecheck example file examples/mvu/pong.links
 examples/mvu/pong.links
 filemode : true
-args : --config=foo
+args : --path=examples/mvu/todomvc
 
 Typecheck example file examples/mvu/todomvc/todoMVC.links
 examples/mvu/todomvc/todoMVC.links

--- a/tests/typecheck_examples.tests
+++ b/tests/typecheck_examples.tests
@@ -717,25 +717,22 @@ args : --path=examples/sessions/mind
 
 Typecheck example file examples/mvu/mousetest.links
 examples/mvu/mousetest.links
-filemode : args
-args : --config=tests/typecheck_examples.tests.config
+filemode : true
 
 Typecheck example file examples/mvu/time.links
 examples/mvu/time.links
-filemode : args
-args : --config=tests/typecheck_examples.tests.config
+filemode : true
 
 Typecheck example file examples/mvu/pong.links
 examples/mvu/pong.links
-filemode : args
-args : --config=tests/typecheck_examples.tests.config
+filemode : true
+args : --config=foo
 
 Typecheck example file examples/mvu/todomvc/todoMVC.links
 examples/mvu/todomvc/todoMVC.links
-filemode : args
-args : --config=tests/typecheck_examples.tests.config
+filemode : true
+args : --path=examples/mvu/todomvc
 
 Typecheck example file examples/mvu/keypress.links
 examples/mvu/keypress.links
-filemode : args
-args : --config=tests/typecheck_examples.tests.config
+filemode : true


### PR DESCRIPTION
There was a small error in one of the MVU files which slipped through the CI because of a combination of a misconfiguration in one of the tests files, and a bug which meant that a failure was not reported.

This patch fixes the error in the MVU example, fixes the misconfiguration, and also fixes the issue in the `test-harness` file which allowed it to slip through undetected.

(Arguably, the `config` check shouldn't be there, since it would be nice to override the default config. But that's for a different patch.)