### PR TITLE
Restore the constancy between `run-tests` and `test-harness`.

### DIFF
--- a/run-tests
+++ b/run-tests
@@ -45,9 +45,6 @@ fi
 if [[ "$1" != "db-only" ]]; then
     for i in tests/*.tests; do
         cmnd="./test-harness $i"
-        if [[ -f "$i.config" ]]; then
-            cmnd="$cmnd $i.config"
-        fi
         echo cmnd=$cmnd
         eval $cmnd
         ret_code=$?

--- a/test-harness
+++ b/test-harness
@@ -4,6 +4,7 @@ links = './links'
 
 import sys, re, time
 import concurrent.futures, threading, multiprocessing
+from os import path
 from subprocess import Popen, PIPE
 
 successes = failures = ignored = 0
@@ -121,9 +122,12 @@ def main():
         filename = sys.argv[1]
         config_file =  sys.argv[2]
     elif len(sys.argv) == 2:
-        filename =  sys.argv[1]
+        filename = sys.argv[1]
     else:
         raise SystemExit('Usage: run <test file> [<links config file>]')
+
+    if path.exists(filename + ".config"):
+        config_file = filename + ".config"
 
     cpus=multiprocessing.cpu_count()
     tp = concurrent.futures.ThreadPoolExecutor(max_workers=cpus)


### PR DESCRIPTION
This patch moves the logic for discovering configs associated with
test scripts from `run-tests` into `test-harness`. As a result
`./test-harness tests/<testname>.tests` will now run correctly when
the tests are expected to be run with a particular configuration.

Resolves #720.