### PR TITLE
Fix #383

### DIFF
--- a/core/json.mli
+++ b/core/json.mli
@@ -62,3 +62,5 @@ val jsonize_call :
   string -> (* Name of the function *)
   Value.t list -> (* Arguments *)
   json_string
+
+val js_dq_escape_string : json_string -> json_string

--- a/core/webif.ml
+++ b/core/webif.ml
@@ -167,13 +167,18 @@ struct
       (fun () -> perform_request valenv run render_cont render_servercont_cont request )
       (fun e ->
         if (is_ajax_call cgi_args) then
-          let formatted_exn =
-            Errors.format_exception e
-            |> Json.js_dq_escape_string in
-          let error_json =
-            "{ \"error\": \"" ^ formatted_exn ^ "\"}" in
-          Lwt.return
-            ("text/plain", Utility.base64encode (error_json))
+          begin
+            match e with
+             | Aborted r -> Lwt.return r
+             | e ->
+                let formatted_exn =
+                  Errors.format_exception e
+                  |> Json.js_dq_escape_string in
+                let error_json =
+                  "{ \"error\": \"" ^ formatted_exn ^ "\"}" in
+                Lwt.return
+                  ("text/plain", Utility.base64encode (error_json))
+          end
         else
           begin
             let mime_type = "text/html; charset=utf-8" in

--- a/core/webif.mli
+++ b/core/webif.mli
@@ -5,7 +5,7 @@ open Webserver_types
 module WebIf : functor (Webs : WEBSERVER) ->
 sig
 
-  val should_contain_client_id : (string * string) list -> bool
+  val is_ajax_call : (string * string) list -> bool
 
   val do_request :
     (Value.env * Ir.var Env.String.t * Types.typing_environment) ->

--- a/core/webserver.ml
+++ b/core/webserver.ml
@@ -126,7 +126,7 @@ struct
 
 
   let get_or_make_client_id cgi_args =
-    if (Webif.should_contain_client_id cgi_args) then
+    if (Webif.is_ajax_call cgi_args) then
       get_client_id_or_die cgi_args
     else
       ClientID.create ()

--- a/lib/js/jslib.js
+++ b/lib/js/jslib.js
@@ -640,7 +640,6 @@ const LINKS = new (function() {
    * @param {any} kappa local (client) continuation, for use when the server is really finished
    * @param {any} continuation server-side continuation which the server asked client to invoke it with
    * @param {any} mailbox
-   * @param {boolean} sync
    */
   function _remoteContinue (kappa, continuation, mailbox) {
     return _makeCont(function (res) {
@@ -838,7 +837,6 @@ const LINKS = new (function() {
    *
    * @param {any} kappa
    * @param {any} callPackage
-   * @param {any} sync
    */
   function _invokeClientCall (kappa, callPackage) {
     DEBUG.debug('Invoking client call to ', callPackage.__name);
@@ -888,6 +886,11 @@ const LINKS = new (function() {
         // Any state that we need for resolving values
         // (currently just a mapping between server and client pids)
         const state = { mobileKeys: { } };
+
+        if (serverResponse.content.hasOwnProperty("error")) {
+          const gripe = serverResponse.content.error;
+          throw new Error("Fatal error: call to server returned an error. Details: " + gripe);
+        }
 
         resolveMobileState(
           state,


### PR DESCRIPTION
The issue was that Lwt.catch was not discriminating between request
types, and was thus responding with a plain HTML page when it should
have been responding with a b64-encoded JSON string.

This patch ensures that the correct error is thrown in the console.