### PR TITLE
Support flat and shredded queries simultaneously (Fix #538)

### DIFF
--- a/core/channelVarUtils.ml
+++ b/core/channelVarUtils.ml
@@ -68,7 +68,7 @@ let variables_in_computation comp =
     | Select (_, value) -> traverse_value value
     | Wrong _ -> ()
     | Table (v1, v2, v3, _) -> List.iter (traverse_value) [v1; v2; v3]
-    | Query (vs_opt, comp, _) ->
+    | Query (vs_opt, _, comp, _) ->
         OptionUtils.opt_iter
           (fun (v1, v2) -> List.iter (traverse_value) [v1; v2]) vs_opt;
         traverse_computation comp

--- a/core/closures.ml
+++ b/core/closures.ml
@@ -132,7 +132,7 @@ struct
             let o1 = o#typ (`Type t1) in
             let o2 = o1#typ (`Type t2) in
             o2#typ (`Type t3)
-          | Query (_, _, t)
+          | Query (_, _, _, t)
           | DoOperation (_, _, t) ->
             o#typ (`Type t)
           | _ -> o in

--- a/core/commonTypes.ml
+++ b/core/commonTypes.ml
@@ -212,6 +212,6 @@ module Constant = struct
 end
 
 module QueryPolicy = struct
-  type t = Plain | Nested | Default
+  type t = Flat | Nested | Default
     [@@deriving show]
 end

--- a/core/commonTypes.ml
+++ b/core/commonTypes.ml
@@ -210,3 +210,8 @@ module Constant = struct
     | String s    -> "'" ^ escape_string s ^ "'"
     | Float value -> string_of_float' value
 end
+
+module QueryPolicy = struct
+  type t = Plain | Nested | Default
+    [@@deriving show]
+end

--- a/core/evalir.ml
+++ b/core/evalir.ml
@@ -702,10 +702,10 @@ struct
        let evaluator =
          let open QueryPolicy in
          match policy with
-           | Plain -> `Plain
+           | Flat -> `Flat
            | Nested -> `Nested
            | Default ->
-               if Settings.get Database.shredding then `Nested else `Plain in
+               if Settings.get Database.shredding then `Nested else `Flat in
 
        let evaluate_standard () =
          match EvalQuery.compile env (range, e) with
@@ -757,7 +757,7 @@ struct
 
        begin
          match evaluator with
-           | `Plain -> evaluate_standard ()
+           | `Flat -> evaluate_standard ()
            | `Nested -> evaluate_nested ()
        end
     | InsertRows (source, rows) ->

--- a/core/evalir.ml
+++ b/core/evalir.ml
@@ -693,15 +693,41 @@ struct
             in apply_cont cont env (`Table ((db, params), Value.unbox_string name, unboxed_keys, row))
           | _ -> eval_error "Error evaluating table handle"
       end
-    | Query (range, e, _t) ->
+    | Query (range, policy, e, _t) ->
        let range =
          match range with
          | None -> None
          | Some (limit, offset) ->
             Some (Value.unbox_int (value env limit), Value.unbox_int (value env offset)) in
-       if Settings.get Database.shredding then
-         begin
-           if range != None then eval_error "Range is not supported for nested queries";
+       let evaluator =
+         let open QueryPolicy in
+         match policy with
+           | Plain -> `Plain
+           | Nested -> `Nested
+           | Default ->
+               if Settings.get Database.shredding then `Nested else `Plain in
+
+       let evaluate_standard () =
+         match EvalQuery.compile env (range, e) with
+           | None -> computation env cont e
+           | Some (db, q, t) ->
+               let q = Sql.string_of_query db range q in
+               let (fieldMap, _, _), _ =
+               Types.unwrap_row(TypeUtils.extract_row t) in
+               let fields =
+               StringMap.fold
+                   (fun name t fields ->
+                     match t with
+                     | `Present t -> (name, t)::fields
+                     | `Absent -> assert false
+                     | `Var _ -> assert false)
+                   fieldMap
+                   []
+               in
+               apply_cont cont env (Database.execute_select fields q db) in
+
+       let evaluate_nested () =
+         if range != None then eval_error "Range is not supported for nested queries";
            match EvalNestedQuery.compile_shredded env e with
            | None -> computation env cont e
            | Some (db, p) ->
@@ -727,28 +753,13 @@ struct
                     "The database driver '%s' does not support shredding."
                     (db#driver_name ())
                 in
-                raise (Errors.runtime_error error_msg)
-           end
-       else (* shredding disabled *)
-         begin
-           match EvalQuery.compile env (range, e) with
-           | None -> computation env cont e
-           | Some (db, q, t) ->
-               let q = Sql.string_of_query db range q in
-               let (fieldMap, _, _), _ =
-               Types.unwrap_row(TypeUtils.extract_row t) in
-               let fields =
-               StringMap.fold
-                   (fun name t fields ->
-                     match t with
-                     | `Present t -> (name, t)::fields
-                     | `Absent -> assert false
-                     | `Var _ -> assert false)
-                   fieldMap
-                   []
-               in
-               apply_cont cont env (Database.execute_select fields q db)
-         end
+                raise (Errors.runtime_error error_msg) in
+
+       begin
+         match evaluator with
+           | `Plain -> evaluate_standard ()
+           | `Nested -> evaluate_nested ()
+       end
     | InsertRows (source, rows) ->
         begin
           match value env source, value env rows with

--- a/core/ir.ml
+++ b/core/ir.ml
@@ -79,7 +79,7 @@ and special =
   | LensGet    of value * Types.datatype
   | LensPut    of value * value * Types.datatype
   | Table      of value * value * value * (Types.datatype * Types.datatype * Types.datatype)
-  | Query      of (value * value) option * computation * Types.datatype
+  | Query      of (value * value) option * QueryPolicy.t * computation * Types.datatype
   | InsertRows of value * value
   | InsertReturning of value * value * value
   | Update     of (binder * value) * computation option * computation

--- a/core/ir.mli
+++ b/core/ir.mli
@@ -80,7 +80,7 @@ and special =
   | LensGet    of value * Types.datatype
   | LensPut    of value * value * Types.datatype
   | Table      of value * value * value * (Types.datatype * Types.datatype * Types.datatype)
-  | Query      of (value * value) option * computation * Types.datatype
+  | Query      of (value * value) option * QueryPolicy.t * computation * Types.datatype
   | InsertRows of value * value
   | InsertReturning of value * value * value
   | Update     of (binder * value) * computation option * computation

--- a/core/irCheck.ml
+++ b/core/irCheck.ml
@@ -752,7 +752,7 @@ struct
                From an implementation perspective, we should check the consistency of the read, write, needed info here *)
               Table (db, table_name, keys, tt), `Table tt, o
 
-        | Query (range, e, original_t) ->
+        | Query (range, policy, e, original_t) ->
             let range, o =
               o#optionu
                 (fun o (limit, offset) ->
@@ -780,7 +780,7 @@ struct
               let row = TypeUtils.extract_row list_content_type in
               ensure (Types.Base.row_satisfies row) "Only base types allowed in query result record" (SSpec special));
 
-              Query (range, e, t), t, o
+              Query (range, policy, e, t), t, o
 
         | InsertRows (source, rows)
 	| InsertReturning (source, rows, _) ->

--- a/core/irTraversals.ml
+++ b/core/irTraversals.ml
@@ -339,7 +339,7 @@ struct
             let lens, _, o = o#value lens in
             let data, _, o = o#value data in
             LensPut (lens, data, rtype), Types.make_tuple_type [], o
-        | Query (range, e, _) ->
+        | Query (range, policy, e, _) ->
             let range, o =
               o#optionu
                 (fun o (limit, offset) ->
@@ -348,7 +348,7 @@ struct
                      (limit, offset), o)
                 range in
             let e, t, o = o#computation e in
-              Query (range, e, t), t, o
+              Query (range, policy, e, t), t, o
         | InsertRows (source, rows) ->
             let source, _, o = o#value source in
 	    let rows, _, o = o#value rows in
@@ -838,9 +838,9 @@ let ir_type_mod_visitor tyenv type_visitor =
                let (t2, _) = type_visitor#typ t2 in
                let (t3, _) = type_visitor#typ t3 in
                super#special (Table (v1, v2, v3, (t1, t2, t3)))
-            | Query (opt, computation, datatype) ->
+            | Query (opt, policy, computation, datatype) ->
                let (datatype, _) = type_visitor#typ datatype in
-               super#special (Query (opt, computation, datatype))
+               super#special (Query (opt, policy, computation, datatype))
             | DoOperation (name, vallist, datatype) ->
                let (datatype, _) = type_visitor#typ datatype in
                super#special (DoOperation (name, vallist, datatype))

--- a/core/lexer.mll
+++ b/core/lexer.mll
@@ -198,6 +198,7 @@ let keywords = [
  "mu"       , MU;
  "mutual"   , MUTUAL;
  "native"   , NATIVE;
+ "nested"   , NESTED;
  "nu"       , NU;
  "offer"    , OFFER;
  "on"       , ON;
@@ -206,6 +207,7 @@ let keywords = [
  "open"     , OPEN;
  "otherwise", OTHERWISE;
  "page"     , PAGE;
+ "plain"    , PLAIN;
  "query"    , QUERY;
  "raise"    , RAISE;
  "readonly" , READONLY;

--- a/core/lexer.mll
+++ b/core/lexer.mll
@@ -198,7 +198,6 @@ let keywords = [
  "mu"       , MU;
  "mutual"   , MUTUAL;
  "native"   , NATIVE;
- "nested"   , NESTED;
  "nu"       , NU;
  "offer"    , OFFER;
  "on"       , ON;
@@ -207,7 +206,6 @@ let keywords = [
  "open"     , OPEN;
  "otherwise", OTHERWISE;
  "page"     , PAGE;
- "plain"    , PLAIN;
  "query"    , QUERY;
  "raise"    , RAISE;
  "readonly" , READONLY;

--- a/core/parser.mly
+++ b/core/parser.mly
@@ -254,6 +254,7 @@ end
 %token SEMICOLON
 %token TRUE FALSE
 %token BARBAR AMPAMP
+%token PLAIN NESTED
 %token <int> UINTEGER
 %token <float> UFLOAT
 %token <string> STRING CDATA REGEXREPL
@@ -568,13 +569,18 @@ spawn_expression:
 | SPAWNCLIENT block                                            { spawn ~ppos:$loc Demon  SpawnClient               $2 }
 | SPAWNWAIT   block                                            { spawn ~ppos:$loc Wait   NoSpawnLocation           $2 }
 
+query_policy:
+| PLAIN                                                        { QueryPolicy.Plain }
+| NESTED                                                       { QueryPolicy.Nested }
+| /* empty */                                                  { QueryPolicy.Default }
+
 postfix_expression:
 | primary_expression | spawn_expression                        { $1 }
 | primary_expression POSTFIXOP                                 { unary_appl ~ppos:$loc (UnaryOp.Name $2) $1 }
 | block                                                        { $1 }
-| QUERY block                                                  { query ~ppos:$loc None $2 }
-| QUERY LBRACKET exp RBRACKET block                            { query ~ppos:$loc (Some ($3, with_pos $loc (Constant (Constant.Int 0)))) $5 }
-| QUERY LBRACKET exp COMMA exp RBRACKET block                  { query ~ppos:$loc (Some ($3, $5)) $7 }
+| QUERY query_policy block                                     { query ~ppos:$loc None $2 $3 }
+| QUERY LBRACKET exp RBRACKET query_policy block               { query ~ppos:$loc (Some ($3, with_pos $loc (Constant (Constant.Int 0)))) $5 $6 }
+| QUERY LBRACKET exp COMMA exp RBRACKET query_policy block     { query ~ppos:$loc (Some ($3, $5)) $7 $8 }
 | postfix_expression arg_spec                                  { with_pos $loc (FnAppl ($1, $2)) }
 | postfix_expression targ_spec                                 { with_pos $loc (TAppl ($1, $2)) }
 | postfix_expression DOT record_label                          { with_pos $loc (Projection ($1, $3)) }

--- a/core/parser.mly
+++ b/core/parser.mly
@@ -74,6 +74,15 @@ let restriction_of_string p =
   | rest      ->
      raise (ConcreteSyntaxError (pos p, "Invalid kind restriction: " ^ rest))
 
+let query_policy_of_string p =
+  function
+  | "flat" -> QueryPolicy.Flat
+  | "nested" -> QueryPolicy.Nested
+  | rest      ->
+     raise (ConcreteSyntaxError (pos p, "Invalid query policy: " ^ rest ^ ", expected 'flat' or 'nested'"))
+
+
+
 let full_kind_of pos prim lin rest =
   let p = primary_kind_of_string pos prim in
   let l = linearity_of_string    pos lin  in
@@ -254,7 +263,6 @@ end
 %token SEMICOLON
 %token TRUE FALSE
 %token BARBAR AMPAMP
-%token PLAIN NESTED
 %token <int> UINTEGER
 %token <float> UFLOAT
 %token <string> STRING CDATA REGEXREPL
@@ -570,8 +578,7 @@ spawn_expression:
 | SPAWNWAIT   block                                            { spawn ~ppos:$loc Wait   NoSpawnLocation           $2 }
 
 query_policy:
-| PLAIN                                                        { QueryPolicy.Plain }
-| NESTED                                                       { QueryPolicy.Nested }
+| VARIABLE                                                     { query_policy_of_string $loc $1 }
 | /* empty */                                                  { QueryPolicy.Default }
 
 postfix_expression:

--- a/core/query/evalNestedQuery.ml
+++ b/core/query/evalNestedQuery.ml
@@ -790,7 +790,7 @@ let unordered_query_package t v =
 let compile_shredded : Value.env -> Ir.computation
                        -> (Value.database * (Sql.query * Shred.flat_type) Shred.package) option =
   fun env e ->
-    let v = Q.Eval.eval env e in
+    let v = Q.Eval.eval QueryPolicy.Nested env e in
       match Q.used_database v with
         | None    -> None
         | Some db ->

--- a/core/query/evalQuery.ml
+++ b/core/query/evalQuery.ml
@@ -300,7 +300,7 @@ let ordered_query v =
 let compile : Value.env -> (int * int) option * Ir.computation -> (Value.database * Sql.query * Types.datatype) option =
   fun env (range, e) ->
     (* Debug.print ("e: "^Ir.show_computation e); *)
-    let v = Q.Eval.eval env e in
+    let v = Q.Eval.eval QueryPolicy.Flat env e in
       (* Debug.print ("v: "^Q.string_of_t v); *)
       match Q.used_database v with
         | None -> None

--- a/core/query/query.ml
+++ b/core/query/query.ml
@@ -674,7 +674,7 @@ struct
     | Return v -> value env v
     | Apply (f, args) ->
         apply env (value env f, List.map (value env) args)
-    | Special (Ir.Query (None, e, _)) -> computation env e
+    | Special (Ir.Query (None, _, e, _)) -> computation env e
     | Special (Ir.Table (db, name, keys, (readtype, _, _))) as _s ->
        (** WR: this case is because shredding needs to access the keys of tables
            but can we avoid it (issue #432)? *)

--- a/core/query/query.mli
+++ b/core/query/query.mli
@@ -26,7 +26,7 @@ sig
       | Primitive of string
       | Var       of Var.var * Types.datatype StringMap.t
       | Constant  of Constant.t
-  and env = Value.env * t Env.Int.t
+  and env = { venv: Value.env; qenv: t Env.Int.t; policy: QueryPolicy.t }
       [@@deriving show]
 
 end
@@ -57,13 +57,13 @@ val sql_of_let_query : let_query -> Sql.query
 
 module Eval :
 sig
-  val env_of_value_env : 'a -> 'a * 'b Env.Int.t
-  val bind : 'a * 'b Env.Int.t -> Env.Int.name * 'b -> 'a * 'b Env.Int.t
+  val env_of_value_env : QueryPolicy.t -> Value.env -> Lang.env
+  val bind : Lang.env -> Env.Int.name * Lang.t -> Lang.env
   val eta_expand_var : Var.var * Types.datatype StringMap.t -> Lang.t
-  val computation : Value.t Value.Env.t * Lang.t Env.Int.t -> Ir.computation -> Lang.t
+  val computation : Lang.env -> Ir.computation -> Lang.t
   val reduce_where_then : Lang.t * Lang.t -> Lang.t
   val reduce_and : Lang.t * Lang.t -> Lang.t
-  val eval : Value.t Value.Env.t -> Ir.computation -> Lang.t
+  val eval : QueryPolicy.t -> Value.t Value.Env.t -> Ir.computation -> Lang.t
 end
 
 val compile_update : Value.database -> Value.env ->

--- a/core/sugarConstructors.ml
+++ b/core/sugarConstructors.ml
@@ -217,9 +217,8 @@ module SugarConstructors (Position : Pos)
        opt_map (fun name -> constant_str ~ppos name) var_opt))
 
   (* Create a query. *)
-  let query ?(ppos=dp) phrases_opt blk =
-    with_pos ppos (Query (phrases_opt, blk, None))
-
+  let query ?(ppos=dp) phrases_opt policy blk =
+    with_pos ppos (Query (phrases_opt, policy, blk, None))
 
   (** Operator applications *)
   (* Apply a binary infix operator. *)

--- a/core/sugarConstructorsIntf.ml
+++ b/core/sugarConstructorsIntf.ml
@@ -132,7 +132,7 @@ module type SugarConstructorsSig = sig
       : ?ppos:t -> phrase -> name list -> phrase -> string option
      -> phrase
   val query
-      : ?ppos:t -> (phrase * phrase) option -> phrase -> phrase
+      : ?ppos:t -> (phrase * phrase) option -> QueryPolicy.t -> phrase -> phrase
 
   (* Operator applications *)
   val infix_appl' : ?ppos:t -> phrase -> BinaryOp.t -> phrase -> phrase

--- a/core/sugarTraversals.ml
+++ b/core/sugarTraversals.ml
@@ -174,14 +174,14 @@ class map =
           let _block_phr = o#phrase _block_phr in
           let _dt = o#option (fun o -> o#type_row) _dt in
           Spawn (_spawn_kind, _given_spawn_location, _block_phr, _dt)
-      | Query (_x, _x_i1, _x_i2) ->
+      | Query (_x, _policy, _x_i1, _x_i2) ->
           let _x =
             o#option
               (fun o (_x, _x_i1) ->
                  let _x = o#phrase _x in
                  let _x_i1 = o#phrase _x_i1 in (_x, _x_i1))
               _x in
-          let _x_i1 = o#phrase _x_i1 in Query (_x, _x_i1, _x_i2)
+          let _x_i1 = o#phrase _x_i1 in Query (_x, _policy, _x_i1, _x_i2)
       | ListLit (_x, _x_i1) ->
           let _x = o#list (fun o -> o#phrase) _x in
           let _x_i1 = o#option (fun o -> o#typ) _x_i1 in
@@ -924,7 +924,7 @@ class fold =
          let o = o#given_spawn_location _given_spawn_location in
          let o = o#phrase _block_phr in
          o
-      | Query (_x, _x_i1, _x_i2) ->
+      | Query (_x, _policy, _x_i1, _x_i2) ->
           let o =
             o#option
               (fun o (_x, _x_i1) ->
@@ -1616,14 +1616,14 @@ class fold_map =
           let (o, _given_spawn_location) = o#given_spawn_location _given_spawn_location in
           let (o, _block_phr) = o#phrase _block_phr in
           (o, (Spawn (_spawn_kind, _given_spawn_location, _block_phr, _dt)))
-      | Query (_x, _x_i1, _x_i2) ->
+      | Query (_x, _policy, _x_i1, _x_i2) ->
           let (o, _x) =
             o#option
               (fun o (_x, _x_i1) ->
                  let (o, _x) = o#phrase _x in
                  let (o, _x_i1) = o#phrase _x_i1 in (o, (_x, _x_i1)))
               _x in
-          let (o, _x_i1) = o#phrase _x_i1 in (o, (Query (_x, _x_i1, _x_i2)))
+          let (o, _x_i1) = o#phrase _x_i1 in (o, (Query (_x, _policy, _x_i1, _x_i2)))
       | ListLit (_x, _x_i1) ->
           let (o, _x) = o#list (fun o -> o#phrase) _x in (o, (ListLit (_x, _x_i1)))
       | RangeLit ((_x_i1, _x_i2)) ->

--- a/core/sugartoir.ml
+++ b/core/sugartoir.ml
@@ -1015,7 +1015,7 @@ struct
                    (instantiate_mb "stringToXml",
                     [ev (WithPos.make ~pos (Sugartypes.Constant (Constant.String name)))]))
           | Block (bs, e) -> eval_bindings Scope.Local env bs e
-          | Query (range, e, _) ->
+          | Query (range, _policy, e, _) ->
               I.query (opt_map (fun (limit, offset) -> (ev limit, ev offset)) range, ec e)
 	  | DBInsert (source, _fields, rows, None) ->
 	      let source = ev source in

--- a/core/sugartypes.ml
+++ b/core/sugartypes.ml
@@ -226,7 +226,7 @@ and phrasenode =
       spawn block, row opt *)
   | Spawn            of spawn_kind * given_spawn_location * phrase *
                           Types.row option
-  | Query            of (phrase * phrase) option * phrase *
+  | Query            of (phrase * phrase) option * QueryPolicy.t * phrase *
                           Types.datatype option
   | RangeLit         of phrase * phrase
   | ListLit          of phrase list * Types.datatype option
@@ -459,8 +459,8 @@ struct
     | LensGetLit (l, _) -> phrase l
     | LensPutLit (l, data, _) -> union_all [phrase l; phrase data]
 
-    | Query (None, p, _) -> phrase p
-    | Query (Some (limit, offset), p, _) ->
+    | Query (None, _, p, _) -> phrase p
+    | Query (Some (limit, offset), _, p, _) ->
        union_all [phrase limit; phrase offset; phrase p]
 
     | Escape (v, p) -> diff (phrase p) (singleton (Binder.to_name v))

--- a/core/transformSugar.ml
+++ b/core/transformSugar.ml
@@ -302,7 +302,7 @@ class transform (env : Types.typing_environment) =
       | CP p ->
          let (o, p, t) = o#cp_phrase p in
          (o, CP p, t)
-      | Query (range, body, Some t) ->
+      | Query (range, policy, body, Some t) ->
           let (o, range) =
             optionu o
               (fun o (limit, offset) ->
@@ -313,7 +313,7 @@ class transform (env : Types.typing_environment) =
           let (o, body, _) = on_effects o (Types.make_empty_closed_row ()) (fun o -> o#phrase) body in
           let (o, body, _) = o#phrase body in
           let (o, t) = o#datatype t in
-            (o, Query (range, body, Some t), t)
+            (o, Query (range, policy, body, Some t), t)
       | ListLit (es, Some t) ->
           let (o, es, _) = list o (fun o -> o#phrase) es in
           let (o, t) = o#datatype t in

--- a/core/typeSugar.ml
+++ b/core/typeSugar.ml
@@ -2934,6 +2934,7 @@ let rec type_check : context -> phrase -> phrase * Types.datatype * usagemap =
               Types.unit_type,
               merge_usages (usages from :: hide (from_option StringMap.empty (opt_map usages where)) :: List.map hide (List.map (usages -<- snd) set))
         | Query (range, policy, p, _) ->
+            let open QueryPolicy in
             let range, outer_effects, range_usages =
               match range with
                 | None -> None, Types.make_empty_open_row default_effect_subkind, StringMap.empty
@@ -2950,9 +2951,20 @@ let rec type_check : context -> phrase -> phrase * Types.datatype * usagemap =
             let () = unify ~handle:Gripers.query_outer
               (no_pos (`Record context.effect_row), no_pos (`Record outer_effects)) in
             let p = type_check (bind_effects context inner_effects) p in
-            let () = if Settings.get  Database.shredding then ()
-                     else let shape = Types.make_list_type (`Record (StringMap.empty, Types.fresh_row_variable (lin_any, res_base), false)) in
-                          unify ~handle:Gripers.query_base_row (pos_and_typ p, no_pos shape) in
+            let evaluator =
+              match policy with
+                | Nested -> `Nested
+                | Plain -> `Plain
+                | Default -> if (Settings.get Database.shredding) then `Nested else `Plain in
+            let () =
+              match evaluator with
+                | `Nested -> ()
+                | `Plain  ->
+                     let shape =
+                       Types.make_list_type
+                         (`Record (StringMap.empty,
+                            Types.fresh_row_variable (lin_any, res_base), false)) in
+                     unify ~handle:Gripers.query_base_row (pos_and_typ p, no_pos shape) in
             Query (range, policy, erase p, Some (typ p)), typ p, merge_usages [range_usages; usages p]
         (* mailbox-based concurrency *)
         | Spawn (Wait, l, p, old_inner) ->

--- a/core/typeSugar.ml
+++ b/core/typeSugar.ml
@@ -2954,12 +2954,12 @@ let rec type_check : context -> phrase -> phrase * Types.datatype * usagemap =
             let evaluator =
               match policy with
                 | Nested -> `Nested
-                | Plain -> `Plain
-                | Default -> if (Settings.get Database.shredding) then `Nested else `Plain in
+                | Flat -> `Flat
+                | Default -> if (Settings.get Database.shredding) then `Nested else `Flat in
             let () =
               match evaluator with
                 | `Nested -> ()
-                | `Plain  ->
+                | `Flat  ->
                      let shape =
                        Types.make_list_type
                          (`Record (StringMap.empty,

--- a/core/typeSugar.ml
+++ b/core/typeSugar.ml
@@ -2933,7 +2933,7 @@ let rec type_check : context -> phrase -> phrase * Types.datatype * usagemap =
               DBUpdate (erase_pat pat, erase from, opt_map erase where, List.map (fun (n,(p,_,_)) -> n, p) set),
               Types.unit_type,
               merge_usages (usages from :: hide (from_option StringMap.empty (opt_map usages where)) :: List.map hide (List.map (usages -<- snd) set))
-        | Query (range, p, _) ->
+        | Query (range, policy, p, _) ->
             let range, outer_effects, range_usages =
               match range with
                 | None -> None, Types.make_empty_open_row default_effect_subkind, StringMap.empty
@@ -2953,7 +2953,7 @@ let rec type_check : context -> phrase -> phrase * Types.datatype * usagemap =
             let () = if Settings.get  Database.shredding then ()
                      else let shape = Types.make_list_type (`Record (StringMap.empty, Types.fresh_row_variable (lin_any, res_base), false)) in
                           unify ~handle:Gripers.query_base_row (pos_and_typ p, no_pos shape) in
-            Query (range, erase p, Some (typ p)), typ p, merge_usages [range_usages; usages p]
+            Query (range, policy, erase p, Some (typ p)), typ p, merge_usages [range_usages; usages p]
         (* mailbox-based concurrency *)
         | Spawn (Wait, l, p, old_inner) ->
             assert (l = NoSpawnLocation);
@@ -3357,7 +3357,7 @@ let rec type_check : context -> phrase -> phrase * Types.datatype * usagemap =
                                                (List.map (StringMap.filter (fun v _ -> not (StringSet.mem v vs)))
                                                          [usages body; from_option StringMap.empty (opt_map usages where); from_option StringMap.empty (opt_map usages orderby)])) in
               if is_query then
-                Query (None, with_pos pos e, Some (typ body)), typ body, us
+                Query (None, QueryPolicy.Default, with_pos pos e, Some (typ body)), typ body, us
               else
                 e, typ body, us
         | Escape (bndr, e) ->

--- a/examples/handlers/pipes.links
+++ b/examples/handlers/pipes.links
@@ -248,7 +248,7 @@ fun expoPipe(n)() {
   expoPipe0(n)
 }
 
-fun nested(start, depth, end) {
+fun nested_pipe(start, depth, end) {
   var pipeline = produceFrom(start) >+> expoPipe(depth) >+> take1(end) >+> printer(intToString);
   pipeline()
 }

--- a/examples/handlers/pipes.links
+++ b/examples/handlers/pipes.links
@@ -248,7 +248,7 @@ fun expoPipe(n)() {
   expoPipe0(n)
 }
 
-fun nested_pipe(start, depth, end) {
+fun nested(start, depth, end) {
   var pipeline = produceFrom(start) >+> expoPipe(depth) >+> take1(end) >+> printer(intToString);
   pipeline()
 }

--- a/tests/database.tests
+++ b/tests/database.tests
@@ -37,3 +37,20 @@ XML literals in query blocks (6)
 query {var x = <a {[("href", "foo.com")]}>{stringToXml("asdf")}</a>; [(a=1)]}
 stdout : [(a = 1)] : [(a:Int)]
 exit : 0
+
+Explicit query evaluator annotation (1)
+query nested { for (x <- [1,2,3]) [(x = x, y = (for (y <- [4,5,6]) [y]))] }
+stdout : [(x = 1, y = [4, 5, 6]), (x = 2, y = [4, 5, 6]), (x = 3, y = [4, 5, 6])] : [(x:Int,y:[Int])]
+exit : 0
+
+Explicit query evaluator annotation (2)
+query plain { for (x <- [1,2,3]) [(x = x, y = (for (y <- [4,5,6]) [y]))] }
+args : --config=tests/shredding/config.sample
+stderr : @..*
+exit : 1
+
+Explicit query evaluator annotation (3)
+query [5] plain { for (x <- [1..10]) [x] }
+args : --config=tests/shredding/config.sample
+stdout : [1, 2, 3, 4, 5]
+exit : 1

--- a/tests/database.tests
+++ b/tests/database.tests
@@ -53,4 +53,5 @@ Explicit query evaluator annotation (3)
 query [4] plain { for (x <- [1, 2, 3, 4, 5, 6]) [(x = x)] }
 args : --config=tests/shredding/config.sample
 stdout : [(x = 1), (x = 2), (x = 3), (x = 4)] : [(x : Int)]
+ignore : pending #756
 exit : 0

--- a/tests/database.tests
+++ b/tests/database.tests
@@ -50,7 +50,7 @@ stderr : @..*
 exit : 1
 
 Explicit query evaluator annotation (3)
-query [5] plain { for (x <- [1..10]) [x] }
+query [4] plain { for (x <- [1, 2, 3, 4, 5, 6]) [(x = x)] }
 args : --config=tests/shredding/config.sample
-stdout : [1, 2, 3, 4, 5]
-exit : 1
+stdout : [(x = 1), (x = 2), (x = 3), (x = 4)] : [(x : Int)]
+exit : 0

--- a/tests/database.tests
+++ b/tests/database.tests
@@ -44,13 +44,13 @@ stdout : [(x = 1, y = [4, 5, 6]), (x = 2, y = [4, 5, 6]), (x = 3, y = [4, 5, 6])
 exit : 0
 
 Explicit query evaluator annotation (2)
-query plain { for (x <- [1,2,3]) [(x = x, y = (for (y <- [4,5,6]) [y]))] }
+query flat { for (x <- [1,2,3]) [(x = x, y = (for (y <- [4,5,6]) [y]))] }
 args : --config=tests/shredding/config.sample
 stderr : @..*
 exit : 1
 
 Explicit query evaluator annotation (3)
-query [4] plain { for (x <- [1, 2, 3, 4, 5, 6]) [(x = x)] }
+query [4] flat { for (x <- [1, 2, 3, 4, 5, 6]) [(x = x)] }
 args : --config=tests/shredding/config.sample
 stdout : [(x = 1), (x = 2), (x = 3), (x = 4)] : [(x : Int)]
 ignore : pending #756

--- a/tests/database.tests
+++ b/tests/database.tests
@@ -72,6 +72,16 @@ stderr : @..*
 exit : 1
 
 Nested query annotations (4)
-query plain { query plain { for (i <- [1,2,3]) [(x = i)] } }
+query flat { query flat { for (i <- [1,2,3]) [(x = i)] } }
 stdout : [(x = 1), (x = 2), (x = 3)] : [(x:Int)]
 exit : 0
+
+Nested query annotations (5)
+query nested { query flat { for (i <- [1,2,3]) [(x = i)] } }
+stderr : @..*
+exit : 1
+
+Nested query annotations (5)
+query flat { query nested { for (i <- [1,2,3]) [(x = i)] } }
+stderr : @..*
+exit : 1

--- a/tests/database.tests
+++ b/tests/database.tests
@@ -55,3 +55,23 @@ args : --config=tests/shredding/config.sample
 stdout : [(x = 1), (x = 2), (x = 3), (x = 4)] : [(x : Int)]
 ignore : pending #756
 exit : 0
+
+Nested query annotations (1)
+query nested { query nested { for (i <- [1,2,3]) [(x = i)] } }
+stdout : [(x = 1), (x = 2), (x = 3)] : [(x:Int)]
+exit : 0
+
+Nested query annotations (2)
+query nested { query { for (i <- [1,2,3]) [(x = i)] } }
+stderr : @..*
+exit : 1
+
+Nested query annotations (3)
+query { query nested { for (i <- [1,2,3]) [(x = i)] } }
+stderr : @..*
+exit : 1
+
+Nested query annotations (4)
+query plain { query plain { for (i <- [1,2,3]) [(x = i)] } }
+stdout : [(x = 1), (x = 2), (x = 3)] : [(x:Int)]
+exit : 0


### PR DESCRIPTION
This patch allows the specification of whether a query should be treated as flat or shredded on a per-query basis. The patch extends query syntax as follows:

```
query [range] policy {
  ...
}
```
where `policy` is either `plain`, `nested`, or omitted. If `plain` is used, then the query will evaluated using the default evaluator, and if `nested` is used, then the query will be shredded. If the policy is omitted, then the `shredding` setting is used to decide, as before.

This allows us to have applications which use shredded queries by default, but also have queries which use ranges, ordering, or regexes. 