### PR TITLE
Untag `dune` as a build-time dependency.

### DIFF
--- a/links-mysql.opam.unsupported
+++ b/links-mysql.opam.unsupported
@@ -15,7 +15,7 @@ build: [
 
 depends: [
   "ocaml" {>= "4.06.0"}
-  "dune" {build & >= "1.10.0"}
+  "dune" {>= "1.10.0"}
   "mysql"
   "links"
 ]

--- a/links-postgresql.opam
+++ b/links-postgresql.opam
@@ -16,7 +16,7 @@ build: [
 
 depends: [
   "ocaml" {>= "4.06.0"}
-  "dune" {build & >= "1.10.0"}
+  "dune" {>= "1.10.0"}
   "postgresql"
   "links"
 ]

--- a/links-sqlite3.opam
+++ b/links-sqlite3.opam
@@ -15,7 +15,7 @@ build: [
 
 depends: [
   "ocaml" {>= "4.06.0"}
-  "dune" {build & >= "1.10.0"}
+  "dune" {>= "1.10.0"}
   "sqlite3"
   "links"
 ]

--- a/links.opam
+++ b/links.opam
@@ -18,7 +18,7 @@ build: [
 
 depends: [
   "ocaml" {>= "4.06.0"}
-  "dune" {build & >= "1.10.0"}
+  "dune" {>= "1.10.0"}
   "ppx_deriving"
   "ppx_deriving_yojson" {>= "3.3"}
   "base64"


### PR DESCRIPTION
[Supposedly `dune` no longer satisfies the OPAM definition of a build-time dependency](https://github.com/ocaml/opam-repository/pull/14501#issuecomment-515951073),
hence we should make it a runtime dependency.

This patch removes `build` tag from the `.opam`-files such that `dune`
becomes a runtime dependency.