### PR TITLE
Display an alert if `jslib` fails to load.

### DIFF
--- a/core/page.ml
+++ b/core/page.ml
@@ -87,6 +87,18 @@ module Make_RealPage (C : JS_PAGE_COMPILER) (G : JS_CODEGEN) = struct
                         ^ env
                         ^ head
                         ^ script_tag (String.concat "\n" defs)
+                        ^ "<script type=\"text/javascript\">
+                             'use strict';
+                             function _isRuntimeReady() {
+                                if (window._JSLIB === void 0 || window._JSLIB !== true) {
+                                   const msg = \"<h1>Fatal error: Runtime dependency `jslib.js' is not loaded.</h1>\";
+                                   document.body.innerHTML = msg;
+                                   document.head.innerHTML = msg;
+                                   return false;
+                                }
+                                return true;
+                             }
+                           </script>"
                      )
                    ^ "<body onload=\'" ^ onload ^ "\'>
   <script type='text/javascript'>
@@ -150,7 +162,7 @@ module Make_RealPage (C : JS_PAGE_COMPILER) (G : JS_CODEGEN) = struct
       ~html:(Value.string_of_xml ~close_tags:true bs)
       ~head:(script_tag welcome_msg ^ "\n" ^ script_tag (C.primitive_bindings) ^ "\n" ^ script_tag("  var _jsonState = " ^ state_string ^ "\n" ^ init_vars)
              ^ Value.string_of_xml ~close_tags:true hs)
-      ~onload:"_startRealPage()"
+      ~onload:"_isRuntimeReady() && _startRealPage()"
       ~external_files:deps
       []
 end

--- a/core/page.ml
+++ b/core/page.ml
@@ -91,7 +91,7 @@ module Make_RealPage (C : JS_PAGE_COMPILER) (G : JS_CODEGEN) = struct
                              'use strict';
                              function _isRuntimeReady() {
                                 if (window._JSLIB === void 0 || window._JSLIB !== true) {
-                                   const msg = \"<h1>Fatal error: Runtime dependency `jslib.js' is not loaded.</h1>\";
+                                   const msg = \"<h1>Startup error: Runtime dependency `jslib.js' is not loaded.</h1>\";
                                    document.body.innerHTML = msg;
                                    document.head.innerHTML = msg;
                                    return false;

--- a/lib/js/jslib.js
+++ b/lib/js/jslib.js
@@ -1,4 +1,6 @@
 'use strict';
+/* Magic constant -- used by the runtime to determine whether jslib has been loaded. */
+window._JSLIB = true;
 
 /* LIST MANIPULATING FUNCTIONS */
 const LINKEDLIST =  (function(){
@@ -15,8 +17,7 @@ const LINKEDLIST =  (function(){
 
 
     isLinkedList: function(v) {
-      return LINKEDLIST.isNil(v)
-        || v.hasOwnProperty("_head") && v.hasOwnProperty("_tail");
+      return LINKEDLIST.isNil(v) || v.hasOwnProperty("_head") && v.hasOwnProperty("_tail");
         //could test list-property recursively, but seems overly expensive
         //&& LINKEDLIST.isLinkedList(v._tail)
 


### PR DESCRIPTION
This patch instruments the Links web runtime with a "readiness check"
before calling `_startRealPage`. If the readiness check fails it emits
an error message (in HTML) and discontinues the start up process. As a
consequence Links will no longer render the user-defined webpage in
the event of the runtime dependency `jslib` failing to load. Instead the following error message is displayed:

```
<h1>Startup error: Runtime dependency `jslib.js' is not loaded.</h1>
```

Currently, the readiness check only checks whether `jslib` is
loaded. It could be extended to check whether alien JavaScript sources
have been loaded too. However, I think the page compiler is due a
refactor before we go down that path.

Resolves #590.