### PR TITLE
Fixes compilation of `show`.

### DIFF
--- a/core/lib.ml
+++ b/core/lib.ml
@@ -307,7 +307,7 @@ let env : (string * (located_primitive * Types.datatype * pure)) list = [
   "show",
   (p1 (fun v -> Value.box_string (Value.string_of_value v)),
    datatype "(a) ~> String",
-   PURE);
+   IMPURE);
 
   "exit",
   (`Continuation Value.Continuation.empty,


### PR DESCRIPTION
The builtin function `show` has an impure effect signature (`(a) ~> String`), yet it was marked as `PURE` in `lib.ml`, meaning that the JavaScript compiler would not CPS transform the function.

This patch marks the function as `IMPURE` in `lib.ml`.

Resolves #689.