### PR TITLE
Prepare for Lwt 5.0.0.

### DIFF
--- a/core/proc.ml
+++ b/core/proc.ml
@@ -199,18 +199,26 @@ struct
       begin
         let (t, w) = Lwt.task () in
         Hashtbl.add state.angels new_pid t;
-        async (fun () -> Lwt.with_value current_pid_key (Some new_pid)
-                          (fun () -> Lwt.with_value angel_done (Some w) pstate))
+        async (fun () ->
+            Lwt.with_value current_pid_key (Some new_pid)
+              (fun () -> Lwt.with_value angel_done (Some w) pstate) >>= fun _ ->
+            Lwt.return_unit)
       end
     else
-      async (fun () -> Lwt.with_value current_pid_key (Some new_pid) pstate);
+      async (fun () ->
+          Lwt.with_value current_pid_key (Some new_pid) pstate >>= fun _ ->
+          Lwt.return_unit
+        );
     Lwt.return new_pid
 
   (** Creates a spawnWait process *)
   let create_spawnwait_process parent_pid pstate =
     let new_pid = ProcessID.create () in
     Hashtbl.add state.spawnwait_processes new_pid (parent_pid, None);
-    async (fun () -> Lwt.with_value current_pid_key (Some new_pid) pstate);
+    async (fun () ->
+        Lwt.with_value current_pid_key (Some new_pid) pstate >>= fun _ ->
+        Lwt.return_unit
+      );
     Lwt.return new_pid
 
   (* Grabs the result of a finished spawnWait process *)


### PR DESCRIPTION
This patch is a response to ocsigen/lwt/issues/603. Lwt 5.0.0 will
introduce a breaking change as the signature of `Lwt.async` changes
from

```ocaml
val async : (unit -> 'a Lwt.t) -> unit
```

to

```ocaml
val async : (unit -> unit Lwt.t) -> unit
```

This patch simply post-composes `>>= fun _ -> Lwt.return_unit` to the
bodies of the function arguments where necessary.