### PR TITLE
Record field punning

### DIFF
--- a/core/parser.mly
+++ b/core/parser.mly
@@ -944,7 +944,7 @@ block_contents:
 | SEMICOLON | /* empty */                                      { ([], with_pos $loc (TupleLit [])) }
 
 labeled_exp:
-| preceded(COLON, VARIABLE)                                    { ($1, with_pos $loc (Var $1)) }
+| preceded(EQ, VARIABLE)                                       { ($1, with_pos $loc (Var $1)) }
 | separated_pair(record_label, EQ, exp)                        { $1 }
 
 labeled_exps:
@@ -1261,7 +1261,7 @@ patterns:
 | separated_nonempty_list(COMMA, pattern)                      { $1 }
 
 labeled_pattern:
-| preceded(COLON, VARIABLE)                                    { ($1, variable_pat ~ppos:$loc $1) }
+| preceded(EQ, VARIABLE)                                       { ($1, variable_pat ~ppos:$loc $1) }
 | separated_pair(record_label, EQ,  pattern)                   { $1 }
 
 labeled_patterns:

--- a/core/parser.mly
+++ b/core/parser.mly
@@ -943,9 +943,12 @@ block_contents:
 | exp                                                          { ([], $1) }
 | SEMICOLON | /* empty */                                      { ([], with_pos $loc (TupleLit [])) }
 
+labeled_exp:
+| preceded(COLON, VARIABLE)                                    { ($1, with_pos $loc (Var $1)) }
+| separated_pair(record_label, EQ, exp)                        { $1 }
+
 labeled_exps:
-| separated_nonempty_list(COMMA,
-    separated_pair(record_label, EQ, exp))                     { $1 }
+| separated_nonempty_list(COMMA, labeled_exp)                  { $1 }
 
 /*
  * Datatype grammar

--- a/core/parser.mly
+++ b/core/parser.mly
@@ -1260,9 +1260,12 @@ primary_pattern:
 patterns:
 | separated_nonempty_list(COMMA, pattern)                      { $1 }
 
+labeled_pattern:
+| preceded(COLON, VARIABLE)                                    { ($1, variable_pat ~ppos:$loc $1) }
+| separated_pair(record_label, EQ,  pattern)                   { $1 }
+
 labeled_patterns:
-| separated_nonempty_list(COMMA,
-   separated_pair(record_label, EQ,  pattern))                 { $1 }
+| separated_nonempty_list(COMMA, labeled_pattern)              { $1 }
 
 multi_args:
 | LPAREN separated_list(COMMA, pattern) RPAREN                 { $2 }

--- a/tests/records.tests
+++ b/tests/records.tests
@@ -103,3 +103,7 @@ stdout : (hello = "hellooo") : (hello:String)
 Record field punning (2)
 var hello = "hellooo"; (:hello, world = 5)
 stdout : (hello = "hellooo", world = 5) : (hello:String,world:Int)
+
+Record field punning (3)
+switch((hello=5, world=10)) { case (:hello, world=y) -> hello + y }
+stdout : 15 : Int

--- a/tests/records.tests
+++ b/tests/records.tests
@@ -107,3 +107,19 @@ stdout : (hello = "hellooo", world = 5) : (hello:String,world:Int)
 Record field punning (3)
 switch((hello=5, world=10)) { case (=hello, world=y) -> hello + y }
 stdout : 15 : Int
+
+Record field punning (4)
+var y = 2; (x=1, =y)
+stdout : (x = 1, y = 2) : (x:Int,y:Int)
+
+Record field punning (5)
+var y = 2; (x=1, =y, z=3)
+stdout : (x = 1, y = 2, z = 3) : (x:Int,y:Int,z:Int)
+
+Record field punning (6)
+var z = 3; (x=1, y=2, =z)
+stdout : (x = 1, y = 2, z = 3) : (x:Int,y:Int,z:Int)
+
+Record field punning (7)
+var x = 1; var y = 2; var z = 3; (=x, =y, =z)
+stdout : (x = 1, y = 2, z = 3) : (x:Int,y:Int,z:Int)

--- a/tests/records.tests
+++ b/tests/records.tests
@@ -95,3 +95,11 @@ exit : 1
 Possibly absent label in a closed row
 fun (x : (a{%b}|%c)) {x : ()}
 stdout : fun : (()) -> ()
+
+Record field punning (1)
+var hello = "hellooo"; (:hello)
+stdout : (hello = "hellooo") : (hello:String)
+
+Record field punning (2)
+var hello = "hellooo"; (:hello, world = 5)
+stdout : (hello = "hellooo", world = 5) : (hello:String,world:Int)

--- a/tests/records.tests
+++ b/tests/records.tests
@@ -97,13 +97,13 @@ fun (x : (a{%b}|%c)) {x : ()}
 stdout : fun : (()) -> ()
 
 Record field punning (1)
-var hello = "hellooo"; (:hello)
+var hello = "hellooo"; (=hello)
 stdout : (hello = "hellooo") : (hello:String)
 
 Record field punning (2)
-var hello = "hellooo"; (:hello, world = 5)
+var hello = "hellooo"; (=hello, world = 5)
 stdout : (hello = "hellooo", world = 5) : (hello:String,world:Int)
 
 Record field punning (3)
-switch((hello=5, world=10)) { case (:hello, world=y) -> hello + y }
+switch((hello=5, world=10)) { case (=hello, world=y) -> hello + y }
 stdout : 15 : Int


### PR DESCRIPTION
A feature I've been missing from OCaml is record field punning. In
OCaml, we can write:

```
let hello = "hello!" in
{ hello; world = 5 }
```

instead of

```
let hello = "hello!" in
{ hello = hello; world = 5 }
```

This patch is a simple parser hack to allow the same sort of thing in
Links. We can't do field punning directly since we get a reduce/reduce
with a parenthesised expression, but we can delineate punned fields with
an operator (I chose a colon), allowing us to write:

```
var hello = "hello!";
(:hello, world = 5)
```

which is parsed in as

```
var hello = "hello!";
(hello = hello, world = 5)
```