### PR TITLE
Add syntax and type checking for type applications

### DIFF
--- a/core/desugarDatatypes.ml
+++ b/core/desugarDatatypes.ml
@@ -103,6 +103,10 @@ object (self)
       (_, None) -> {< all_desugared = false >}
     | _ -> self
 
+  method! type_arg' = function
+      (_, None) -> {< all_desugared = false >}
+    | _ -> self
+
   method! phrasenode = function
     | TableLit (_, (_, None), _, _, _) -> {< all_desugared = false >}
     | p -> super#phrasenode p
@@ -796,6 +800,10 @@ module Desugar = struct
   let datatype' map alias_env ((dt, _) : datatype') =
     (dt, Some (datatype map alias_env dt))
 
+  let type_arg' map alias_env ((ta, _) : type_arg') : type_arg' =
+    let unlocated = WithPos.make Datatype.Unit in
+    (ta, Some (type_arg map alias_env ta unlocated))
+
   (* Desugar a foreign function declaration. Foreign declarations cannot use type variables from
      the context. Any type variables found are implicitly universally quantified at this point. *)
   let foreign alias_env dt =
@@ -841,6 +849,8 @@ object (self)
   val alias_env = initial_alias_env
 
   method! datatype' node = (self, Desugar.datatype' map alias_env node)
+
+  method! type_arg' node = (self, Desugar.type_arg' map alias_env node)
 
   method! phrasenode = function
     | Block (bs, p) ->

