### PR TITLE
MVU: Unescaped text nodes

### DIFF
--- a/lib/js/vdom.js
+++ b/lib/js/vdom.js
@@ -538,14 +538,9 @@ const VDom = (function() {
     } else if (lbl =="HTMLAppend") {
       return evalHTML(val["1"]).concat(evalHTML(val["2"]));
     } else if (lbl == "HTMLText") {
-      const text = val["1"];
-      const escaped = val["2"];
-      if (escaped) {
-        return [String(text)];
-      } else {
-        return [h("span", { innerHTML: String(text) }, [])];
-      }
       return [String(val)];
+    } else if (lbl == "HTMLRaw") {
+      return [h("span", { innerHTML: String(val) }, [])];
     } else if (lbl == "HTMLTag") {
       // First, get ourselves a dictionary of attributes and event handlers
       const attrRes = evalAttr(val.attrs);

--- a/lib/js/vdom.js
+++ b/lib/js/vdom.js
@@ -538,6 +538,13 @@ const VDom = (function() {
     } else if (lbl =="HTMLAppend") {
       return evalHTML(val["1"]).concat(evalHTML(val["2"]));
     } else if (lbl == "HTMLText") {
+      const text = val["1"];
+      const escaped = val["2"];
+      if (escaped) {
+        return [String(text)];
+      } else {
+        return [h("span", { innerHTML: String(text) }, [])];
+      }
       return [String(val)];
     } else if (lbl == "HTMLTag") {
       // First, get ourselves a dictionary of attributes and event handlers

--- a/lib/stdlib/mvuAttrs.links
+++ b/lib/stdlib/mvuAttrs.links
@@ -102,7 +102,7 @@ fun value(val) {
 }
 
 fun for_(val) {
-    attr ("for", val)
+    attr ("htmlFor", val)
 }
 
 fun text(val) {

--- a/lib/stdlib/mvuHTML.links
+++ b/lib/stdlib/mvuHTML.links
@@ -4,14 +4,18 @@ open import MvuAttrs;
 typename HTML(a :: Type(Any, Any)) =
   [| HTMLEmpty
    | HTMLAppend: (HTML(a), HTML(a))
-   | HTMLText: (String)
+   | HTMLText: (String, Bool) # Bool: Whether or not text node is escaped
    | HTMLTag: (tagName: String, attrs: Attr(a), children: HTML(a))
    |];
 
 var empty = HTMLEmpty;
 
 fun textNode(str) {
-  HTMLText(str)
+  HTMLText(str, true)
+}
+
+fun unescapedTextNode(str) {
+  HTMLText(str, false)
 }
 
 sig tag : forall a :: Type(Any, Any), e :: Row .

--- a/lib/stdlib/mvuHTML.links
+++ b/lib/stdlib/mvuHTML.links
@@ -4,18 +4,19 @@ open import MvuAttrs;
 typename HTML(a :: Type(Any, Any)) =
   [| HTMLEmpty
    | HTMLAppend: (HTML(a), HTML(a))
-   | HTMLText: (String, Bool) # Bool: Whether or not text node is escaped
+   | HTMLText: (String)
+   | HTMLRaw: (String)
    | HTMLTag: (tagName: String, attrs: Attr(a), children: HTML(a))
    |];
 
 var empty = HTMLEmpty;
 
 fun textNode(str) {
-  HTMLText(str, true)
+  HTMLText(str)
 }
 
 fun unescapedTextNode(str) {
-  HTMLText(str, false)
+  HTMLRaw(str)
 }
 
 sig tag : forall a :: Type(Any, Any), e :: Row .


### PR DESCRIPTION
Minor patch: currently the MVU library only supports escaped text nodes (for example, showing raw HTML and "&"-coded symbols). Sometimes this is too restrictive (like in my GtoPdb clone).

This patch allows you to do

```
unescapedTextNode("&amp;")
```

for example, which will correctly come out as an ampersand. The trick is to have a `span` tag and set its `innerHTML` attribute.

The patch also contains a fix to the `for` attribute (the library works using properties rather than attributes generally, so it must be `htmlFor` rather than just `for`).