### PR TITLE
Add log10 function

### DIFF
--- a/core/lib.ml
+++ b/core/lib.ml
@@ -1175,6 +1175,7 @@ let env : (string * (located_primitive * Types.datatype * pure)) list = [
   "sin",     float_fn sin PURE;
   "tan",     float_fn tan PURE;
   "log",     float_fn log PURE;
+  "log10",   float_fn log10 PURE;
   "sqrt",    float_fn sqrt PURE;
 
   ("environment",

--- a/lib/js/jslib.js
+++ b/lib/js/jslib.js
@@ -3685,6 +3685,7 @@ var _tan = Math.tan; var tan = LINKS.kify(_tan);
 var _sin = Math.sin; var sin = LINKS.kify(_sin);
 var _cos = Math.cos; var cos = LINKS.kify(_cos);
 var _log = Math.log; var log = LINKS.kify(_log);
+var _log10 = Math.log10; var log10 = LINKS.kify(_log10);
 
 function _makeCgiEnvironment() {
   var env = [];


### PR DESCRIPTION
This simple patch adds the `log10` function, found in both the OCaml and JS libraries, to Links.