### PR TITLE
Allow quoted field names in lens expressions

### DIFF
--- a/core/parser.mly
+++ b/core/parser.mly
@@ -854,7 +854,7 @@ database_expression:
 | DATABASE atomic_expression perhaps_db_driver                 { with_pos $loc (DatabaseLit ($2, $3))           }
 
 fn_dep_cols:
-| VARIABLE+                                                    { $1 }
+| field_label+                                                 { $1 }
 
 fn_dep:
 | fn_dep_cols RARROW fn_dep_cols                               { ($1, $3) }
@@ -866,8 +866,8 @@ lens_expression:
 | LENS exp DEFAULT                                             { with_pos $loc (LensLit ($2, None))}
 | LENS exp TABLEKEYS exp                                       { with_pos $loc (LensKeysLit ($2, $4, None))}
 | LENS exp WITH LBRACE fn_deps RBRACE                          { with_pos $loc (LensFunDepsLit ($2, $5, None))}
-| LENSDROP VARIABLE DETERMINED BY
-  VARIABLE DEFAULT exp FROM exp                                { with_pos $loc (LensDropLit ($9, $2, $5, $7, None)) }
+| LENSDROP field_label DETERMINED BY
+  field_label DEFAULT exp FROM exp                             { with_pos $loc (LensDropLit ($9, $2, $5, $7, None)) }
 | LENSSELECT FROM exp BY exp                                   { with_pos $loc (LensSelectLit ($3, $5, None)) }
 | LENSJOIN exp WITH exp ON exp DELETE LBRACE exp COMMA exp RBRACE  { with_pos $loc (LensJoinLit ($2, $4, $6, $9, $11, None)) }
 | LENSJOIN exp WITH exp ON exp DELETE_LEFT                     { with_pos $loc (LensJoinLit ($2, $4, $6,


### PR DESCRIPTION
Record definitions allow fields like the following:
  (foo: Int, "returning": Bool)

for field names like "returning" which are keywords. However, these
quoted field names were not allowed in relational lens expressions.