### PR TITLE
Fix #619

### DIFF
--- a/core/query/query.ml
+++ b/core/query/query.ml
@@ -58,8 +58,8 @@ let unbox_pair =
           x, y
     | _ -> raise (runtime_type_error "failed to unbox pair")
 
-let rec unbox_list x =
-  match x with
+let rec unbox_list =
+  function
     | Q.Concat vs -> concat_map unbox_list vs
     | Q.Singleton v -> [v]
     | _ -> raise (runtime_type_error "failed to unbox list")

--- a/core/query/query.ml
+++ b/core/query/query.ml
@@ -58,8 +58,8 @@ let unbox_pair =
           x, y
     | _ -> raise (runtime_type_error "failed to unbox pair")
 
-let rec unbox_list =
-  function
+let rec unbox_list x =
+  match x with
     | Q.Concat vs -> concat_map unbox_list vs
     | Q.Singleton v -> [v]
     | _ -> raise (runtime_type_error "failed to unbox list")
@@ -632,6 +632,8 @@ struct
       reduce_or (v, w)
     | Primitive "==", [v; w] ->
       reduce_eq (v, w)
+    | Primitive "stringToXml", [v] ->
+      Q.Singleton (XML (Value.Text (unbox_string v)))
     | Primitive f, args ->
         Apply (f, args)
     | If (c, t, e), args ->

--- a/tests/database.tests
+++ b/tests/database.tests
@@ -2,3 +2,38 @@ Orderby clause (not a semantic test, just syntax)
 for (x <- [1, 2, 3]) orderby (x) [x]
 stdout : [1, 2, 3] : [Int]
 exit : 0
+
+XML literals in query blocks (1)
+query { for (x <- [(<a>asdf</a>)]) [(b=2)] }
+stdout : [(b = 2)] : [(b:Int)]
+exit : 0
+
+XML literals in query blocks (2)
+query { for (x <- (<a>asdf</a>)) [(b=2)] }
+stdout : [(b = 2)] : [(b:Int)]
+exit : 0
+
+XML literals in query blocks (3)
+query { for (x <- (<a>asdf</a>)) [(b=2)] }
+stdout : [(b = 2)] : [(b:Int)]
+exit : 0
+
+XML literals in query blocks (4)
+query {var x = <a>asdf</a>; [(a=1)]}
+stdout : [(a = 1)] : [(a:Int)]
+exit : 0
+
+XML literals in query blocks (5)
+query {var x = <a href="foo.com">asdf</a>; [(a=1)]}
+stdout : [(a = 1)] : [(a:Int)]
+exit : 0
+
+XML literals in query blocks (6)
+query {var x = <a href="foo.com">{stringToXml("asdf")}</a>; [(a=1)]}
+stdout : [(a = 1)] : [(a:Int)]
+exit : 0
+
+XML literals in query blocks (6)
+query {var x = <a {[("href", "foo.com")]}>{stringToXml("asdf")}</a>; [(a=1)]}
+stdout : [(a = 1)] : [(a:Int)]
+exit : 0


### PR DESCRIPTION
A bug which has been nagging me for a while because soundness errors make me sad. 
One of those bugs where the fix is straightforward, but diagnosing and
debugging is less so.

Turns out that we need to implement the `stringToXml` function during
query normalisation, otherwise evaluation gets stuck, and we end up with what looks like a soundness bug (but in fact is due to an unevaluated application of a primitive).