### PR TITLE
Compile session exceptions using deep handlers

### DIFF
--- a/core/desugarSessionExceptions.ml
+++ b/core/desugarSessionExceptions.ml
@@ -122,7 +122,7 @@ object (o : 'self_type)
           (inner_effects, try_dt, outer_effects, otherwise_dt) in
 
         let hndl_desc = {
-          shd_depth = Shallow;
+          shd_depth = Deep;
           shd_types = types;
           shd_raw_row = raw_row;
           shd_params = None;


### PR DESCRIPTION
There is an arbitrary choice as to whether to compile session exceptions
using deep or shallow handlers. I switched this to Shallow at some
point, and since then it seems that shallow handlers no longer compile
on the client.

(Unfortunately, this means that session exceptions are broken in 0.9).
This patch switches them back to deep.