### PR TITLE
Keep quantifiers on IR let-bound values

### DIFF
--- a/core/ir.ml
+++ b/core/ir.ml
@@ -117,7 +117,7 @@ let tapp (v, tyargs) =
     | [] -> v
     | _ -> TApp (v, tyargs)
 
-let letm (b, tc) = Let (b, ([], tc))
+let letm ?(tyvars=[]) (b, tc) = Let (b, (tyvars, tc))
 let letmv (b, v) = letm (b, Return v)
 
 let rec is_atom =

--- a/core/ir.mli
+++ b/core/ir.mli
@@ -107,7 +107,7 @@ val binder_of_fun_def : fun_def -> binder
 
 val tapp : value * tyarg list -> value
 
-val letm : binder * tail_computation -> binding
+val letm : ?tyvars:tyvar list -> binder * tail_computation -> binding
 val letmv : binder * value -> binding
 (*val letv : tybinder * value -> binding*)
 

--- a/core/sugartoir.ml
+++ b/core/sugartoir.ml
@@ -117,7 +117,8 @@ sig
   val condition : (value sem * tail_computation sem * tail_computation sem) -> tail_computation sem
 
   val comp : env -> (CompilePatterns.Pattern.t * value sem * tail_computation sem) -> tail_computation sem
-  val letvar : (var_info * tail_computation sem * (var -> tail_computation sem)) -> tail_computation sem
+  val letvar : (var_info * tail_computation sem * tyvar list *
+               (var -> tail_computation sem)) -> tail_computation sem
 
   val xml : value sem * string * (name * (value sem) list) list * (value sem) list -> value sem
   val record : (name * value sem) list * (value sem) option -> value sem
@@ -267,7 +268,7 @@ struct
 
     val lift_alist : ('a*'b sem) list -> (('a*'b) list) M.sem
 
-    val comp_binding : var_info * tail_computation -> var M.sem
+    val comp_binding : ?tyvars:tyvar list -> var_info * tail_computation -> var M.sem
 
     val fun_binding :
       Var.var_info * (tyvar list * binder list * computation) * location ->
@@ -300,9 +301,9 @@ struct
                   (fun vs -> lift ((name, v) :: vs))))
         ss (lift [])
 
-    let comp_binding (x_info, e) =
+    let comp_binding ?(tyvars=[]) (x_info , e) =
       let xb, x = Var.fresh_var x_info in
-        lift_binding (letm (xb, e)) x
+        lift_binding (letm ~tyvars (xb, e)) x
 
     let fun_binding (f_info, (tyvars, xsb, body), location) =
       let fb, f = Var.fresh_var f_info in
@@ -612,10 +613,10 @@ struct
                    (fun offset ->
                       lift (Special (Query (Some (limit, offset), (bs, e), sem_type s)), sem_type s)))
 
-  let letvar (x_info, s, body) =
+  let letvar (x_info, s, tyvars, body) =
     bind s
       (fun e ->
-         M.bind (comp_binding (x_info, e))
+         M.bind (comp_binding ~tyvars (x_info, e))
            (fun x -> body x))
 
   let comp env (p, s, body) =
@@ -1102,7 +1103,7 @@ struct
             begin
               let open Sugartypes in
               match b with
-                | Val ({node=Pattern.Variable bndr; _}, (_, body), _, _)
+                | Val ({node=Pattern.Variable bndr; _}, (tyvars, body), _, _)
                      when Binder.has_type bndr ->
                     let x  = Binder.to_name bndr in
                     let xt = Binder.to_type bndr in
@@ -1110,6 +1111,7 @@ struct
                       I.letvar
                         (x_info,
                          ec body,
+                         tyvars,
                          fun v ->
                            eval_bindings scope (extend [x] [(v, xt)] env) bs e)
                 | Val (p, (_, body), _, _) ->

--- a/tests/typed_ir.tests
+++ b/tests/typed_ir.tests
@@ -18,3 +18,8 @@ ConcatMap (#368)
 tests/typed_ir/T368.links
 filemode : true
 stdout : () : ()
+
+Quantifiers on let-bound values (#620)
+tests/typed_ir/T620.links
+filemode : true
+stdout : () : ()

--- a/tests/typed_ir/T620.links
+++ b/tests/typed_ir/T620.links
@@ -1,0 +1,7 @@
+sig foo : () -> ()
+fun foo() {
+  ()
+}
+
+sig bar : () ~> ()
+var bar = foo;


### PR DESCRIPTION
Resolves #620 by keeping quantifiers in the IR on let-bound values. I'm not sure whether both `Val` cases of `eval_bindings` in `sugartoir.ml` should be amended. All the affected programs we identified so far are fixed by this patch.