### PR TITLE
Frozen lets

### DIFF
--- a/core/desugarFuns.ml
+++ b/core/desugarFuns.ml
@@ -79,11 +79,12 @@ let unwrap_def (bndr, linearity, (tyvars, lam), location) =
   (for recursive functions)
 *)
 let unwrap_def_dp { rec_binder = fb; rec_linearity = lin; rec_definition = tlam;
-                    rec_location = location; rec_signature = t; rec_unsafe_signature = ut;
-                    rec_pos } =
+                    rec_location = location; rec_signature; rec_unsafe_signature;
+                    rec_pos; rec_frozen } =
   let (fb, lin, tlam, location) = unwrap_def (fb, lin, tlam, location) in
   { rec_binder = fb; rec_linearity = lin; rec_definition = tlam;
-    rec_location = location; rec_signature = t; rec_unsafe_signature = ut; rec_pos }
+    rec_location = location; rec_signature; rec_unsafe_signature;
+    rec_pos; rec_frozen }
 
 class desugar_funs env =
 object (o : 'self_type)

--- a/core/desugarInners.ml
+++ b/core/desugarInners.ml
@@ -178,7 +178,9 @@ object (o : 'self_type)
                let o = o#with_visiting visiting_funs in
 
                let (o, defs) = list o defs in
-               (o, { fn with rec_definition = ((tyvars, Some (inner, extras)), lam) } :: defs)
+               (o, { fn with
+                     rec_definition = ((tyvars, Some (inner, extras)), lam);
+                     rec_frozen = true } :: defs)
             | _ :: _ -> assert false
           in list o defs
         in

--- a/core/lexer.mll
+++ b/core/lexer.mll
@@ -341,6 +341,8 @@ rule lex ctxt nl = parse
   | "infixr"                            { INFIXR ctxt#setprec }
   | "prefix"                            { PREFIX ctxt#setprec }
   | "postfix"                           { POSTFIX ctxt#setprec }
+  | "~fun"                              { FROZEN_FUN }
+  | "~linfun"                           { FROZEN_LINFUN }
   | def_id as var                       { try List.assoc var keywords
                                           with Not_found | NotFound _ ->
                                             if Char.isUpper var.[0] then CONSTRUCTOR var

--- a/core/liftRecursive.ml
+++ b/core/liftRecursive.ml
@@ -30,6 +30,7 @@ object ((self : 'self_type))
                       rec_location = fn.fun_location;
                       rec_signature = fn.fun_signature;
                       rec_unsafe_signature = fn.fun_unsafe_signature;
+                      rec_frozen = fn.fun_frozen;
                       rec_pos = pos;
                     }]
             else

--- a/core/parser.mly
+++ b/core/parser.mly
@@ -212,6 +212,7 @@ module MutualBindings = struct
                   rec_location = fn.fun_location;
                   rec_signature = fn.fun_signature;
                   rec_unsafe_signature = fn.fun_unsafe_signature;
+                  rec_frozen = fn.fun_frozen;
                   rec_pos = pos; }) fs in
           [WithPos.make ~pos:mut_pos (Funs fs)] in
 

--- a/core/parser.mly
+++ b/core/parser.mly
@@ -226,7 +226,7 @@ end
 
 %token END
 %token EQ IN
-%token FUN LINFUN RARROW LOLLI FATRARROW VAR OP
+%token FUN LINFUN FROZEN_FUN FROZEN_LINFUN RARROW LOLLI FATRARROW VAR OP
 %token SQUIGRARROW SQUIGLOLLI TILDE
 %token IF ELSE
 %token MINUS MINUSDOT
@@ -297,7 +297,7 @@ end
 %type <Sugartypes.regex> regex_pattern
 %type <Sugartypes.regex list> regex_pattern_sequence
 %type <Sugartypes.Pattern.with_pos> pattern
-%type <DeclaredLinearity.t * Sugartypes.name *
+%type <(DeclaredLinearity.t * bool) * Sugartypes.name *
        Sugartypes.Pattern.with_pos list list * Location.t *
        Sugartypes.phrase> tlfunbinding
 %type <Sugartypes.phrase> postfix_expression
@@ -401,11 +401,17 @@ linearity:
 | FUN                                                          { dl_unl }
 | LINFUN                                                       { dl_lin }
 
+fun_kind:
+| FUN                                                          { (dl_unl, false) }
+| LINFUN                                                       { (dl_lin, false) }
+| FROZEN_FUN                                                   { (dl_unl, true) }
+| FROZEN_LINFUN                                                { (dl_lin, true) }
+
 tlfunbinding:
-| linearity VARIABLE arg_lists perhaps_location block          { ($1, $2, $3, $4, $5)                }
-| OP pattern sigop pattern perhaps_location block              { (dl_unl, WithPos.node $3, [[$2; $4]], $5, $6) }
-| OP PREFIXOP pattern perhaps_location block                   { (dl_unl, $2, [[$3]], $4, $5)          }
-| OP pattern POSTFIXOP perhaps_location block                  { (dl_unl, $3, [[$2]], $4, $5)          }
+| fun_kind VARIABLE arg_lists perhaps_location block           { ($1, $2, $3, $4, $5)                }
+| OP pattern sigop pattern perhaps_location block              { ((dl_unl, false), WithPos.node $3, [[$2; $4]], $5, $6) }
+| OP PREFIXOP pattern perhaps_location block                   { ((dl_unl, false), $2, [[$3]], $4, $5)          }
+| OP pattern POSTFIXOP perhaps_location block                  { ((dl_unl, false), $3, [[$2]], $4, $5)          }
 
 tlvarbinding:
 | VAR VARIABLE perhaps_location EQ exp                         { (PatName $2, $5, $3) }
@@ -888,8 +894,8 @@ links_open:
 binding:
 | VAR pattern EQ exp SEMICOLON                                 { val_binding ~ppos:$loc $2 $4 }
 | exp SEMICOLON                                                { with_pos $loc (Exp $1) }
-| signatures linearity VARIABLE arg_lists block                { fun_binding ~ppos:$loc (fst $1) ~unsafe_sig:(snd $1) ($2, $3, $4, loc_unknown, $5) }
-| linearity VARIABLE arg_lists block                           { fun_binding ~ppos:$loc None ($1, $2, $3, loc_unknown, $4) }
+| signatures fun_kind VARIABLE arg_lists block                 { fun_binding ~ppos:$loc (fst $1) ~unsafe_sig:(snd $1) ($2, $3, $4, loc_unknown, $5) }
+| fun_kind VARIABLE arg_lists block                            { fun_binding ~ppos:$loc None ($1, $2, $3, loc_unknown, $4) }
 | typedecl SEMICOLON | links_module
 | links_open SEMICOLON                                         { $1 }
 

--- a/core/sugarConstructors.ml
+++ b/core/sugarConstructors.ml
@@ -154,7 +154,7 @@ module SugarConstructors (Position : Pos)
 
   (** Bindings *)
   (* Create a function binding. *)
-  let fun_binding ?(ppos=dp) sig_opt ?(unsafe_sig=false) ?(frozen=false) (linearity, bndr, args, location, blk) =
+  let fun_binding ?(ppos=dp) sig_opt ?(unsafe_sig=false) ((linearity, frozen), bndr, args, location, blk) =
     let fun_signature = datatype_opt_of_sig_opt sig_opt bndr in
     with_pos ppos (Fun { fun_binder = binder bndr;
                          fun_linearity = linearity;

--- a/core/sugarConstructorsIntf.ml
+++ b/core/sugarConstructorsIntf.ml
@@ -106,9 +106,8 @@ module type SugarConstructorsSig = sig
 
   (* Bindings *)
   val fun_binding
-      : ?ppos:t -> signature -> ?unsafe_sig:bool -> ?frozen:bool
-     -> (DeclaredLinearity.t * name * Pattern.with_pos list list * Location.t *
-           phrase)
+      : ?ppos:t -> signature -> ?unsafe_sig:bool
+     -> ((DeclaredLinearity.t * bool) * name * Pattern.with_pos list list * Location.t * phrase)
      -> binding
   val fun_binding'
       : ?ppos:t -> ?linearity:DeclaredLinearity.t -> ?tyvars:tyvar list

--- a/core/sugarTraversals.ml
+++ b/core/sugarTraversals.ml
@@ -735,27 +735,29 @@ class map =
         fun_unsafe_signature; }
 
     method recursive_function  : recursive_function -> recursive_function
-      = fun { rec_binder = a;
-              rec_linearity = b;
-              rec_definition = ((tyvar, ty), d);
-              rec_location = e;
-              rec_signature = f;
-              rec_unsafe_signature = g;
-              rec_pos = h } ->
-      let a = o#binder a in
+      = fun { rec_binder;
+              rec_linearity;
+              rec_definition = ((tyvar, ty), lit);
+              rec_location;
+              rec_signature;
+              rec_unsafe_signature;
+              rec_frozen;
+              rec_pos } ->
+      let rec_binder = o#binder rec_binder in
       let tyvar = o#list (fun o -> o#tyvar) tyvar in
       let ty = o#option (fun o (t, x)-> o#typ t, x) ty in
-      let d = o#funlit d in
-      let e = o#location e in
-      let f = o#option (fun o -> o#datatype') f in
-      let h = o#position h in
-      { rec_binder = a;
-        rec_linearity = b;
-        rec_definition = ((tyvar, ty), d);
-        rec_location = e;
-        rec_signature = f;
-        rec_unsafe_signature = g;
-        rec_pos = h; }
+      let lit = o#funlit lit in
+      let rec_location = o#location rec_location in
+      let rec_signature = o#option (fun o -> o#datatype') rec_signature in
+      let rec_pos = o#position rec_pos in
+      { rec_binder;
+        rec_linearity;
+        rec_definition = ((tyvar, ty), lit);
+        rec_location;
+        rec_signature;
+        rec_unsafe_signature;
+        rec_frozen;
+        rec_pos; }
 
     method program : program -> program =
       fun (bindings, phrase) ->
@@ -1409,19 +1411,20 @@ class fold =
           o
 
     method recursive_function  : recursive_function -> 'self
-      = fun { rec_binder = a;
+      = fun { rec_binder;
               rec_linearity = _;
-              rec_definition = ((b, _), c);
-              rec_location = d;
-              rec_signature = e;
+              rec_definition = ((tyvar, _), lit);
+              rec_location;
+              rec_signature;
               rec_unsafe_signature = _;
-              rec_pos = g } ->
-      let o = o#binder a in
-      let o = o#list (fun o -> o#tyvar) b in
-      let o = o#funlit c in
-      let o = o#location d in
-      let o = o#option (fun o -> o#datatype') e in
-      let o = o#position g
+              rec_frozen = _;
+              rec_pos } ->
+      let o = o#binder rec_binder in
+      let o = o#list (fun o -> o#tyvar) tyvar in
+      let o = o#funlit lit in
+      let o = o#location rec_location in
+      let o = o#option (fun o -> o#datatype') rec_signature in
+      let o = o#position rec_pos
       in o
 
     method program : program -> 'self_type =
@@ -2209,25 +2212,27 @@ class fold_map =
             fun_unsafe_signature; })
 
     method recursive_function  : recursive_function -> 'self * recursive_function
-      = fun { rec_binder = _x;
-              rec_linearity = _x1;
-              rec_definition = (_x_i1, _x_i2);
-              rec_location = _x_i3;
-              rec_signature = _x_i4;
-              rec_unsafe_signature = _x_i5;
-              rec_pos = _x_i6 } ->
-      let (o, _x) = o#binder _x in
-      let (o, _x_i2) = o#funlit _x_i2 in
-      let (o, _x_i3) = o#location _x_i3 in
-      let (o, _x_i4) = o#option (fun o -> o#datatype') _x_i4 in
-      let (o, _x_i6) = o#position _x_i6 in
-      (o, { rec_binder = _x;
-            rec_linearity = _x1;
-            rec_definition = (_x_i1, _x_i2);
-            rec_location = _x_i3;
-            rec_signature = _x_i4;
-            rec_unsafe_signature = _x_i5;
-            rec_pos = _x_i6 })
+      = fun { rec_binder;
+              rec_linearity;
+              rec_definition = (ty, lit);
+              rec_location;
+              rec_signature;
+              rec_unsafe_signature;
+              rec_frozen;
+              rec_pos } ->
+      let o, rec_binder = o#binder rec_binder in
+      let o, lit = o#funlit lit in
+      let o, rec_location = o#location rec_location in
+      let o, rec_signature = o#option (fun o -> o#datatype') rec_signature in
+      let o, rec_pos = o#position rec_pos in
+      (o, { rec_binder;
+            rec_linearity;
+            rec_definition = (ty, lit);
+            rec_location;
+            rec_signature;
+            rec_unsafe_signature;
+            rec_frozen;
+            rec_pos })
 
     method binder : Binder.with_pos -> ('self_type * Binder.with_pos) =
       Binder.traverse_map

--- a/core/sugartypes.ml
+++ b/core/sugartypes.ml
@@ -339,6 +339,7 @@ and recursive_function = {
     rec_location: Location.t;
     rec_signature: datatype' option;
     rec_unsafe_signature: bool;
+    rec_frozen : bool;
     rec_pos: Position.t
   }
   [@@deriving show]


### PR DESCRIPTION
This allows writing "frozen function definitions", which will never generalise their types:


```
~fun f(x) { x }
```

The major issue with this change right now is that you can write mutual blocks with one frozen function and one-non frozen one, allowing definitions like:

```
mutual {
  ~fun f(x) { x }
  fun g(x) { f(x) }
}
```

This now causes quantifiers to escape their scope, similar to #678, meaning `f` uses the quantifiers bound by `g`'s type.