### PR TITLE
Fix addAttributes

### DIFF
--- a/lib/js/jslib.js
+++ b/lib/js/jslib.js
@@ -2172,10 +2172,9 @@ function _addAttributes(xml, attrs) {
 
   const xmlItem = JSON.parse(JSON.stringify(first));
 
-  for (let attr in attrs) {
-    xmlItem.attrs[attr] = attrs[attr];
-  }
-
+  LINKEDLIST.forEach(attrs, function(a) {
+    xmlItem.attrs[a[1]] = a[2];
+  });
   return LINKEDLIST.singleton( xmlItem );
 }
 


### PR DESCRIPTION
Fixes #670. 

The issue was that the `addAttributes` function was not correctly implemented. Since I don't think any of us were aware of the sugar for allowing attribute lists, nobody noticed!

This patch correctly implements the logic needed for `addAttributes` to work.