### PR TITLE
Specify the compatible version range of `dune`.

### DIFF
--- a/links-mysql.opam.unsupported
+++ b/links-mysql.opam.unsupported
@@ -15,7 +15,7 @@ build: [
 
 depends: [
   "ocaml" {>= "4.06.0"}
-  "dune" {build}
+  "dune" {build & >= "1.10.0"}
   "mysql"
   "links"
 ]

--- a/links-postgresql.opam
+++ b/links-postgresql.opam
@@ -16,7 +16,7 @@ build: [
 
 depends: [
   "ocaml" {>= "4.06.0"}
-  "dune" {build}
+  "dune" {build & >= "1.10.0"}
   "postgresql"
   "links"
 ]

--- a/links-sqlite3.opam
+++ b/links-sqlite3.opam
@@ -15,7 +15,7 @@ build: [
 
 depends: [
   "ocaml" {>= "4.06.0"}
-  "dune" {build}
+  "dune" {build & >= "1.10.0"}
   "sqlite3"
   "links"
 ]


### PR DESCRIPTION
We require `dune` as a build-time dependency. In our `dune-project`
file we specifically state that we use `dune` version `1.10.0` (I am
not sure whether that is strictly true, I suspect it may be an
over-approximation). However, in our `.opam` files we do not state any
bound on `dune`, hence OPAM is let to believe that Links can be built
using older versions of `dune`.

This patch makes explicit in the `.opam` files that we require at
least version `1.10.0` of `dune` to build Links.