### PR TITLE
Fix warnings being fatal in development mode

### DIFF
--- a/dune
+++ b/dune
@@ -5,6 +5,7 @@
           -strict-sequence ;; Enforces the lhs of a sequence to have type `unit'.
           -safe-string     ;; Immutable strings.
           -annot           ;; Dumps information per (file) module about types, bindings, tail-calls, etc. Used by some tools.
+          -warn-error -a+31 ;; Only error on warning 31.
           -w A-4-44-45-60  ;; Ignores warnings 4, 44, 45, and 60.
           -g               ;; Adds debugging information to the resulting executable / library.
          )))


### PR DESCRIPTION
This is a small amendum to #668 - sorry, I should have picked this up earlier.

The dev profile by will error on most warnings by default. While additional strictness may be useful, it can be some little frustrating as non-fatal issues cause the build to fail (and make editor error highlighting a little more confusing).

We use `-warn-error -a+31` (the default setting for ocamlc) to prevent these warnings from erroring.

This change also allows us to build Links in development mode on 4.08 (albeit with it warning on `bin/repl.ml`).