### PR TITLE
MVU: Make onChange event handler take DOM value as a parameter

### DIFF
--- a/lib/stdlib/mvuAttrs.links
+++ b/lib/stdlib/mvuAttrs.links
@@ -157,11 +157,6 @@ fun classList(classes) {
 fun onClick(f) {
   eventHandler(UnitHandler("click", f))
 }
-
-fun onChange(f) {
-  eventHandler(UnitHandler("change", f))
-}
-
 fun onMouseMove(f) {
   eventHandler(UnitHandler("mousemove", f))
 }
@@ -213,6 +208,10 @@ fun onKeyPress(f) {
 
 fun onInput(f) {
   eventHandler(PropertyHandler("input", "value", fun(val) { Just(f(val)) }))
+}
+
+fun onChange(f) {
+  eventHandler(PropertyHandler("change", "value", fun(val) { Just(f(val)) } ))
 }
 
 fun getKey(event, f) {


### PR DESCRIPTION
Small patch: currently `onChange` takes an event handler function of type `() -> Message`. This patch changes it to `(String) -> Message`, where `String` is the `value` attribute of the element. This makes `onChange` useful for things like dropdown menus.