### PR TITLE
Endow testscripts with an optional header section.

### DIFF
--- a/test-harness
+++ b/test-harness
@@ -27,7 +27,7 @@ def parse(stream):
     are auxiliary options"""
     def tests():
         tests = []
-        for line in stream.readlines():
+        for line in stream:
             if not str.strip(line) and tests[-1]:
                 yield tests
                 tests = []
@@ -115,6 +115,34 @@ def evaluate(name, code, config_file, stdout='', stderr='', exit = '0', env = No
         failures += 1
         print('!FAILURE: %s [TIMED OUT]' % name)
 
+def peek_line(f):
+    pos = f.tell()
+    line = f.readline()
+    f.seek(pos)
+    return line
+
+def parseTestScript(stream):
+    header = dict()
+    if peek_line(stream) == "---\n":
+        stream.readline()
+        line_num = 1
+        line = peek_line(stream)
+        while not (line == "---\n"):
+            raw_line = stream.readline()
+            line_num += 1
+            line = str.strip(raw_line)
+            keyvalue = list(map(str.strip, str.split(line, ':', 1)))
+            if len(keyvalue) == 2:
+                header[keyvalue[0]] = keyvalue[1]
+            else:
+                raise SystemExit("Syntax error on line " + str(line_num) + ": " + raw_line)
+            line = peek_line(stream)
+        stream.readline()
+        stream.readline()
+    yield header
+    yield from parse(stream)
+
+
 def main():
     config_file = None
 
@@ -126,12 +154,17 @@ def main():
     else:
         raise SystemExit('Usage: run <test file> [<links config file>]')
 
-    if path.exists(filename + ".config"):
-        config_file = filename + ".config"
-
     cpus=multiprocessing.cpu_count()
     tp = concurrent.futures.ThreadPoolExecutor(max_workers=cpus)
-    for name, code, opts in parse(open(filename, 'r')):
+
+    stream = parseTestScript(open(filename, 'r'))
+    # Process the header, if any.
+    header = next(stream)
+    if config_file == None and "config" in header:
+        config_file = header["config"]
+
+    # Process the body.
+    for name, code, opts in stream:
         # enqueues execution of
         # evaluate(name, code, config_file, **opts)
         # in the thread pool

--- a/tests/freezeml.tests
+++ b/tests/freezeml.tests
@@ -1,3 +1,7 @@
+---
+config: tests/freezeml.tests.config
+---
+
 Polymorphic Instantiation (1)
 fun(x)(y) { y }
 stdout : fun : forall a,b::Row,c::(Any,Any),d::Row.(a) -b-> (c::Any) -d-> c::Any

--- a/tests/typed_ir.tests
+++ b/tests/typed_ir.tests
@@ -1,3 +1,7 @@
+---
+config: tests/typed_ir.tests.config
+---
+
 Anonymous constant function
 fun (x) {1}
 stdout : fun : (_::(Unl,Mono)) -> Int


### PR DESCRIPTION
This patch aims to remove some of the "magic" in the test suite
runners. Specifically, this patch augments our ad-hoc testscript
language with an optional header section, which contains key value
pairs (currently only "config: path/to/file.config" is supported) that
can be used to fix parameters globally for the tests in the respective
script. So if a script uses a particular config file it has to be
listed explicitly in the script header.

Syntactically a header is surrounded by a pair of `---` followed by a
blank line. A header may only contain key-value pairs of the form
`key: value`. This syntax is adopted directly from the Markdown header
format. Example:

```
---
config: tests/typed_ir.tests.config
---

Anonymous constant function
fun(x) {1}
stdout : fun : (_::(Unl,Mono)) -> Int
```

It is possible to override the value of the `config` key by explicitly
passing the name of a configuration file as a command line
argument. For example the following command

```
$ ./test-harness tests/typed_ir.tests tests/typed_ir.tests.config-alternative
```

would run `typed_ir.tests` with the alternative configuration file. 