### PR TITLE
Decouple IR type structure simplifications from IR type checking.

### DIFF
--- a/core/basicsettings.ml
+++ b/core/basicsettings.ml
@@ -263,6 +263,7 @@ module Ir = struct
   let typecheck_ir = Settings.add_bool("typecheck_ir", false, `User)
   (* Abort compilation on IR typing error *)
   let fail_on_ir_type_error = Settings.add_bool("fail_on_ir_type_error", false, `User)
+  let simplify_types = Settings.add_bool("simplify_types", false, `User)
 end
 
 (* Generalise stuff *)


### PR DESCRIPTION
This patch resolves #561 by separating the type structure
simplification pass from the IR type checker. A new flag
`simplify_types` is introduced which dictates whether the
simplification pass is run -- well that is, it runs if the flag is set
or `typecheck_ir` is set as I am not sure whether the IR type checker
depends on the simplification pass.

The patch also fixes a couple of issues with side effects in the IR
backend pipeline infrastructure. As settings `typecheck_ir` and
`show_compiled_ir_after_backend_transformations` had no effect if
Links was not booted with those settings set to true, meaning that
they could not be toggled from within the REPL. This is rectified by
replaying the side effects whenever a backend pipeline is invoked.