### PR TITLE
Fix links-mode using non-existent faces

### DIFF
--- a/links-mode.el
+++ b/links-mode.el
@@ -125,11 +125,11 @@
    ;; comments
    '("\\(^\\|[^</]\\)#.*$" . font-lock-comment-face)
    ;; XML forests
-   '("<#>.*</#>" . font-lock-xml-face)
+   '("<#>.*</#>" . font-lock-function-name-face)
    ;; XML tags
-   '("</?[a-z][^>]*>" 0 font-lock-xml-face t)
+   '("</?[a-z][^>]*>" 0 font-lock-function-name-face t)
    ;; XML escapes (attributes)
-   '("\"{[^}]*}\"" 0 font-lock-normal-face t)
+   '("\"{[^}]*}\"" 0 font-lock-constant-face t)
    ;; special operations
    `(,(regexp-opt links-keywords 'words) . font-lock-keyword-face)
    ;; types & variant tags

--- a/links-mode.el
+++ b/links-mode.el
@@ -129,7 +129,7 @@
    ;; XML tags
    '("</?[a-z][^>]*>" 0 font-lock-function-name-face t)
    ;; XML escapes (attributes)
-   '("\"{[^}]*}\"" 0 font-lock-constant-face t)
+   '("\"{[^}]*}\"" 0 'default t)
    ;; special operations
    `(,(regexp-opt links-keywords 'words) . font-lock-keyword-face)
    ;; types & variant tags


### PR DESCRIPTION
I've been having some weird issues with `links-mode`, where highlighting would stop working after encountering XML tags. It appears that the font-lock keyword listing was using faces which don't exist (at least on my Emacs setup), and so were crashing the syntax highlighter.

Changing the face names appears to fix this - I'm just using function name instead of XML (which is what `mhtml-mode` appears to use), and the default face for XML attributes. It's still not perfect, but it's a definite improvement.