### PR TITLE
[WIP] attempt to fix newlines configuration

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,10 +1,2 @@
-# Checkout files in repository using native line endings by default
-* text=auto
-
-# Some file extensions are binary and should not be modified in any way
-*.pdf binary
-*.zip binary
-
-# An important exception is a file for testing Links' support for DOS line
-# endings
+# Ensure the local copy of the DOS line endings test uses CRLF
 tests/dos-newlines.links text eol=crlf

--- a/.gitattributes
+++ b/.gitattributes
@@ -7,4 +7,4 @@
 
 # An important exception is a file for testing Links' support for DOS line
 # endings
-tests/dos-newlines.links text=crlf
+tests/dos-newlines.links text eol=crlf

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,2 +1,2 @@
-# Ensure the local copy of the DOS line endings test uses CRLF
-tests/dos-newlines.links text eol=crlf
+# Ensure the DOS line endings test is preserved exactly
+tests/dos-newlines.links binary

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,5 +1,5 @@
-# Checkout files in repository using UNIX line endings
-* text eol=lf
+# Checkout files in repository using native line endings by default
+* text=auto
 
 # Some file extensions are binary and should not be modified in any way
 *.pdf binary
@@ -7,4 +7,4 @@
 
 # An important exception is a file for testing Links' support for DOS line
 # endings
-tests/dos-newlines.links text=auto eol=crlf
+tests/dos-newlines.links text=crlf

--- a/examples/.gitattributes
+++ b/examples/.gitattributes
@@ -1,1 +1,1 @@
-*.jpg binary
+# *.jpg binary


### PR DESCRIPTION
I ran into a bizarre problem with `tests/dos-newlines.links` showing changes in my local repository, I observed this on Mac OSX and Linux even after doing new clones.  After discussion with @slindley and looking at #503 it seems that the current configuration is too aggressive and may be leading to inconsistent states.  This changes the configuration so that by default all files are treated as text, with automatic newline replacement (this should mean that whatever is native is used for local files, but translated to CR on the repository).  The exception is tests/dos-newlines.text, which is specified to use CRLF.  (The version in the repository still is stored using CR, but the local file copy is stored as CRLF).

This worked for me, but  needs to pass the CI and be tested by people using different operating systems before it is safe to merge.