### PR TITLE
Remove the option `realpages`.

### DIFF
--- a/core/basicsettings.ml
+++ b/core/basicsettings.ml
@@ -270,11 +270,6 @@ module Generalise = struct
   let show_generalisation = Settings.add_bool("show_generalisation", false, `User)
 end
 
-(* Webif stuff *)
-module Webif = struct
-  let realpages = Settings.add_bool ("realpages", false, `System)
-end
-
 (* Json stuff *)
 module Json = struct
   let show_json = Settings.add_bool("show_json", false, `User)

--- a/core/webif.ml
+++ b/core/webif.ml
@@ -7,7 +7,6 @@ open ProcessTypes
 open Webserver_types
 open Utility
 
-let realpages = Basicsettings.Webif.realpages
 let ( >>= ) = Lwt.bind
 
 module WebIf = functor (Webs : WEBSERVER) ->

--- a/core/webif.mli
+++ b/core/webif.mli
@@ -2,8 +2,6 @@
 
 open Webserver_types
 
-val realpages : bool Settings.setting
-
 module WebIf : functor (Webs : WEBSERVER) ->
 sig
 


### PR DESCRIPTION
The option `realpages` used to govern whether Links would serve
web pages built on the server or build them dynamically on the 
client. The option appears to have been unused (and unsupported)
for a while. Although, the default value of `realpages` was `false`
the Links appserver would always serve pages built on the server.

This patch removes the option altogether.