### PR TITLE
Fix type variable name generation in error messages

### DIFF
--- a/core/irCheck.ml
+++ b/core/irCheck.ml
@@ -398,8 +398,10 @@ let eq_types occurrence : type_eq_context -> (Types.datatype * Types.datatype) -
 
 let check_eq_types (ctx : type_eq_context) et at occurrence =
   if not (eq_types occurrence ctx (et, at)) then
+    let exp_str = Types.string_of_datatype et in
+    let act_str = Types.string_of_datatype ~refresh_tyvar_names:false at in
     raise_ir_type_error
-      ("Type mismatch:\n Expected:\n  " ^ Types.string_of_datatype et ^ "\n Actual:\n  " ^ Types.string_of_datatype at)
+      ("Type mismatch:\n Expected:\n  " ^ exp_str ^ "\n Actual:\n  " ^ act_str)
       occurrence
 
 let check_eq_type_lists = fun (ctx : type_eq_context) exptl actl occurrence ->
@@ -422,7 +424,11 @@ let ensure_effect_present_in_row ctx allowed_effects required_effect_name requir
 let ensure_effect_rows_compatible ctx allowed_effects imposed_effects_row occurrence =
   ensure
     (eq_types occurrence ctx (`Record allowed_effects, `Record imposed_effects_row))
-    ("Incompatible effects; Allowed:\n" ^ (Types.string_of_row allowed_effects) ^ "\nactual effects:\n" ^  (Types.string_of_row imposed_effects_row))
+    (let allowed_str = Types.string_of_row allowed_effects in
+     let actual_str  = Types.string_of_row ~refresh_tyvar_names:true
+                                           imposed_effects_row in
+     "Incompatible effects:\n Allowed:\n  " ^ allowed_str ^
+     "\n Actual:\n  " ^ actual_str)
     occurrence
 
 
@@ -619,8 +625,13 @@ struct
               end
             else
               begin
