### PR TITLE
Print an error message if database driver loading fails

### DIFF
--- a/core/errors.ml
+++ b/core/errors.ml
@@ -49,6 +49,14 @@ exception ModuleError of string * Position.t option
 exception DisabledExtension of Position.t option * (string * bool) option * string option * string
 exception PrimeAlien of Position.t
 
+exception LocateFailure of string
+let driver_locate_failure driver = LocateFailure driver
+exception IllformedPluginDescription of string
+let illformed_plugin_description plugin = IllformedPluginDescription plugin
+exception DependencyLoadFailure of string * Dynlink.error
+let dependency_load_failure file err = DependencyLoadFailure (file, err)
+exception LoadFailure of string * Dynlink.error
+let load_failure file err = LoadFailure (file, err)
 
 let prefix_lines prefix s =
   prefix ^ Str.global_replace (Str.regexp "\n") ("\n" ^ prefix) s
@@ -164,6 +172,14 @@ let format_exception =
        Printf.sprintf "Syntax error: Foreign binders cannot contain single quotes `'`.\nIn expression: %s." expr
      in
      pos_prefix ~pos message
+  | LocateFailure driver ->
+     pos_prefix (Printf.sprintf "Error: Cannot locate database driver '%s'\n" driver)
+  | IllformedPluginDescription file ->
+     pos_prefix (Printf.sprintf "Error: The database driver description '%s' is illformed\n" file)
+  | DependencyLoadFailure (file, err) ->
+     pos_prefix (Printf.sprintf "Error: Cannot load plugin dependency '%s' (link error: %s)\n" file (Dynlink.error_message err))
+  | LoadFailure (file, err) ->
+     pos_prefix (Printf.sprintf "Error: Cannot load plugin '%s' (link error: %s)\n" file (Dynlink.error_message err))
   | Sys.Break -> "Caught interrupt"
   | exn -> pos_prefix ("Error: " ^ Printexc.to_string exn)
 

--- a/core/errors.mli
+++ b/core/errors.mli
@@ -50,3 +50,7 @@ val dynlink_error: string -> exn
 val module_error : ?pos:Position.t -> string -> exn
 val disabled_extension : ?pos:Position.t -> ?setting:(string * bool) -> ?flag:string -> string -> exn
 val prime_alien : Position.t -> exn
+val driver_locate_failure : string -> exn
+val illformed_plugin_description : string -> exn
+val dependency_load_failure : string -> Dynlink.error -> exn
+val load_failure : string -> Dynlink.error -> exn

--- a/core/utility.ml
+++ b/core/utility.ml
@@ -1273,7 +1273,10 @@ end = struct
     type t = link_t
 
     let follow link =
-      let node = Unix.stat (to_filename link) in
+      let node =
+        try Unix.stat (to_filename link)
+        with Unix.Unix_error _ -> raise (AccessError (to_filename link))
+      in
       match node.st_kind with
       | S_REG -> make_file node.st_ino (File.make link.root link.rev_suffix)
       | S_DIR -> make_dir node.st_ino (Directory.make link.root link.rev_suffix)


### PR DESCRIPTION
This patch slightly improves error messages when Links fails to load a
database driver. Beforehand a raw exception would be printed to
stderr. With this patch a standard error message, conforming with the
style of messages in `errors.ml`, is printed.

For example, before Links would print `LocateFailure "postgresql"`
when it failed to locate the `postgresql` driver, now it will print

```
***: Error: Cannot locate database driver 'postgresql'
```

Resolves #746