### PR TITLE
Fix default jsliburl handling

### DIFF
--- a/core/basicsettings.ml
+++ b/core/basicsettings.ml
@@ -115,7 +115,7 @@ module Js =
 struct
   let optimise = Settings.add_bool("optimise_javascript", true, `User)
   let elim_dead_defs = Settings.add_bool("elim_dead_defs", false, `User)
-  let lib_url = Settings.add_string("jsliburl", "lib/", `User)
+  let lib_url = Settings.add_string("jsliburl", "/lib/", `User)
   let lib_dir = Settings.add_string("jslibdir", "", `User)
 
   let hide_database_info = Settings.add_bool("js_hide_database_info", true, `System)

--- a/core/webserver.ml
+++ b/core/webserver.ml
@@ -257,7 +257,7 @@ struct
         let prefixed_lib_url =
           let base_url = Settings.get_value Basicsettings.Appserver.internal_base_url in
           let js_url = Settings.get_value Basicsettings.Js.lib_url in
-          if base_url = "" then js_url else
+          if base_url = "" then "/" ^ (Utility.strip_slashes js_url) ^ "/" else
           "/" ^
           (base_url |> Utility.strip_slashes) ^ "/" ^
           (js_url |> Utility.strip_slashes) ^ "/" in


### PR DESCRIPTION
The handling of `jsliburl` was buggy in that slashes weren't properly handled in the case of a non-empty base URL. This manifested itself in lots of errors for new users who did not have `jsliburl` explicitly set to `/lib/`.

This patch fixes the handling (and the default value of the property) so the config need not explicitly contain `jsliburl` anymore.