### PR TITLE
Bump development version 0.9 -> 0.9.1

### DIFF
--- a/core/basicsettings.ml
+++ b/core/basicsettings.ml
@@ -97,7 +97,7 @@ module DatabaseDrivers = struct
 end
 
 (** The banner *)
-let version = "0.9 (Burghmuirhead)"
+let version = "0.9.1 (Burghmuirhead)"
 let welcome_note = Settings.add_string ("welcome_note",
 " _     _ __   _ _  __  ___\n\
  / |   | |  \\ | | |/ / / ._\\\n\

--- a/links.opam
+++ b/links.opam
@@ -7,7 +7,7 @@ homepage: "https://github.com/links-lang/links"
 dev-repo: "git+https://github.com/links-lang/links.git"
 bug-reports: "https://github.com/links-lang/links/issues"
 license: "GPL-2"
-version: "0.9"
+version: "0.9.1"
 
 
 build: [


### PR DESCRIPTION
Now that Links 0.9 is released, we can bump revision number such that development happens on 0.9.1.