--- a/core/desugarInners.ml
+++ b/core/desugarInners.ml
@@ -103,9 +103,9 @@ object (o : 'self_type)
     | TAppl ({node=Section (Section.Name name);_} as p, tyargs)
     | TAppl ({node=FreezeSection (Section.Name name);_} as p, tyargs)
          when StringMap.mem name extra_env ->
-        let tyargs = o#add_extras name tyargs in
+        let tyargs = o#add_extras name (List.map (snd ->- val_of) tyargs) in
         let o = o#unbind name in
-        let (o, e, t) = o#phrasenode (TAppl (SourceCode.WithPos.map ~f:freeze p, tyargs)) in
+        let (o, e, t) = o#phrasenode (tappl' (SourceCode.WithPos.map ~f:freeze p, tyargs)) in
         (o#with_extra_env extra_env, e, t)
     | InfixAppl ((tyargs, BinaryOp.Name name), e1, e2) when StringMap.mem name extra_env ->
         let tyargs = o#add_extras name tyargs in

--- a/core/parser.mly
+++ b/core/parser.mly
@@ -569,12 +569,16 @@ postfix_expression:
 | QUERY LBRACKET exp RBRACKET block                            { query ~ppos:$loc (Some ($3, with_pos $loc (Constant (Constant.Int 0)))) $5 }
 | QUERY LBRACKET exp COMMA exp RBRACKET block                  { query ~ppos:$loc (Some ($3, $5)) $7 }
 | postfix_expression arg_spec                                  { with_pos $loc (FnAppl ($1, $2)) }
+| postfix_expression targ_spec                                 { with_pos $loc (TAppl ($1, $2)) }
 | postfix_expression DOT record_label                          { with_pos $loc (Projection ($1, $3)) }
 | postfix_expression AT                                        { with_pos $loc (Instantiate $1) }
 
 
 arg_spec:
 | LPAREN perhaps_exps RPAREN                                   { $2 }
+
+targ_spec:
+| LBRACKET type_arg_list RBRACKET                              { List.map (fun x -> (x, None)) $2 }
 
 exps:
 | separated_nonempty_list(COMMA, exp)                          { $1 }

--- a/core/sugarTraversals.ml
+++ b/core/sugarTraversals.ml
@@ -225,7 +225,7 @@ class map =
           TAbstr ((_x, _x_i1))
       | TAppl ((_x, _x_i1)) ->
           let _x = o#phrase _x in
-          let _x_i1 = o#list (fun o -> o#tyarg) _x_i1 in
+          let _x_i1 = o#list (fun o -> o#type_arg') _x_i1 in
           TAppl ((_x, _x_i1))
       | TupleLit _x ->
           let _x = o#list (fun o -> o#phrase) _x in TupleLit _x
@@ -634,6 +634,12 @@ class map =
       | Row _x -> let _x = o#row _x in Row _x
       | Presence _x -> let _x = o#fieldspec _x in Presence _x
 
+    method type_arg' : type_arg' -> type_arg' =
+      fun (x, y) ->
+        let x = o#type_arg x in
+        let y = o#option (fun o -> o#tyarg) y in
+        (x, y)
+
     method constant : Constant.t -> Constant.t =
       function
       | Constant.Float _x  -> let _x = o#float _x  in Constant.Float _x
@@ -955,7 +961,9 @@ class fold =
           let o = o#list (fun o -> o#tyvar) (_x) in
           let o = o#phrase _x_i1 in o
       | TAppl ((_x, _x_i1)) ->
-          let o = o#phrase _x in o
+          let o = o#phrase _x in
+          let o = o#list (fun o -> o#type_arg') _x_i1 in
+          o
       | TupleLit _x -> let o = o#list (fun o -> o#phrase) _x in o
       | RecordLit ((_x, _x_i1)) ->
           let o =
@@ -1318,6 +1326,12 @@ class fold =
       | Row _x -> let o = o#row _x in o
       | Presence _x -> let o = o#fieldspec _x in o
 
+    method type_arg' : type_arg' -> 'self_type =
+      fun (x, y) ->
+        let o = o#type_arg x in
+        let o = o#unknown y in
+        o
+
     method constant : Constant.t -> 'self_type =
       function
       | Constant.Float  _x -> let o = o#float  _x in o
@@ -1648,7 +1662,9 @@ class fold_map =
       | TAbstr ((_x, _x_i1)) ->
           let (o, _x_i1) = o#phrase _x_i1 in (o, (TAbstr ((_x, _x_i1))))
       | TAppl ((_x, _x_i1)) ->
-          let (o, _x) = o#phrase _x in (o, (TAppl ((_x, _x_i1))))
+          let (o, _x) = o#phrase _x in
+          let (o, _x_i1) = o#list (fun o -> o#type_arg') _x_i1 in
+          (o, (TAppl ((_x, _x_i1))))
       | TupleLit _x ->
           let (o, _x) = o#list (fun o -> o#phrase) _x in (o, (TupleLit _x))
       | RecordLit ((_x, _x_i1)) ->
@@ -2099,6 +2115,11 @@ class fold_map =
       | Type _x -> let (o, _x) = o#datatype _x in (o, Type _x)
       | Row _x -> let (o, _x) = o#row _x in (o, Row _x)
       | Presence _x -> let (o, _x) = o#fieldspec _x in (o, Presence _x)
+
+    method type_arg' : type_arg' -> ('self_type * type_arg') =
+      fun (x, y) ->
+        let o, x = o#type_arg x in
+        (o, (x, y))
 
     method constant : Constant.t -> ('self_type * Constant.t) =
       function

--- a/core/sugarTraversals.mli
+++ b/core/sugarTraversals.mli
@@ -60,6 +60,7 @@ class map :
     method datatypenode    : Datatype.t -> Datatype.t
     method datatype'       : datatype' -> datatype'
     method type_arg        : Datatype.type_arg -> Datatype.type_arg
+    method type_arg'       : type_arg' -> type_arg'
     method constant        : Constant.t -> Constant.t
     method binop           : BinaryOp.t -> BinaryOp.t
     method tybinop         : tyarg list * BinaryOp.t -> tyarg list * BinaryOp.t
@@ -137,6 +138,7 @@ class fold :
     method datatypenode    : Datatype.t -> 'self
     method datatype'       : datatype' -> 'self
     method type_arg        : Datatype.type_arg -> 'self
+    method type_arg'       : type_arg' -> 'self
     method constant        : Constant.t -> 'self
     method binop           : BinaryOp.t -> 'self
     method tybinop         : tyarg list * BinaryOp.t -> 'self
@@ -172,6 +174,7 @@ object ('self)
   method datatype        : Datatype.with_pos -> 'self * Datatype.with_pos
   method datatypenode    : Datatype.t -> 'self * Datatype.t
   method datatype'       : datatype' -> 'self * datatype'
+  method type_arg'       : type_arg' -> 'self * type_arg'
   method directive       : directive -> 'self * directive
   method fieldconstraint : fieldconstraint -> 'self * fieldconstraint
   method fieldspec       : Datatype.fieldspec -> 'self * Datatype.fieldspec

--- a/core/sugartoir.ml
+++ b/core/sugartoir.ml
@@ -847,7 +847,7 @@ struct
               cofv (I.apply_pure (I.var (lookup_name_and_type f env), evs es))
           | FnAppl ({node=TAppl ({node=Var f; _}, tyargs); _}, es)
                when Lib.is_pure_primitive f ->
-              cofv (I.apply_pure (instantiate f tyargs, evs es))
+              cofv (I.apply_pure (instantiate f (List.map (snd ->- val_of) tyargs), evs es))
           | FnAppl (e, es) when is_pure_primitive e ->
               cofv (I.apply_pure (ev e, evs es))
           | FnAppl (e, es) ->
@@ -860,7 +860,7 @@ struct
               let vt = I.sem_type v in
                 begin
                   try
-                    cofv (I.tappl (v, tyargs))
+                    cofv (I.tappl (v, List.map (snd ->- val_of) tyargs))
                   with
                       Instantiate.ArityMismatch (expected, provided) ->
                         raise (Errors.TypeApplicationArityMismatch { pos;

--- a/core/sugartypes.ml
+++ b/core/sugartypes.ml
@@ -142,6 +142,10 @@ end
 type datatype' = Datatype.with_pos * Types.datatype option
     [@@deriving show]
 
+type type_arg' = Datatype.type_arg * Types.type_arg option
+    [@@deriving show]
+
+
 module Pattern = struct
   type t =
     | Any
@@ -239,7 +243,7 @@ and phrasenode =
   | UnaryAppl        of (tyarg list * UnaryOp.t) * phrase
   | FnAppl           of phrase * phrase list
   | TAbstr           of tyvar list * phrase
-  | TAppl            of phrase * tyarg list
+  | TAppl            of phrase * type_arg' list
   | TupleLit         of phrase list
   | RecordLit        of (name * phrase) list * phrase option
   | Projection       of phrase * name
@@ -366,7 +370,20 @@ let tabstr : tyvar list * phrasenode -> phrasenode = fun (tyvars, e) ->
 let tappl : phrasenode * tyarg list -> phrasenode = fun (e, tys) ->
   match tys with
     | [] -> e
-    | _  -> TAppl (WithPos.make e, tys)
+    | _  ->
+       let make_arg ty =
+         (Datatype.Type (WithPos.make (Datatype.TypeVar ("$none", None, `Rigid))), Some ty)
+       in
+       TAppl (WithPos.make e, List.map make_arg tys)
+
+let tappl' : phrase * tyarg list -> phrasenode = fun (e, tys) ->
+  match tys with
+    | [] -> WithPos.node e
+    | _  ->
+       let make_arg ty =
+         (Datatype.Type (WithPos.make (Datatype.TypeVar ("$none", None, `Rigid))), Some ty)
+       in
+       TAppl (e, List.map make_arg tys)
 
 module Freevars =
 struct

--- a/core/transformSugar.ml
+++ b/core/transformSugar.ml
@@ -383,7 +383,7 @@ class transform (env : Types.typing_environment) =
             check_type_application
               (TAppl (e, tyargs), t)
               (fun () ->
-                 let t = Instantiate.apply_type t tyargs in
+                 let t = Instantiate.apply_type t (List.map (snd ->- val_of) tyargs) in
                    (o, TAppl (e, tyargs), t))
       | TupleLit [e] ->
           (* QUESTION:


### PR DESCRIPTION
This adds syntax for explicit type applications. One may now write:

```
~id[Int] # Produces a type ∀ e. (Int) -e-> Int
~id[Int, {}] # Produces a type (Int) {}-> Int
```