-              ensure (eq_types (SVal orig) (o#extract_type_equality_context ()) (vt, t) || is_sub_type (vt, t)) (Printf.sprintf "coercion error: %s is not a subtype of %s"
-                                         (string_of_datatype vt) (string_of_datatype t)) (SVal orig);
+              ensure (eq_types (SVal orig) (o#extract_type_equality_context ())
+                               (vt, t) || is_sub_type (vt, t))
+                (let vt_str = string_of_datatype vt in
+                 let t_str  = string_of_datatype ~refresh_tyvar_names:true t in
+                 Printf.sprintf "coercion error: %s is not a subtype of %s"
+                                vt_str t_str)
+                (SVal orig);
               Coerce (v, t), t, o
               end
       in

--- a/core/typeSugar.ml
+++ b/core/typeSugar.ml
@@ -426,7 +426,7 @@ end
 
     (* Wrappers for generating type variable names *)
     let build_tyvar_names =
-      Types.build_tyvar_names Types.free_bound_type_vars
+      Types.build_tyvar_names ~refresh_tyvar_names:true Types.free_bound_type_vars
     let add_rowvar_names =
       Types.add_tyvar_names Types.free_bound_row_type_vars
     let add_typearg_names =

--- a/core/typeSugar.ml
+++ b/core/typeSugar.ml
@@ -426,11 +426,11 @@ end
 
     (* Wrappers for generating type variable names *)
     let build_tyvar_names =
-      Types.build_tyvar_names (Types.free_bound_type_vars ~include_aliases:true)
+      Types.build_tyvar_names Types.free_bound_type_vars
     let add_rowvar_names =
-      Types.add_tyvar_names (Types.free_bound_row_type_vars ~include_aliases:true)
+      Types.add_tyvar_names Types.free_bound_row_type_vars
     let add_typearg_names =
-      Types.add_tyvar_names (Types.free_bound_type_arg_type_vars ~include_aliases:true)
+      Types.add_tyvar_names Types.free_bound_type_arg_type_vars
 
     let die pos msg = raise (Errors.Type_error (pos, msg))
 

--- a/core/types.ml
+++ b/core/types.ml
@@ -2253,9 +2253,10 @@ let add_tyvar_names (f : 'a -> Vars.vars_list) (tys : 'a list) =
     * when printing error messages.  It then builds a consistent set of variable
       names for several different types appearing in the error message.
  *)
-let build_tyvar_names (f : 'a -> Vars.vars_list) (tys : 'a list) =
-  Vars.tyvar_name_counter := 0;
-  Hashtbl.reset Vars.tyvar_name_map;
+let build_tyvar_names ~refresh_tyvar_names (f : 'a -> Vars.vars_list)
+      (tys : 'a list) =
+  if refresh_tyvar_names then
+    begin Vars.tyvar_name_counter := 0; Hashtbl.reset Vars.tyvar_name_map; end;
   add_tyvar_names f tys
 
 (*
@@ -2280,7 +2281,7 @@ let string_of_datatype ?(policy=Print.default_policy) ?(refresh_tyvar_names=true
     let policy = policy () in
     let t = if policy.Print.quantifiers then t
             else Print.strip_quantifiers t in
-    if refresh_tyvar_names then build_tyvar_names (fun x -> free_bound_type_vars x) [t];
+    build_tyvar_names ~refresh_tyvar_names free_bound_type_vars [t];
     let context = Print.context_with_shared_effect policy (fun o -> o#typ t) in
     Print.datatype context (policy, Vars.tyvar_name_map) t
   else
@@ -2289,7 +2290,7 @@ let string_of_datatype ?(policy=Print.default_policy) ?(refresh_tyvar_names=true
 let string_of_row ?(policy=Print.default_policy) ?(refresh_tyvar_names=true) row =
   if Settings.get_value Basicsettings.print_types_pretty then
     let policy = policy () in
-    if refresh_tyvar_names then build_tyvar_names (fun x -> free_bound_row_type_vars x) [row];
+    build_tyvar_names ~refresh_tyvar_names free_bound_row_type_vars [row];
     let context = Print.context_with_shared_effect policy (fun o -> o#row row) in
     Print.row "," context (policy, Vars.tyvar_name_map) row
   else
@@ -2297,33 +2298,28 @@ let string_of_row ?(policy=Print.default_policy) ?(refresh_tyvar_names=true) row
 
 let string_of_presence ?(policy=Print.default_policy) ?(refresh_tyvar_names=true)
                        (f : field_spec) =
-  if refresh_tyvar_names then
-    build_tyvar_names (fun x -> free_bound_field_spec_type_vars x) [f];
+  build_tyvar_names ~refresh_tyvar_names free_bound_field_spec_type_vars [f];
   Print.presence Print.empty_context (policy (), Vars.tyvar_name_map) f
 
 let string_of_type_arg ?(policy=Print.default_policy) ?(refresh_tyvar_names=true)
                        (arg : type_arg) =
   let policy = policy () in
-  if refresh_tyvar_names then
-    build_tyvar_names (fun x -> free_bound_type_arg_type_vars x) [arg];
+  build_tyvar_names ~refresh_tyvar_names free_bound_type_arg_type_vars [arg];
   let context = Print.context_with_shared_effect policy (fun o -> o#type_arg arg) in
   Print.type_arg context (policy, Vars.tyvar_name_map) arg
 
 let string_of_row_var ?(policy=Print.default_policy) ?(refresh_tyvar_names=true) row_var =
-  if refresh_tyvar_names then
-    build_tyvar_names (fun x -> free_bound_row_var_vars x) [row_var];
+  build_tyvar_names ~refresh_tyvar_names free_bound_row_var_vars [row_var];
   match Print.row_var Print.name_of_type "," Print.empty_context (policy (), Vars.tyvar_name_map) row_var
   with | None -> ""
        | Some s -> s
 
 let string_of_tycon_spec ?(policy=Print.default_policy) ?(refresh_tyvar_names=true) (tycon : tycon_spec) =
-  if refresh_tyvar_names then
-    build_tyvar_names (fun x -> free_bound_tycon_type_vars x) [tycon];
+  build_tyvar_names ~refresh_tyvar_names free_bound_tycon_type_vars [tycon];
   Print.tycon_spec Print.empty_context (policy (), Vars.tyvar_name_map) tycon
 
 let string_of_quantifier ?(policy=Print.default_policy) ?(refresh_tyvar_names=true) (quant : quantifier) =
-  if refresh_tyvar_names then
-    build_tyvar_names (fun x -> free_bound_quantifier_vars x) [quant];
+  build_tyvar_names ~refresh_tyvar_names free_bound_quantifier_vars [quant];
   Print.quantifier (policy (), Vars.tyvar_name_map) quant
 
 

--- a/core/types.mli
+++ b/core/types.mli
@@ -357,7 +357,8 @@ val string_of_environment        : environment -> string
 val string_of_typing_environment : typing_environment -> string
 
 (** generating type variable names *)
-val build_tyvar_names : ('a -> Vars.vars_list)
+val build_tyvar_names : refresh_tyvar_names:bool
+                     -> ('a -> Vars.vars_list)
                      -> ('a list)
                      -> unit
 val add_tyvar_names : ('a -> Vars.vars_list)

--- a/core/types.mli
+++ b/core/types.mli
@@ -206,9 +206,9 @@ val empty_type : datatype
 val free_type_vars : datatype -> TypeVarSet.t
 val free_row_type_vars : row -> TypeVarSet.t
 val free_tyarg_vars : type_arg -> TypeVarSet.t
-val free_bound_type_vars     : ?include_aliases:bool -> typ -> Vars.vars_list
-val free_bound_row_type_vars : ?include_aliases:bool -> row -> Vars.vars_list
-val free_bound_type_arg_type_vars : ?include_aliases:bool -> type_arg -> Vars.vars_list
+val free_bound_type_vars          : typ      -> Vars.vars_list
+val free_bound_row_type_vars      : row      -> Vars.vars_list
+val free_bound_type_arg_type_vars : type_arg -> Vars.vars_list
 
 val var_of_quantifier : quantifier -> int
 val primary_kind_of_quantifier : quantifier -> PrimaryKind.t


### PR DESCRIPTION
This PR fixes a bug which made it non-straightforward to share variable names between two calls to `string_of_datatype`. I think the reason is that when I originally wrote name generation code I only focused on its use by grippers and didn't think that it might be used more widely. But now that we have the IR typechecker we get useless messages like:

```
Type mismatch:
 Expected:
  (229:(a::Any, b::Any) -c-> d::Any,230:a::Any)
 Actual:
  (229:(a::Any, b::Any) -c-> d::Any,230:a::Any)
```
Here both types are identical and that's because `string_of_datatype` generates a fresh set of variables for each call. With this PR we have:

```
Type mismatch:
 Expected:
  (229:(a::Any, b::Any) -c-> d::Any,230:a::Any)
 Actual:
  (229:(a::Any, b::Any) -e-> d::Any,230:a::Any)
```
which makes a lot more sense.

Also, I allowed myself to drop an unused `include_aliases` optional argument. It wasn't used (i.e. it was always `true`) and the possibility of having it set to `false` was marked as a bug in a comment.