### PR TITLE
Various datatype refactorings

### DIFF
--- a/core/closures.ml
+++ b/core/closures.ml
@@ -55,7 +55,7 @@ struct
               zs in
             List.fold_left
               (fun o q ->
-                let tv = Types.var_of_quantifier q in
+                let tv = Quantifier.to_var q in
                 o#register_type_var tv
               )
               o
@@ -147,11 +147,11 @@ struct
 
 
       method quantifier q =
-        let var = Types.var_of_quantifier q in
+        let var = Quantifier.to_var q in
         o#bound_typevar var q
 
       method quantifier_remove q =
-        let var = Types.var_of_quantifier q in
+        let var = Quantifier.to_var q in
         {< bound_type_vars = Types.TypeVarMap.remove var bound_type_vars >}
 
 
@@ -585,9 +585,9 @@ struct
         - Three maps mapping the old free variables to fresh ones (to be used with Instantiate)  **)
       method create_substitutions_replacing_free_variables (free_type_vars : Quantifier.t list) =
         List.fold_right (fun oldq (qs, (type_map, row_map, presence_map) ) ->
-          let typevar = Types.var_of_quantifier oldq in
-          let primary_kind = Types.primary_kind_of_quantifier oldq in
-          let subkind = Types.subkind_of_quantifier oldq in
+          let typevar = Quantifier.to_var oldq in
+          let primary_kind = Quantifier.to_primary_kind oldq in
+          let subkind = Quantifier.to_subkind oldq in
           let newvar = Types.fresh_raw_variable () in
           let make_new_type_variable () = Unionfind.fresh (`Var (newvar, subkind, `Rigid)) in
           let updated_maps = match primary_kind with

--- a/core/closures.ml
+++ b/core/closures.ml
@@ -3,7 +3,7 @@ open CommonTypes
 open Ir
 open Var
 
-type freevars = {termvars: (Ir.binder list) ; typevars: Types.quantifier list} [@@deriving show]
+type freevars = {termvars: (Ir.binder list) ; typevars: Quantifier.t list} [@@deriving show]
 type fenv = freevars IntMap.t [@@deriving show]
 
 module ClosureVars =
@@ -583,7 +583,7 @@ struct
       (** Given a list of free variables, return a tuple containing the following:
         - a list of fresh quantifiers, each corresponding to one free variable
         - Three maps mapping the old free variables to fresh ones (to be used with Instantiate)  **)
-      method create_substitutions_replacing_free_variables (free_type_vars : Types.quantifier list) =
+      method create_substitutions_replacing_free_variables (free_type_vars : Quantifier.t list) =
         List.fold_right (fun oldq (qs, (type_map, row_map, presence_map) ) ->
           let typevar = Types.var_of_quantifier oldq in
           let primary_kind = Types.primary_kind_of_quantifier oldq in

--- a/core/commonTypes.ml
+++ b/core/commonTypes.ml
@@ -134,6 +134,13 @@ module Kind = struct
     [@@deriving eq,show]
 end
 
+module Quantifier = struct
+  type t = int * Kind.t
+    [@@deriving show]
+
+  let to_string = Format.asprintf "%a" pp
+end
+
 module Location = struct
   type t = Client | Server | Native | Unknown
     [@@deriving show]

--- a/core/commonTypes.ml
+++ b/core/commonTypes.ml
@@ -138,7 +138,22 @@ module Quantifier = struct
   type t = int * Kind.t
     [@@deriving show]
 
+  let to_var = function
+    | (var, _) -> var
+
+  let to_kind : t -> Kind.t = function
+    | (_, k) -> k
+
+  let to_primary_kind : t -> PrimaryKind.t = function
+    | (_, (pk, _)) -> pk
+
+  let to_subkind : t -> Subkind.t = function
+    | (_, (_, sk)) -> sk
+
   let to_string = Format.asprintf "%a" pp
+
+  let eq : t -> t -> bool = fun lvar rvar ->
+    to_var lvar = to_var rvar
 end
 
 module Location = struct

--- a/core/commonTypes.ml
+++ b/core/commonTypes.ml
@@ -102,16 +102,14 @@ let res_mono    = Restriction.Mono
 let res_session = Restriction.Session
 let res_effect  = Restriction.Effect
 
-type subkind = Linearity.t * Restriction.t
+module Subkind = struct
+  type t = Linearity.t * Restriction.t
     [@@deriving eq,show]
 
-let min_subkind (ll, lr) (rl, rr) =
-  match Restriction.min lr rr with
-  | Some r -> Some (Linearity.min ll rl, r)
-  | None -> None
-
-let string_of_subkind (lin, res) =
-  Printf.sprintf "(%s,%s)" (Linearity.to_string lin) (Restriction.to_string res)
+  let to_string (lin, res) =
+    Printf.sprintf "(%s,%s)" (Linearity.to_string   lin)
+                             (Restriction.to_string res)
+end
 
 module PrimaryKind = struct
   type t =

--- a/core/commonTypes.ml
+++ b/core/commonTypes.ml
@@ -167,8 +167,10 @@ let loc_server  = Location.Server
 let loc_native  = Location.Native
 let loc_unknown = Location.Unknown
 
-type freedom = [`Flexible | `Rigid]
+module Freedom = struct
+  type t = [`Flexible | `Rigid]
     [@@deriving show]
+end
 
 module Name = struct
   type t = string

--- a/core/commonTypes.ml
+++ b/core/commonTypes.ml
@@ -167,6 +167,11 @@ let loc_unknown = Location.Unknown
 type freedom = [`Flexible | `Rigid]
     [@@deriving show]
 
+module Name = struct
+  type t = string
+    [@@deriving show]
+end
+
 module Primitive = struct
   type t = Bool | Int | Char | Float | XmlItem | DB | String
     [@@deriving show]

--- a/core/commonTypes.ml
+++ b/core/commonTypes.ml
@@ -129,6 +129,11 @@ let pk_type     = PrimaryKind.Type
 let pk_row      = PrimaryKind.Row
 let pk_presence = PrimaryKind.Presence
 
+module Kind = struct
+  type t = PrimaryKind.t * Subkind.t
+    [@@deriving eq,show]
+end
+
 module Location = struct
   type t = Client | Server | Native | Unknown
     [@@deriving show]

--- a/core/compilePatterns.ml
+++ b/core/compilePatterns.ml
@@ -30,8 +30,8 @@ struct
     | Any
     | Nil
     | Cons     of t * t
-    | Variant  of name * t
-    | Effect   of name * t list * t
+    | Variant  of Name.t * t
+    | Effect   of Name.t * t list * t
     | Negative of StringSet.t
     | Record   of t StringMap.t * t option
     | Constant of Constant.t

--- a/core/desugarDatatypes.ml
+++ b/core/desugarDatatypes.ml
@@ -135,7 +135,7 @@ let typevars =
 object (self)
   inherit SugarTraversals.fold as super
 
-  val tyvar_list : name list = []
+  val tyvar_list : Name.t list = []
   val tyvars : type_variable StringMap.t = StringMap.empty
 
   (* fill in subkind with the default *)

--- a/core/desugarDatatypes.ml
+++ b/core/desugarDatatypes.ml
@@ -601,7 +601,7 @@ module Desugar = struct
         | TypeApplication (tycon, ts) ->
             (* Matches kinds of the quantifiers against the type arguments.
              * Returns Types.type_args based on the given frontend type arguments. *)
-            let match_quantifiers : type a. (a -> Types.kind) -> a list -> Types.type_arg list = fun proj qs ->
+            let match_quantifiers : type a. (a -> Kind.t) -> a list -> Types.type_arg list = fun proj qs ->
               let match_kinds i (q, t) =
                 let primary_kind_of_type_arg : Datatype.type_arg -> PrimaryKind.t = function
                   | Type _ -> PrimaryKind.Type

--- a/core/desugarDatatypes.ml
+++ b/core/desugarDatatypes.ml
@@ -371,12 +371,12 @@ module Desugar = struct
          self#row (fields, var)
      end)#datatype
 
-  (** Desugars quantifiers into Types.quantifiers, returning the updated
+  (** Desugars quantifiers into Quantifier.ts, returning the updated
      variable environment.
 
      This is used within the `typename` and `Forall` desugaring. *)
   let desugar_quantifiers (var_env: var_env) (qs: Sugartypes.quantifier list) body pos :
-      (Types.quantifier list * var_env) =
+      (Quantifier.t list * var_env) =
     (* Bind all quantified variables, and then do a naive {!typevars} pass over this set to infer
        any unannotated kinds, and verify existing kinds/subkinds match up.
 
@@ -583,7 +583,7 @@ module Desugar = struct
             let _ = Unionfind.change point (`Recursive (var, datatype { var_env with tyvars; row_operations } t)) in
               `MetaTypeVar point
         | Forall (qs, t) ->
-            let (qs: Types.quantifier list), var_env = desugar_quantifiers var_env qs t pos in
+            let (qs: Quantifier.t list), var_env = desugar_quantifiers var_env qs t pos in
             let t = datatype var_env t in
               `ForAll (qs, t)
         | Unit -> Types.unit_type
@@ -758,7 +758,7 @@ module Desugar = struct
     | Presence f -> `Presence (fieldspec var_env alias_env f node)
 
   (* pre condition: all subkinds have been filled in *)
-  let generate_var_mapping (vars : type_variable list) : Types.quantifier list * var_env =
+  let generate_var_mapping (vars : type_variable list) : Quantifier.t list * var_env =
     let addt x t envs = { envs with tyvars = StringMap.add x (`Type t) envs.tyvars } in
     let addr x r envs = { envs with tyvars = StringMap.add x (`Row r) envs.tyvars } in
     let addf x f envs = { envs with tyvars = StringMap.add x (`Presence f) envs.tyvars } in

--- a/core/desugarFors.ml
+++ b/core/desugarFors.ml
@@ -54,7 +54,7 @@ let tt = function
   It roughly corresponds to [[qs]].
 *)
 let results :  Types.row ->
-  (Sugartypes.phrase list * Sugartypes.name list * Types.datatype list) -> Sugartypes.phrase =
+  (Sugartypes.phrase list * Name.t list * Types.datatype list) -> Sugartypes.phrase =
   fun eff (es, xs, ts) ->
     (* let results_type = Types.make_tuple_type ts in *)
     let rec results =
@@ -102,7 +102,7 @@ object (o : 'self_type)
   *)
   method qualifiers : Sugartypes.iterpatt list ->
     'self_type *
-      (Sugartypes.phrase list * Sugartypes.Pattern.with_pos list * Sugartypes.name list *
+      (Sugartypes.phrase list * Sugartypes.Pattern.with_pos list * Name.t list *
          Types.datatype list) =
     fun qs ->
       let o, (es, ps, xs, ts) =

--- a/core/generalise.ml
+++ b/core/generalise.ml
@@ -177,7 +177,7 @@ let mono_type_args : type_arg -> unit =
 (** generalise:
     Universally quantify any free type variables in the expression.
 *)
-let generalise : gen_kind -> ?unwrap:bool -> environment -> datatype -> ((quantifier list * type_arg list) * datatype) =
+let generalise : gen_kind -> ?unwrap:bool -> environment -> datatype -> ((Quantifier.t list * type_arg list) * datatype) =
   fun kind ?(unwrap=true) env t ->
     (* throw away any existing top-level quantifiers *)
     Debug.if_set show_generalisation (fun () -> "Generalising : " ^ string_of_datatype t);
@@ -233,5 +233,5 @@ let generalise_rigid = generalise `Rigid
 (** generalise both rigid and flexible type variables *)
 let generalise = generalise `All
 
-let get_quantifiers_rigid (env : environment) (t : datatype) : quantifier list =
+let get_quantifiers_rigid (env : environment) (t : datatype) : Quantifier.t list =
   get_type_args `Rigid (env_type_vars env) t |> Types.quantifiers_of_type_args

--- a/core/generalise.ml
+++ b/core/generalise.ml
@@ -61,7 +61,7 @@ let rec get_type_args : gen_kind -> TypeVarSet.t -> datatype -> type_arg list =
         | `Alias ((_, _, ts), t) ->
             concat_map (get_type_arg_type_args kind bound_vars) ts @ gt t
         | `ForAll (qs, t) ->
-           get_type_args kind (Types.add_quantified_vars qs bound_vars) t
+           get_type_args kind (TypeVarSet.add_quantifiers qs bound_vars) t
         | `Application (_, args) ->
             Utility.concat_map (get_type_arg_type_args kind bound_vars) args
         | `RecursiveApplication appl ->

--- a/core/generalise.mli
+++ b/core/generalise.mli
@@ -1,4 +1,8 @@
-val generalise : ?unwrap:bool -> Types.environment -> Types.datatype -> ((Types.quantifier list * Types.type_arg list) * Types.datatype)
-val generalise_rigid : ?unwrap:bool -> Types.environment -> Types.datatype -> ((Types.quantifier list * Types.type_arg list) * Types.datatype)
-val get_quantifiers_rigid : Types.environment -> Types.datatype -> Types.quantifier list
+open CommonTypes
+
+val generalise : ?unwrap:bool -> Types.environment -> Types.datatype
+              -> ((Quantifier.t list * Types.type_arg list) * Types.datatype)
+val generalise_rigid : ?unwrap:bool -> Types.environment -> Types.datatype
+                    -> ((Quantifier.t list * Types.type_arg list) * Types.datatype)
+val get_quantifiers_rigid : Types.environment -> Types.datatype -> Quantifier.t list
 val rigidify_type_arg : Types.type_arg -> unit

--- a/core/instantiate.ml
+++ b/core/instantiate.ml
@@ -365,7 +365,7 @@ let instantiation_maps_of_type_arguments :
 
     if (not arities_okay) then
       (Debug.print (Printf.sprintf "# Type variables (total %d)" vars_length);
-       let tyvars = String.concat "\n" @@ List.mapi (fun i t -> (string_of_int @@ i+1) ^ ". " ^ Types.show_quantifier t) vars in
+       let tyvars = String.concat "\n" @@ List.mapi (fun i t -> (string_of_int @@ i+1) ^ ". " ^ Quantifier.to_string t) vars in
        Debug.print tyvars;
        Debug.print (Printf.sprintf "\n# Type arguments (total %d)" tyargs_length);
        let tyargs' = String.concat "\n" @@ List.mapi (fun i arg -> (string_of_int @@ i+1) ^ ". " ^ Types.string_of_type_arg arg) tyargs in

--- a/core/instantiate.ml
+++ b/core/instantiate.ml
@@ -76,9 +76,9 @@ let instantiates : instantiation_maps -> (datatype -> datatype) * (row -> row) *
         | `Table (f, d, r) -> `Table (inst f, inst d, inst r)
         | `ForAll (qs, t) ->
            let remove_shadowed_quantifier (tmap,rmap,pmap) q =
-             let var = Types.var_of_quantifier q in
+             let var = Quantifier.to_var q in
              let open CommonTypes.PrimaryKind in
-             match Types.primary_kind_of_quantifier q with
+             match Quantifier.to_primary_kind q with
                | Type ->
                   (IntMap.remove var tmap, rmap, pmap)
                | Row ->
@@ -430,7 +430,7 @@ let replace_quantifiers t qs' =
         let tyargs =
           List.map2
             (fun q q' ->
-              assert (primary_kind_of_quantifier q = primary_kind_of_quantifier q');
+              assert (Quantifier.to_primary_kind q = Quantifier.to_primary_kind q');
               type_arg_of_quantifier q')
             qs
             qs'

--- a/core/instantiate.mli
+++ b/core/instantiate.mli
@@ -1,3 +1,4 @@
+open CommonTypes
 open Utility
 
 type instantiation_maps = (Types.datatype IntMap.t * Types.row IntMap.t * Types.field_spec IntMap.t)
@@ -14,11 +15,11 @@ val datatype : instantiation_maps -> Types.datatype -> Types.datatype
 val row : instantiation_maps -> Types.row -> Types.row
 val presence : instantiation_maps -> Types.field_spec -> Types.field_spec
 val alias : string -> Types.type_arg list -> Types.tycon_environment -> Types.datatype
-val recursive_application : string -> Types.quantifier list -> Types.type_arg list -> Types.datatype -> Types.datatype
+val recursive_application : string -> Quantifier.t list -> Types.type_arg list -> Types.datatype -> Types.datatype
 
 (* Given a quantified type and a list of type arguments, create the corresponding instantiation maps *)
 val instantiation_maps_of_type_arguments : bool -> Types.datatype -> Types.type_arg list -> (Types.datatype * instantiation_maps)
 
 val apply_type : Types.datatype -> Types.type_arg list -> Types.datatype
 val freshen_quantifiers : Types.datatype -> Types.datatype
-val replace_quantifiers : Types.datatype -> Types.quantifier list -> Types.datatype
+val replace_quantifiers : Types.datatype -> Quantifier.t list -> Types.datatype

--- a/core/ir.ml
+++ b/core/ir.ml
@@ -14,7 +14,7 @@ type binder = Var.binder
   [@@deriving show]
 
 (* type variables *)
-type tyvar = Types.quantifier
+type tyvar = Quantifier.t
   [@@deriving show]
 type tyarg = Types.type_arg
   [@@deriving show]

--- a/core/ir.ml
+++ b/core/ir.ml
@@ -19,9 +19,6 @@ type tyvar = Types.quantifier
 type tyarg = Types.type_arg
   [@@deriving show]
 
-type name = string
-  [@@deriving show]
-
 type name_set = Utility.stringset
   [@@deriving show]
 type 'a name_map = 'a Utility.stringmap
@@ -40,14 +37,14 @@ type value =
   | Constant   of Constant.t
   | Variable   of var
   | Extend     of value name_map * value option
-  | Project    of name * value
+  | Project    of Name.t * value
   | Erase      of name_set * value
-  | Inject     of name * value * Types.datatype
+  | Inject     of Name.t * value * Types.datatype
 
   | TAbs       of tyvar list * value
   | TApp       of value * tyarg list
 
-  | XmlNode    of name * value name_map * value list
+  | XmlNode    of Name.t * value name_map * value list
   | ApplyPure  of value * value list
 
   | Closure    of var * tyarg list * value
@@ -66,7 +63,7 @@ and binding =
   | Let        of binder * (tyvar list * tail_computation)
   | Fun        of fun_def
   | Rec        of fun_def list
-  | Alien      of binder * name * language
+  | Alien      of binder * Name.t * language
   | Module     of string * binding list option
 and special =
   | Wrong      of Types.datatype
@@ -85,10 +82,10 @@ and special =
   | Update     of (binder * value) * computation option * computation
   | Delete     of (binder * value) * computation option
   | CallCC     of value
-  | Select     of name * value
+  | Select     of Name.t * value
   | Choice     of value * (binder * computation) name_map
   | Handle     of handler
-  | DoOperation of name * value list * Types.datatype
+  | DoOperation of Name.t * value list * Types.datatype
 and computation = binding list * tail_computation
 and effect_case = binder * binder * computation
 and handler = {

--- a/core/ir.mli
+++ b/core/ir.mli
@@ -18,9 +18,6 @@ type tyvar = Types.quantifier
 type tyarg = Types.type_arg
   [@@deriving show]
 
-type name = string
-  [@@deriving show]
-
 type name_set = Utility.stringset
   [@@deriving show]
 type 'a name_map = 'a Utility.stringmap
@@ -41,14 +38,14 @@ type value =
   | Constant   of Constant.t                      (* constant: c *)
   | Variable   of var                             (* variable use: x *)
   | Extend     of value name_map * value option   (* record extension: (l1=v1, ..., lk=vk|r) or (l1=v1, ..., lk=vk) *)
-  | Project    of name * value                    (* record projection: r.l *)
+  | Project    of Name.t * value                    (* record projection: r.l *)
   | Erase      of name_set * value                (* erase fields from a record: r\{ls} *)
-  | Inject     of name * value * Types.datatype   (* variant injection: L(v) *)
+  | Inject     of Name.t * value * Types.datatype   (* variant injection: L(v) *)
 
   | TAbs       of tyvar list * value       (* type abstraction: /\xs.v *)
   | TApp       of value * tyarg list       (* type application: v ts *)
 
-  | XmlNode    of name * value name_map * value list
+  | XmlNode    of Name.t * value name_map * value list
                                        (* XML node construction: <tag attributes>body</tag> *)
   | ApplyPure  of value * value list   (* non-side-effecting application: v ws *)
 
@@ -67,7 +64,7 @@ and binding =
   | Let        of binder * (tyvar list * tail_computation)
   | Fun        of fun_def
   | Rec        of fun_def list
-  | Alien      of binder * name * language
+  | Alien      of binder * Name.t * language
   | Module     of string * binding list option
 and special =
   | Wrong      of Types.datatype
@@ -86,10 +83,10 @@ and special =
   | Update     of (binder * value) * computation option * computation
   | Delete     of (binder * value) * computation option
   | CallCC     of value
-  | Select     of name * value
+  | Select     of Name.t * value
   | Choice     of value * (binder * computation) name_map
   | Handle     of handler
-  | DoOperation of name * value list * Types.datatype
+  | DoOperation of Name.t * value list * Types.datatype
 and computation = binding list * tail_computation
 and effect_case = binder * binder * computation
 and handler = {

--- a/core/ir.mli
+++ b/core/ir.mli
@@ -13,7 +13,7 @@ type binder = Var.binder
   [@@deriving show]
 
 (* type variables *)
-type tyvar = Types.quantifier
+type tyvar = Quantifier.t
   [@@deriving show]
 type tyarg = Types.type_arg
   [@@deriving show]

--- a/core/irCheck.ml
+++ b/core/irCheck.ml
@@ -314,8 +314,8 @@ let eq_types occurrence : type_eq_context -> (Types.datatype * Types.datatype) -
               List.fold_left2 (fun (context, prev_eq) lqvar rqvar ->
                   let lid, _ = lqvar in
                   let rid, _ = rqvar in
-                  let l_kind = Types.kind_of_quantifier lqvar in
-                  let r_kind = Types.kind_of_quantifier rqvar in
+                  let l_kind = Quantifier.to_kind lqvar in
+                  let r_kind = Quantifier.to_kind rqvar in
                   let ctx' = { typevar_subst = IntMap.add lid rid context.typevar_subst;
                                tyenv = Env.bind context.tyenv (rid, r_kind)
                              } in
@@ -535,13 +535,13 @@ struct
         | TAbs (tyvars, v) ->
             let o = List.fold_left
               (fun o quant ->
-                let var = var_of_quantifier quant in
-                let kind = kind_of_quantifier quant in
+                let var  = Quantifier.to_var  quant in
+                let kind = Quantifier.to_kind quant in
                 o#add_typevar_to_context var kind) o tyvars in
             let v, t, o = o#value v in
             let o = List.fold_left
               (fun o quant ->
-                let var = var_of_quantifier quant in
+                let var = Quantifier.to_var quant in
                 o#remove_typevar_to_context var) o tyvars in
             let t = Types.for_all (tyvars, t) in
               TAbs (tyvars, v), t, o
@@ -595,8 +595,8 @@ struct
 
                 let outer_to_inner_type_var_map  =
                   List.fold_left2 (fun map iq oq  ->
-                      let iv = Types.var_of_quantifier iq in
-                      let ov = Types.var_of_quantifier oq in
+                      let iv = Quantifier.to_var iq in
+                      let ov = Quantifier.to_var oq in
                       IntMap.add ov iv map
                     )  IntMap.empty inner_quantifiers outer_quantifiers  in
 
@@ -1093,8 +1093,8 @@ struct
         (if is_recursive then o#impose_presence_of_effect "wild" Types.unit_type occurrence);
         let o = List.fold_left
               (fun o quant ->
-                let var = var_of_quantifier quant in
-                let kind = kind_of_quantifier quant in
+                let var  = Quantifier.to_var  quant in
+                let kind = Quantifier.to_kind quant in
                 o#add_typevar_to_context var kind) o tyvars in
 
         (* determine body type, using translated version of expected effects in context *)
@@ -1103,7 +1103,7 @@ struct
 
         let o = List.fold_left
               (fun o quant ->
-                let var = var_of_quantifier quant in
+                let var = Quantifier.to_var quant in
                 o#remove_typevar_to_context var) o tyvars in
         let o, _ = o#set_allowed_effects previously_allowed_effects in
 
@@ -1131,13 +1131,13 @@ struct
             lazy (
               let o = List.fold_left
                 (fun o quant ->
-                  let var = var_of_quantifier quant in
-                  let kind = kind_of_quantifier quant in
+                  let var  = Quantifier.to_var  quant in
+                  let kind = Quantifier.to_kind quant in
                   o#add_typevar_to_context var kind) o tyvars in
               let tc, act, o = o#tail_computation tc in
               let o = List.fold_left
                 (fun o quant ->
-                  let var = var_of_quantifier quant in
+                  let var = Quantifier.to_var quant in
                   o#remove_typevar_to_context var) o tyvars in
               let exp = Var.type_of_binder x in
               let act_foralled = Types.for_all (tyvars, act) in

--- a/core/irCheck.ml
+++ b/core/irCheck.ml
@@ -1066,7 +1066,7 @@ struct
       (if it exists), must be added to the environment before calling *)
     method handle_funbinding
              (expected_overall_funtype : datatype)
-             (tyvars : Types.quantifier list)
+             (tyvars : Quantifier.t list)
              (parameter_types : datatype list)
              (body : computation)
              (is_recursive : bool)

--- a/core/irCheck.ml
+++ b/core/irCheck.ml
@@ -134,7 +134,7 @@ module Env = Env.Int
 
 type type_eq_context = {
   typevar_subst : Var.var IntMap.t; (* equivalences of typevars *)
-  tyenv: Types.kind Env.t (* track kinds of bound typevars *)
+  tyenv: Kind.t Env.t (* track kinds of bound typevars *)
 }
 
 

--- a/core/operators.ml
+++ b/core/operators.ml
@@ -11,7 +11,7 @@
    longer exists this module can be merged back into Sugartypes.
 *)
 
-type name = string [@@deriving show]
+open CommonTypes
 
 type regexflag = RegexList | RegexNative | RegexGlobal | RegexReplace
     [@@deriving show]
@@ -25,7 +25,7 @@ module UnaryOp = struct
   type t =
     | Minus
     | FloatMinus
-    | Name of name
+    | Name of Name.t
     [@@deriving show]
 
   let to_string = function
@@ -42,7 +42,7 @@ module BinaryOp = struct
     | And
     | Or
     | Cons
-    | Name of name
+    | Name of Name.t
     [@@deriving show]
 
   let to_string = function
@@ -57,6 +57,6 @@ end
 
 (* Operator section *)
 module Section = struct
-  type t = Minus | FloatMinus | Project of name | Name of name
+  type t = Minus | FloatMinus | Project of Name.t | Name of Name.t
     [@@deriving show]
 end

--- a/core/parser.mly
+++ b/core/parser.mly
@@ -298,7 +298,7 @@ end
 %type <Sugartypes.regex> regex_pattern
 %type <Sugartypes.regex list> regex_pattern_sequence
 %type <Sugartypes.Pattern.with_pos> pattern
-%type <(DeclaredLinearity.t * bool) * Sugartypes.name *
+%type <(DeclaredLinearity.t * bool) * Name.t *
        Sugartypes.Pattern.with_pos list list * Location.t *
        Sugartypes.phrase> tlfunbinding
 %type <Sugartypes.phrase> postfix_expression

--- a/core/sugarConstructors.ml
+++ b/core/sugarConstructors.ml
@@ -34,10 +34,10 @@ module SugarConstructors (Position : Pos)
 
   (* Stores either a name of variable to be used in a binding pattern or the
      pattern itself.  Used for passing an argument to val_binding. *)
-  type name_or_pat = PatName of name | Pat of Pattern.with_pos
+  type name_or_pat = PatName of Name.t | Pat of Pattern.with_pos
 
   (* Optionally stores a datatype signature.  Isomporphic to Option. *)
-  type signature = (name WithPos.t * datatype') WithPos.t option
+  type signature = (Name.t WithPos.t * datatype') WithPos.t option
 
   (* Produces a datatype if a name is accompanied by a signature.  Raises an
      exception if name does not match a name in a signature. *)

--- a/core/sugarConstructorsIntf.ml
+++ b/core/sugarConstructorsIntf.ml
@@ -44,25 +44,25 @@ module type SugarConstructorsSig = sig
 
   (* Helper data types and functions for passing arguments to smart
      constructors.  *)
-  type name_or_pat = PatName of name
+  type name_or_pat = PatName of Name.t
                    | Pat     of Pattern.with_pos
 
-  type signature = (name WithPos.t * datatype') WithPos.t option
+  type signature = (Name.t WithPos.t * datatype') WithPos.t option
 
   (* Common stuff *)
-  val var         : ?ppos:t -> name -> phrase
-  val freeze_var  : ?ppos:t -> name -> phrase
+  val var         : ?ppos:t -> Name.t -> phrase
+  val freeze_var  : ?ppos:t -> Name.t -> phrase
   val block       : ?ppos:t -> block_body -> phrase
   val block_node  :            block_body -> phrasenode
   val datatype    : Datatype.with_pos -> Datatype.with_pos * 'a option
   val cp_unit     : t -> cp_phrase
-  val record      : ?ppos:t -> ?exp:phrase -> (name * phrase) list -> phrase
+  val record      : ?ppos:t -> ?exp:phrase -> (Name.t * phrase) list -> phrase
   val tuple       : ?ppos:t -> phrase list -> phrase
   val orderby_tuple : ?ppos:t -> phrase list -> phrase
   val list        :
     ?ppos:t -> ?ty:Types.datatype -> phrase list -> phrase
   val constructor :
-    ?ppos:t -> ?body:phrase -> ?ty:Types.datatype -> name -> phrase
+    ?ppos:t -> ?body:phrase -> ?ty:Types.datatype -> Name.t -> phrase
 
   (* Constants *)
   val constant      : ?ppos:t -> Constant.t -> phrase
@@ -70,13 +70,13 @@ module type SugarConstructorsSig = sig
   val constant_char : ?ppos:t -> char       -> phrase
 
   (* Binders *)
-  val binder   : ?ppos:t -> ?ty:Types.datatype -> name -> Binder.with_pos
+  val binder   : ?ppos:t -> ?ty:Types.datatype -> Name.t -> Binder.with_pos
 
   (* Imports *)
-  val import : ?ppos:t -> ?pollute:bool -> name list -> binding
+  val import : ?ppos:t -> ?pollute:bool -> Name.t list -> binding
 
   (* Patterns *)
-  val variable_pat : ?ppos:t -> ?ty:Types.datatype -> name -> Pattern.with_pos
+  val variable_pat : ?ppos:t -> ?ty:Types.datatype -> Name.t -> Pattern.with_pos
   val tuple_pat    : ?ppos:t -> Pattern.with_pos list -> Pattern.with_pos
   val any_pat      : t -> Pattern.with_pos
 
@@ -98,16 +98,16 @@ module type SugarConstructorsSig = sig
      -> ?row:Types.row -> spawn_kind -> given_spawn_location -> phrase
      -> phrase
   val fn_appl_node
-      : ?ppos:t -> name -> tyarg list -> phrase list -> phrasenode
+      : ?ppos:t -> Name.t -> tyarg list -> phrase list -> phrasenode
   val fn_appl
-      : ?ppos:t -> name -> tyarg list -> phrase list -> phrase
+      : ?ppos:t -> Name.t -> tyarg list -> phrase list -> phrase
   val fn_appl_var
-      : ?ppos:t -> name -> name -> phrase
+      : ?ppos:t -> Name.t -> Name.t -> phrase
 
   (* Bindings *)
   val fun_binding
       : ?ppos:t -> signature -> ?unsafe_sig:bool
-     -> ((DeclaredLinearity.t * bool) * name * Pattern.with_pos list list * Location.t * phrase)
+     -> ((DeclaredLinearity.t * bool) * Name.t * Pattern.with_pos list list * Location.t * phrase)
      -> binding
   val fun_binding'
       : ?ppos:t -> ?linearity:DeclaredLinearity.t -> ?tyvars:tyvar list
@@ -127,9 +127,9 @@ module type SugarConstructorsSig = sig
 
   (* Database queries *)
   val db_exps
-      : ?ppos:t -> (name * phrase) list -> phrase
+      : ?ppos:t -> (Name.t * phrase) list -> phrase
   val db_insert
-      : ?ppos:t -> phrase -> name list -> phrase -> string option
+      : ?ppos:t -> phrase -> Name.t list -> phrase -> string option
      -> phrase
   val query
       : ?ppos:t -> (phrase * phrase) option -> phrase -> phrase
@@ -143,8 +143,8 @@ module type SugarConstructorsSig = sig
   val validate_xml
       : ?tags:(string * string) -> phrase -> unit
   val xml
-      : ?ppos:t -> ?tags:(string * string) -> name
-     -> (name * (phrase list)) list -> phrase option -> phrase list
+      : ?ppos:t -> ?tags:(string * string) -> Name.t
+     -> (Name.t * (phrase list)) list -> phrase option -> phrase list
      -> phrase
 
   (* Handlers *)

--- a/core/sugarConstructorsIntf.ml
+++ b/core/sugarConstructorsIntf.ml
@@ -40,7 +40,7 @@ module type SugarConstructorsSig = sig
   val with_dummy_pos : 'a -> 'a WithPos.t
 
   (* Fresh type variables. *)
-  val fresh_known_type_variable  : freedom -> known_type_variable
+  val fresh_known_type_variable  : Freedom.t -> known_type_variable
 
   (* Helper data types and functions for passing arguments to smart
      constructors.  *)

--- a/core/sugarTraversals.ml
+++ b/core/sugarTraversals.ml
@@ -74,7 +74,7 @@ class map =
 
     method kind : kind -> kind = fun x -> x
 
-    method freedom : freedom -> freedom = fun x -> x
+    method freedom : Freedom.t -> Freedom.t = fun x -> x
 
     method type_variable : type_variable -> type_variable =
       fun (_x, _x_i1, _x_i2) ->
@@ -841,7 +841,7 @@ class fold =
 
     method kind : kind -> 'self_type = fun _ -> o
 
-    method freedom : freedom -> 'self_type = fun _ -> o
+    method freedom : Freedom.t -> 'self_type = fun _ -> o
 
     method type_variable : type_variable -> 'self_type =
       fun (_x, _x_i1, _x_i2) ->
@@ -1535,7 +1535,7 @@ class fold_map =
 
     method kind : kind -> ('self_type * kind) = fun k -> (o, k)
 
-    method freedom : freedom -> ('self_type * freedom) = fun k -> (o, k)
+    method freedom : Freedom.t -> ('self_type * Freedom.t) = fun k -> (o, k)
 
     method type_variable : type_variable -> ('self_type * type_variable) =
       fun (_x, _x_i1, _x_i2) ->

--- a/core/sugarTraversals.ml
+++ b/core/sugarTraversals.ml
@@ -527,7 +527,7 @@ class map =
       fun p ->
         WithPos.map2 ~f_pos:o#position ~f_node:o#patternnode p
 
-    method name : name -> name = o#string
+    method name : Name.t -> Name.t = o#string
 
     method location : Location.t -> Location.t = o#unknown
 
@@ -1235,7 +1235,7 @@ class fold =
         ~f_pos:(fun o v -> o#position v)
         ~f_node:(fun o v -> o#patternnode v)
 
-    method name : name -> 'self_type = o#string
+    method name : Name.t -> 'self_type = o#string
 
     method location : Location.t -> 'self_type = o#unknown
 
@@ -2016,7 +2016,7 @@ class fold_map =
         ~f_pos:(fun o v -> o#position v)
         ~f_node:(fun o v -> o#patternnode v)
 
-    method name : name -> ('self_type * name) = o#string
+    method name : Name.t -> ('self_type * Name.t) = o#string
 
     method location : Location.t -> ('self_type * Location.t) = o#unknown
 

--- a/core/sugarTraversals.ml
+++ b/core/sugarTraversals.ml
@@ -70,7 +70,7 @@ class map =
       | Project _x -> let _x = o#name _x in Project _x
       | Name _x -> let _x = o#name _x in Name _x
 
-    method subkind : subkind -> subkind = fun x -> x
+    method subkind : Subkind.t -> Subkind.t = fun x -> x
 
     method kind : kind -> kind = fun x -> x
 
@@ -837,7 +837,7 @@ class fold =
       | Project _x -> let o = o#name _x in o
       | Name _x -> let o = o#name _x in o
 
-    method subkind : subkind -> 'self_type = fun _ -> o
+    method subkind : Subkind.t -> 'self_type = fun _ -> o
 
     method kind : kind -> 'self_type = fun _ -> o
 
@@ -1531,7 +1531,7 @@ class fold_map =
       | Project _x -> let (o, _x) = o#name _x in (o, Project _x)
       | Name _x -> let (o, _x) = o#name _x in (o, Name _x)
 
-    method subkind : subkind -> ('self_type * subkind) = fun k -> (o, k)
+    method subkind : Subkind.t -> ('self_type * Subkind.t) = fun k -> (o, k)
 
     method kind : kind -> ('self_type * kind) = fun k -> (o, k)
 

--- a/core/sugarTraversals.mli
+++ b/core/sugarTraversals.mli
@@ -48,7 +48,7 @@ class map :
     method cp_phrase       : cp_phrase -> cp_phrase
     method patternnode     : Pattern.t -> Pattern.t
     method pattern         : Pattern.with_pos -> Pattern.with_pos
-    method name            : name -> name
+    method name            : Name.t -> Name.t
     method location        : Location.t -> Location.t
     method iterpatt        : iterpatt -> iterpatt
     method funlit          : funlit -> funlit
@@ -127,7 +127,7 @@ class fold :
     method cp_phrase       : cp_phrase -> 'self
     method patternnode     : Pattern.t -> 'self
     method pattern         : Pattern.with_pos -> 'self
-    method name            : name -> 'self
+    method name            : Name.t -> 'self
     method location        : Location.t -> 'self
     method iterpatt        : iterpatt -> 'self
     method funlit          : funlit -> 'self
@@ -193,7 +193,7 @@ object ('self)
   method iterpatt        : iterpatt -> 'self * iterpatt
   method list            : 'a . ('self -> 'a -> 'self * 'a) -> 'a list -> 'self * 'a list
   method location        : Location.t -> 'self * Location.t
-  method name            : name -> 'self * name
+  method name            : Name.t -> 'self * Name.t
   method option          : 'a . ('self -> 'a -> 'self * 'a) -> 'a option -> 'self * 'a option
   method patternnode     : Pattern.t -> 'self * Pattern.t
   method pattern         : Pattern.with_pos -> 'self * Pattern.with_pos
@@ -212,7 +212,7 @@ object ('self)
   method row_var         : Datatype.row_var -> 'self * Datatype.row_var
   method section         : Section.t -> 'self * Section.t
   method sentence        : sentence -> 'self * sentence
-  method string          : name -> 'self * name
+  method string          : Name.t -> 'self * Name.t
   method subkind         : subkind -> 'self * subkind
   method kind            : kind -> 'self * kind
   method freedom         : freedom -> 'self * freedom

--- a/core/sugarTraversals.mli
+++ b/core/sugarTraversals.mli
@@ -30,7 +30,7 @@ class map :
     method binder          : Binder.with_pos -> Binder.with_pos
     method sentence        : sentence -> sentence
     method section         : Section.t -> Section.t
-    method subkind         : subkind -> subkind
+    method subkind         : Subkind.t -> Subkind.t
     method kind            : kind -> kind
     method freedom         : freedom -> freedom
     method type_variable   : type_variable -> type_variable
@@ -109,7 +109,7 @@ class fold :
     method binder          : Binder.with_pos -> 'self
     method sentence        : sentence -> 'self
     method section         : Section.t -> 'self
-    method subkind         : subkind -> 'self
+    method subkind         : Subkind.t -> 'self
     method kind            : kind -> 'self
     method freedom         : freedom -> 'self
     method type_variable   : type_variable -> 'self
@@ -213,7 +213,7 @@ object ('self)
   method section         : Section.t -> 'self * Section.t
   method sentence        : sentence -> 'self * sentence
   method string          : Name.t -> 'self * Name.t
-  method subkind         : subkind -> 'self * subkind
+  method subkind         : Subkind.t -> 'self * Subkind.t
   method kind            : kind -> 'self * kind
   method freedom         : freedom -> 'self * freedom
   method type_variable   : type_variable -> 'self * type_variable

--- a/core/sugarTraversals.mli
+++ b/core/sugarTraversals.mli
@@ -32,7 +32,7 @@ class map :
     method section         : Section.t -> Section.t
     method subkind         : Subkind.t -> Subkind.t
     method kind            : kind -> kind
-    method freedom         : freedom -> freedom
+    method freedom         : Freedom.t -> Freedom.t
     method type_variable   : type_variable -> type_variable
     method known_type_variable   : known_type_variable -> known_type_variable
     method row_var         : Datatype.row_var -> Datatype.row_var
@@ -111,7 +111,7 @@ class fold :
     method section         : Section.t -> 'self
     method subkind         : Subkind.t -> 'self
     method kind            : kind -> 'self
-    method freedom         : freedom -> 'self
+    method freedom         : Freedom.t -> 'self
     method type_variable   : type_variable -> 'self
     method known_type_variable : known_type_variable -> 'self
     method row_var         : Datatype.row_var -> 'self
@@ -215,7 +215,7 @@ object ('self)
   method string          : Name.t -> 'self * Name.t
   method subkind         : Subkind.t -> 'self * Subkind.t
   method kind            : kind -> 'self * kind
-  method freedom         : freedom -> 'self * freedom
+  method freedom         : Freedom.t -> 'self * Freedom.t
   method type_variable   : type_variable -> 'self * type_variable
   method known_type_variable : known_type_variable -> 'self * known_type_variable
   method type_arg        : Datatype.type_arg -> 'self * Datatype.type_arg

--- a/core/sugartoir.ml
+++ b/core/sugartoir.ml
@@ -125,11 +125,11 @@ sig
   val letvar : (var_info * tail_computation sem * tyvar list *
                (var -> tail_computation sem)) -> tail_computation sem
 
-  val xml : value sem * string * (name * (value sem) list) list * (value sem) list -> value sem
-  val record : (name * value sem) list * (value sem) option -> value sem
+  val xml : value sem * string * (Name.t * (value sem) list) list * (value sem) list -> value sem
+  val record : (Name.t * value sem) list * (value sem) option -> value sem
 
-  val project : value sem * name -> value sem
-  val update : value sem * (name * value sem) list -> value sem
+  val project : value sem * Name.t -> value sem
+  val update : value sem * (Name.t * value sem) list -> value sem
 
   val coerce : value sem * datatype -> value sem
 
@@ -141,7 +141,7 @@ sig
   val db_update : env -> (CompilePatterns.Pattern.t * value sem * tail_computation sem option * tail_computation sem) -> tail_computation sem
   val db_delete : env -> (CompilePatterns.Pattern.t * value sem * tail_computation sem option) -> tail_computation sem
 
-  val do_operation : name * (value sem) list * Types.datatype -> tail_computation sem
+  val do_operation : Name.t * (value sem) list * Types.datatype -> tail_computation sem
 
   val handle : env -> (tail_computation sem *
                          (CompilePatterns.Pattern.t * (env -> tail_computation sem)) list *
@@ -152,7 +152,7 @@ sig
 
   val switch : env -> (value sem * (CompilePatterns.Pattern.t * (env -> tail_computation sem)) list * Types.datatype) -> tail_computation sem
 
-  val inject : name * value sem * datatype -> value sem
+  val inject : Name.t * value sem * datatype -> value sem
   (* val case : *)
   (*   value sem * string * (var_info * (var -> tail_computation sem)) * *)
   (*   (var_info * (var -> tail_computation sem)) option -> *)
@@ -193,9 +193,9 @@ sig
     (var list -> tail_computation sem) ->
     tail_computation sem
 
-  val alien : var_info * name * language * (var -> tail_computation sem) -> tail_computation sem
+  val alien : var_info * Name.t * language * (var -> tail_computation sem) -> tail_computation sem
 
-  val select : name * value sem -> tail_computation sem
+  val select : Name.t * value sem -> tail_computation sem
 
   val offer : env -> (value sem * (CompilePatterns.Pattern.t * (env -> tail_computation sem)) list * Types.datatype) -> tail_computation sem
 end
@@ -283,7 +283,7 @@ struct
        * location) list ->
       (Var.var list) M.sem
 
-    val alien_binding : var_info * name * language -> var M.sem
+    val alien_binding : var_info * Name.t * language -> var M.sem
 
     val value_of_untyped_var : var M.sem * datatype -> value sem
   end =

--- a/core/sugartoir.ml
+++ b/core/sugartoir.ml
@@ -114,7 +114,7 @@ sig
 
   val escape : (var_info * Types.row * (var -> tail_computation sem)) -> tail_computation sem
 
-  val tabstr : (Types.quantifier list * value sem) -> value sem
+  val tabstr : (Quantifier.t list * value sem) -> value sem
   val tappl : (value sem * Types.type_arg list) -> value sem
 
   val apply : (value sem * (value sem) list) -> tail_computation sem
@@ -183,13 +183,13 @@ sig
 
   val letfun :
     env ->
-    (var_info * (Types.quantifier list * (CompilePatterns.Pattern.t list * tail_computation sem)) * location) ->
+    (var_info * (Quantifier.t list * (CompilePatterns.Pattern.t list * tail_computation sem)) * location) ->
     (var -> tail_computation sem) ->
     tail_computation sem
 
   val letrec :
     env ->
-    (var_info * (Types.quantifier list * (CompilePatterns.Pattern.t list * (var list -> tail_computation sem))) * location) list ->
+    (var_info * (Quantifier.t list * (CompilePatterns.Pattern.t list * (var list -> tail_computation sem))) * location) list ->
     (var list -> tail_computation sem) ->
     tail_computation sem
 

--- a/core/sugartypes.ml
+++ b/core/sugartypes.ml
@@ -73,11 +73,11 @@ let default_effect_subkind : Subkind.t = (lin_unl, res_any)
 type kind = PrimaryKind.t option * Subkind.t option
     [@@deriving show]
 
-type type_variable = Name.t * kind * freedom
+type type_variable = Name.t * kind * Freedom.t
     [@@deriving show]
 
 (* type variable of primary kind Type? *)
-type known_type_variable = Name.t * Subkind.t option * freedom
+type known_type_variable = Name.t * Subkind.t option * Freedom.t
     [@@deriving show]
 
 type quantifier = type_variable

--- a/core/sugartypes.ml
+++ b/core/sugartypes.ml
@@ -67,17 +67,17 @@ type tyarg = Types.type_arg
    i.e. in let-bindings.
 *)
 
-let default_subkind : subkind = (lin_unl, res_any)
-let default_effect_subkind : subkind = (lin_unl, res_any)
+let default_subkind : Subkind.t = (lin_unl, res_any)
+let default_effect_subkind : Subkind.t = (lin_unl, res_any)
 
-type kind = PrimaryKind.t option * subkind option
+type kind = PrimaryKind.t option * Subkind.t option
     [@@deriving show]
 
 type type_variable = Name.t * kind * freedom
     [@@deriving show]
 
 (* type variable of primary kind Type? *)
-type known_type_variable = Name.t * subkind option * freedom
+type known_type_variable = Name.t * Subkind.t option * freedom
     [@@deriving show]
 
 type quantifier = type_variable
@@ -89,7 +89,7 @@ let string_of_type_variable ((var, (kind, subkind), _) : type_variable) =
   match kind with
   | None -> var
   | Some kind ->
-     let subkind = OptionUtils.opt_app string_of_subkind "" subkind in
+     let subkind = OptionUtils.opt_app Subkind.to_string "" subkind in
      var ^ "::" ^ PrimaryKind.to_string kind ^ subkind
 
 type fieldconstraint = Readonly | Default

--- a/core/sugartypes.ml
+++ b/core/sugartypes.ml
@@ -55,7 +55,7 @@ end = struct
 end
 
 (* type variables *)
-type tyvar = Types.quantifier
+type tyvar = Quantifier.t
   [@@deriving show]
 type tyarg = Types.type_arg
   [@@deriving show]

--- a/core/transformSugar.ml
+++ b/core/transformSugar.ml
@@ -721,7 +721,7 @@ class transform (env : Types.typing_environment) =
         | Constant.Bool v   -> (o, Constant.Bool v  , Types.bool_type  )
         | Constant.Char v   -> (o, Constant.Char v  , Types.char_type  )
 
-    method quantifiers : Types.quantifier list -> ('self_type * Types.quantifier list) =
+    method quantifiers : Quantifier.t list -> ('self_type * Quantifier.t list) =
       fun qs -> (o, qs)
     method backup_quantifiers : IntSet.t = IntSet.empty
     method restore_quantifiers : IntSet.t -> 'self_type = fun _ -> o

--- a/core/transformSugar.ml
+++ b/core/transformSugar.ml
@@ -164,7 +164,7 @@ class transform (env : Types.typing_environment) =
     method bind_tycon name tycon =
       {< tycon_env = TyEnv.bind tycon_env (name, tycon) >}
 
-    method lookup_type : name -> Types.datatype = fun var ->
+    method lookup_type : Name.t -> Types.datatype = fun var ->
       TyEnv.lookup var_env var
 
     method lookup_effects : Types.row = effect_row

--- a/core/transformSugar.mli
+++ b/core/transformSugar.mli
@@ -58,7 +58,7 @@ object ('self)
   method funlit          : Types.row -> funlit -> 'self * funlit * Types.datatype
   method iterpatt        : iterpatt -> 'self * iterpatt
 
-  method quantifiers     : Types.quantifier list -> 'self * Types.quantifier list
+  method quantifiers     : Quantifier.t list -> 'self * Quantifier.t list
   method backup_quantifiers : Utility.IntSet.t
   method restore_quantifiers : Utility.IntSet.t -> 'self
 

--- a/core/transformSugar.mli
+++ b/core/transformSugar.mli
@@ -46,7 +46,7 @@ object ('self)
 
   method bind_tycon      : string -> Types.tycon_spec -> 'self
 
-  method lookup_type     : name -> Types.datatype
+  method lookup_type     : Name.t -> Types.datatype
   method lookup_effects  : Types.row
   method with_effects    : Types.row -> 'self
 

--- a/core/typeSugar.ml
+++ b/core/typeSugar.ml
@@ -3136,7 +3136,7 @@ let rec type_check : context -> phrase -> phrase * Types.datatype * usagemap =
                           (* the free type variables in the arguments (and effects) *)
                           let arg_vars = Types.TypeVarSet.union (Types.free_type_vars fps) (Types.free_row_type_vars fe) in
                           (* return true if this quantifier appears free in the arguments (or effects) *)
-                          let free_in_arg q = Types.TypeVarSet.mem (Types.var_of_quantifier q) arg_vars in
+                          let free_in_arg q = Types.TypeVarSet.mem (Quantifier.to_var q) arg_vars in
 
                           (* quantifiers for the return type *)
                           let rqs =
@@ -3457,7 +3457,7 @@ let rec type_check : context -> phrase -> phrase * Types.datatype * usagemap =
 
                           (* return true if this quantifier appears
                              free in the projected type *)
-                          let free_in_body q = Types.TypeVarSet.mem (Types.var_of_quantifier q) vars in
+                          let free_in_body q = Types.TypeVarSet.mem (Quantifier.to_var q) vars in
 
                           (* quantifiers for the projected type *)
                           let pta, pqs =
@@ -4159,7 +4159,7 @@ and type_binding : context -> binding -> binding * context * usagemap =
                  | t_tyvars ->
                    if not (List.for_all
                              (fun q ->
-                               List.exists (Types.eq_quantifiers q) t_tyvars) tyvars)
+                               List.exists (Quantifier.eq q) t_tyvars) tyvars)
                    then
                      Gripers.inconsistent_quantifiers ~pos ~t1:t ~t2:ft;
                    t_tyvars, t
@@ -4337,7 +4337,7 @@ and type_binding : context -> binding -> binding * context * usagemap =
                            if not
                                 (List.for_all
                                    (fun q ->
-                                     List.exists (Types.eq_quantifiers q) outer_tyvars) body_tyvars) then
+                                     List.exists (Quantifier.eq q) outer_tyvars) body_tyvars) then
                              Gripers.inconsistent_quantifiers ~pos ~t1:outer ~t2:gen;
 
                            (* We could check that inner_tyvars is
@@ -4363,7 +4363,7 @@ and type_binding : context -> binding -> binding * context * usagemap =
                              let rec find p i =
                                function
                                | [] -> None
-                               | q :: _ when Types.eq_quantifiers p q -> Some i
+                               | q :: _ when Quantifier.eq p q -> Some i
                                | _ :: qs -> find p (i+1) qs in
                              let find p = find p 0 inner_tyvars in
                              List.map find outer_tyvars

--- a/core/typeSugar.ml
+++ b/core/typeSugar.ml
@@ -49,7 +49,7 @@ let generalise_toplevel
 module Env = Env.String
 
 module Utils : sig
-  val dummy_source_name : unit -> name
+  val dummy_source_name : unit -> Name.t
   val unify : Types.datatype * Types.datatype -> unit
   val instantiate : Types.environment -> string ->
                     (Types.type_arg list * Types.datatype)

--- a/core/typeSugar.ml
+++ b/core/typeSugar.ml
@@ -54,7 +54,7 @@ module Utils : sig
   val instantiate : Types.environment -> string ->
                     (Types.type_arg list * Types.datatype)
   val generalise : ?unwrap:bool -> Types.environment -> Types.datatype ->
-                   ((Types.quantifier list*Types.type_arg list) * Types.datatype)
+                   ((Quantifier.t list*Types.type_arg list) * Types.datatype)
 
   (* val is_pure : phrase -> bool *)
   val is_pure_binding : binding -> bool

--- a/core/typeUtils.mli
+++ b/core/typeUtils.mli
@@ -1,3 +1,5 @@
+open CommonTypes
+
 (** type destructors *)
 exception TypeDestructionError of string
 
@@ -27,8 +29,8 @@ val split_row : string -> Types.row -> (Types.datatype * Types.row)
 val split_variant_type : string -> Types.datatype -> (Types.datatype * Types.datatype)
 val variant_at : ?overstep_quantifiers:bool -> string -> Types.datatype -> Types.datatype
 
-val quantifiers : Types.datatype -> Types.quantifier list
-val split_quantified_type : Types.datatype -> (Types.quantifier list * Types.datatype)
+val quantifiers : Types.datatype -> Quantifier.t list
+val split_quantified_type : Types.datatype -> (Quantifier.t list * Types.datatype)
 
 val record_without : Types.datatype -> Utility.StringSet.t -> Types.datatype
 

--- a/core/types.ml
+++ b/core/types.ml
@@ -19,11 +19,11 @@ module TypeVarMap = Utility.IntMap
 (* points *)
 type 'a point = 'a Unionfind.point [@@deriving show]
 
-type kind = PrimaryKind.t * subkind
+type kind = PrimaryKind.t * Subkind.t
     [@@deriving eq,show]
 
 type 't meta_type_var_non_rec_basis =
-    [ `Var of (int * subkind * freedom)
+    [ `Var of (int * Subkind.t * freedom)
     | `Body of 't ]
       [@@deriving show]
 
@@ -484,7 +484,7 @@ let kind_of_quantifier : quantifier -> kind =
 let primary_kind_of_quantifier : quantifier -> PrimaryKind.t =
   fun (_, (pk, _)) -> pk
 
-let subkind_of_quantifier : quantifier -> subkind
+let subkind_of_quantifier : quantifier -> Subkind.t
   = fun q ->
     snd (kind_of_quantifier q)
 
@@ -539,7 +539,7 @@ type visit_context = StringSet.t * var_set * var_set
    By default, this visits the entire type, and returns true iff all child nodes
    of the type satisfy the predicate. *)
 class virtual type_predicate = object(self)
-  method var_satisfies : (int * subkind * freedom) -> bool = fun _ -> true
+  method var_satisfies : (int * Subkind.t * freedom) -> bool = fun _ -> true
 
   method point_satisfies : 'a 'c . (visit_context -> 'a -> bool) -> visit_context -> ([< 'a meta_max_basis] as 'c) point -> bool
     = fun f ((rec_appl, rec_vars, quant_vars) as vars) point ->
@@ -599,7 +599,7 @@ end
     By default this does nothing. However, it can be extended by {!Constraint}s
     to mutate various flexible type variables. *)
 class virtual type_iter = object(self)
-  method visit_var : 'a 'c. ([< 'a meta_max_basis > `Var] as 'c) point -> (int * subkind * freedom) -> unit = fun _ _ -> ()
+  method visit_var : 'a 'c. ([< 'a meta_max_basis > `Var] as 'c) point -> (int * Subkind.t * freedom) -> unit = fun _ _ -> ()
 
   method visit_point : 'a 'c . (visit_context -> 'a -> unit) -> visit_context -> ([< 'a meta_max_basis > `Var] as 'c) point -> unit
     = fun f ((rec_appl, rec_vars, quant_vars) as vars) point ->
@@ -1863,7 +1863,7 @@ struct
     else
       empty_context
 
-  let subkind : (policy * names) -> subkind -> string =
+  let subkind : (policy * names) -> Subkind.t -> string =
     let full (l, r) = "(" ^ Linearity.to_string l ^ "," ^
                         Restriction.to_string r ^ ")" in
 

--- a/core/types.ml
+++ b/core/types.ml
@@ -19,9 +19,6 @@ module TypeVarMap = Utility.IntMap
 (* points *)
 type 'a point = 'a Unionfind.point [@@deriving show]
 
-type kind = PrimaryKind.t * Subkind.t
-    [@@deriving eq,show]
-
 type 't meta_type_var_non_rec_basis =
     [ `Var of (int * Subkind.t * freedom)
     | `Body of 't ]
@@ -48,7 +45,7 @@ module Abstype =
 struct
   type t = { id    : istring ;
              name  : istring ;
-             arity : kind list }
+             arity : Kind.t list }
       [@@deriving eq,show]
   let make name arity =
     let id = Utility.gensym ~prefix:"abstype:" () in
@@ -140,7 +137,7 @@ and rec_appl = {
   r_name: string;
   r_dual: bool;
   r_unique_name: string;
-  r_quantifiers : kind list;
+  r_quantifiers : Kind.t list;
   r_args: type_arg list;
   r_unwind: type_arg list -> bool -> typ;
   r_linear: unit -> bool option
@@ -155,7 +152,7 @@ and typ =
     | `Effect of row
     | `Table of typ * typ * typ
     | `Lens of Lens.Type.t
-    | `Alias of ((string * kind list * type_arg list) * typ)
+    | `Alias of ((string * Kind.t list * type_arg list) * typ)
     | `Application of (Abstype.t * type_arg list)
     | `RecursiveApplication of rec_appl
     | `MetaTypeVar of meta_type_var
@@ -169,7 +166,7 @@ and meta_type_var  = (typ meta_type_var_basis) point
 and meta_row_var   = (row meta_row_var_basis) point
 and meta_presence_var = (field_spec meta_presence_var_basis) point
 and meta_var = [ `Type of meta_type_var | `Row of meta_row_var | `Presence of meta_presence_var ]
-and quantifier = int * kind
+and quantifier = int * Kind.t
 and type_arg =
     [ `Type of typ | `Row of row | `Presence of field_spec ]
       [@@deriving show]
@@ -478,7 +475,7 @@ let var_of_quantifier : quantifier -> int =
   function
     | var, _ -> var
 
-let kind_of_quantifier : quantifier -> kind =
+let kind_of_quantifier : quantifier -> Kind.t =
   fun (_, k) -> k
 
 let primary_kind_of_quantifier : quantifier -> PrimaryKind.t =
@@ -1881,7 +1878,7 @@ struct
       | (Linearity.Unl, Restriction.Effect)  -> Restriction.to_string res_effect
       | (l, r) -> full (l, r)
 
-  let kind : (policy * names) -> kind -> string =
+  let kind : (policy * names) -> Kind.t -> string =
     let full (policy, _vars) (k, sk) =
       PrimaryKind.to_string k ^ subkind (policy, _vars) sk in
     fun (policy, _vars) (k, sk) ->

--- a/core/types.ml
+++ b/core/types.ml
@@ -20,7 +20,7 @@ module TypeVarMap = Utility.IntMap
 type 'a point = 'a Unionfind.point [@@deriving show]
 
 type 't meta_type_var_non_rec_basis =
-    [ `Var of (int * Subkind.t * freedom)
+    [ `Var of (int * Subkind.t * Freedom.t)
     | `Body of 't ]
       [@@deriving show]
 
@@ -536,7 +536,7 @@ type visit_context = StringSet.t * var_set * var_set
    By default, this visits the entire type, and returns true iff all child nodes
    of the type satisfy the predicate. *)
 class virtual type_predicate = object(self)
-  method var_satisfies : (int * Subkind.t * freedom) -> bool = fun _ -> true
+  method var_satisfies : (int * Subkind.t * Freedom.t) -> bool = fun _ -> true
 
   method point_satisfies : 'a 'c . (visit_context -> 'a -> bool) -> visit_context -> ([< 'a meta_max_basis] as 'c) point -> bool
     = fun f ((rec_appl, rec_vars, quant_vars) as vars) point ->
@@ -596,7 +596,7 @@ end
     By default this does nothing. However, it can be extended by {!Constraint}s
     to mutate various flexible type variables. *)
 class virtual type_iter = object(self)
-  method visit_var : 'a 'c. ([< 'a meta_max_basis > `Var] as 'c) point -> (int * Subkind.t * freedom) -> unit = fun _ _ -> ()
+  method visit_var : 'a 'c. ([< 'a meta_max_basis > `Var] as 'c) point -> (int * Subkind.t * Freedom.t) -> unit = fun _ _ -> ()
 
   method visit_point : 'a 'c . (visit_context -> 'a -> unit) -> visit_context -> ([< 'a meta_max_basis > `Var] as 'c) point -> unit
     = fun f ((rec_appl, rec_vars, quant_vars) as vars) point ->

--- a/core/types.ml
+++ b/core/types.ml
@@ -125,10 +125,9 @@ module RecIdMap = Map.Make(RecId)
 module type RECIDSET = Utility.Set with type elt = rec_id
 module RecIdSet : RECIDSET = Set.Make(RecId)
 
-
 type tygroup = {
   id: int;
-  type_map: ((quantifier list * typ) Utility.StringMap.t);
+  type_map: ((Quantifier.t list * typ) Utility.StringMap.t);
   linearity_map: bool Utility.StringMap.t
 }
 
@@ -156,7 +155,7 @@ and typ =
     | `Application of (Abstype.t * type_arg list)
     | `RecursiveApplication of rec_appl
     | `MetaTypeVar of meta_type_var
-    | `ForAll of (quantifier list * typ)
+    | `ForAll of (Quantifier.t list * typ)
     | (typ, row) session_type_basis ]
 and field_spec     = [ `Present of typ | `Absent | `Var of meta_presence_var ]
 and field_spec_map = field_spec field_env
@@ -166,7 +165,6 @@ and meta_type_var  = (typ meta_type_var_basis) point
 and meta_row_var   = (row meta_row_var_basis) point
 and meta_presence_var = (field_spec meta_presence_var_basis) point
 and meta_var = [ `Type of meta_type_var | `Row of meta_row_var | `Presence of meta_presence_var ]
-and quantifier = int * Kind.t
 and type_arg =
     [ `Type of typ | `Row of row | `Presence of field_spec ]
       [@@deriving show]
@@ -181,12 +179,12 @@ let is_present =
   | `Present _           -> true
   | (`Absent | `Var _) -> false
 
-type alias_type = quantifier list * typ [@@deriving show]
+type alias_type = Quantifier.t list * typ [@@deriving show]
 
 type tycon_spec = [
   | `Alias of alias_type
   | `Abstract of Abstype.t
-  | `Mutual of (quantifier list * tygroup ref) (* Type in same recursive group *)
+  | `Mutual of (Quantifier.t list * tygroup ref) (* Type in same recursive group *)
 ] [@@deriving show]
 
 
@@ -214,7 +212,7 @@ sig
     method meta_presence_var : meta_presence_var -> (meta_presence_var * 'self_type)
     method field_spec : field_spec -> (field_spec * 'self_type)
     method field_spec_map : field_spec_map -> (field_spec_map * 'self_type)
-    method quantifier : quantifier -> (quantifier * 'self_type)
+    method quantifier : Quantifier.t -> (Quantifier.t * 'self_type)
     method type_arg : type_arg -> (type_arg * 'self_type)
   end
 end
@@ -471,17 +469,17 @@ let check_rec : int -> var_set -> 'a -> (var_set -> 'a) -> 'a =
     else
       k (IntSet.add var rec_vars)
 
-let var_of_quantifier : quantifier -> int =
+let var_of_quantifier : Quantifier.t -> int =
   function
     | var, _ -> var
 
-let kind_of_quantifier : quantifier -> Kind.t =
+let kind_of_quantifier : Quantifier.t -> Kind.t =
   fun (_, k) -> k
 
-let primary_kind_of_quantifier : quantifier -> PrimaryKind.t =
+let primary_kind_of_quantifier : Quantifier.t -> PrimaryKind.t =
   fun (_, (pk, _)) -> pk
 
-let subkind_of_quantifier : quantifier -> Subkind.t
+let subkind_of_quantifier : Quantifier.t -> Subkind.t
   = fun q ->
     snd (kind_of_quantifier q)
 
@@ -491,10 +489,10 @@ let primary_kind_of_type_arg : type_arg -> PrimaryKind.t =
   | `Row _      -> pk_row
   | `Presence _ -> pk_presence
 
-let eq_quantifiers : quantifier -> quantifier -> bool =
+let eq_quantifiers : Quantifier.t -> Quantifier.t -> bool =
   fun p q -> var_of_quantifier p = var_of_quantifier q
 
-let add_quantified_vars : quantifier list -> TypeVarSet.t -> TypeVarSet.t =
+let add_quantified_vars : Quantifier.t list -> TypeVarSet.t -> TypeVarSet.t =
   fun qs vars -> List.fold_right IntSet.add (List.map var_of_quantifier qs) vars
 
 
@@ -882,7 +880,7 @@ module Env = Env.String
   let make_presence_variable var subkind = `Var (build_type_variable `Flexible var subkind)
   let make_rigid_presence_variable var subkind = `Var (build_type_variable `Rigid var subkind)
 
-  let type_arg_of_quantifier : quantifier -> type_arg =
+  let type_arg_of_quantifier : Quantifier.t -> type_arg =
     fun (var, (pk, sk)) ->
     let open PrimaryKind in
     match pk with
@@ -930,17 +928,17 @@ module Env = Env.String
   let fresh_presence_variable subkind = make_presence_variable (fresh_raw_variable ()) subkind
   let fresh_rigid_presence_variable subkind = make_rigid_presence_variable (fresh_raw_variable ()) subkind
 
-  let fresh_type_quantifier subkind : quantifier * datatype =
+  let fresh_type_quantifier subkind : Quantifier.t * datatype =
     let var = fresh_raw_variable () in
     let point = Unionfind.fresh (`Var (var, subkind, `Rigid)) in
       (var, (PrimaryKind.Type, subkind)), `MetaTypeVar point
 
-  let fresh_row_quantifier subkind : quantifier * row =
+  let fresh_row_quantifier subkind : Quantifier.t * row =
     let var = fresh_raw_variable () in
     let point = make_rigid_row_variable var subkind in
       (var, (PrimaryKind.Row, subkind)), (FieldEnv.empty, point, false)
 
-  let fresh_presence_quantifier subkind : quantifier * field_spec =
+  let fresh_presence_quantifier subkind : Quantifier.t * field_spec =
     let var = fresh_raw_variable () in
     let point = Unionfind.fresh (`Var (var, subkind, `Rigid)) in
       (var, (PrimaryKind.Presence, subkind)), `Var point
@@ -1505,7 +1503,7 @@ let quantifier_of_type_arg =
 
 let quantifiers_of_type_args = List.map quantifier_of_type_arg
 
-let for_all : quantifier list * datatype -> datatype = fun (qs, t) ->
+let for_all : Quantifier.t list * datatype -> datatype = fun (qs, t) ->
   concrete_type (`ForAll (qs, t))
 
 (* useful types *)
@@ -1904,7 +1902,7 @@ struct
       | PrimaryKind.Row, _ | PrimaryKind.Presence, _ ->
          full ({policy with kinds="full"}, _vars) (k, sk)
 
-  let quantifier : (policy * names) -> quantifier -> string =
+  let quantifier : (policy * names) -> Quantifier.t -> string =
     fun (policy, vars) q ->
       let k = kind_of_quantifier q in
       Vars.find (var_of_quantifier q) vars ^ has_kind (kind (policy, vars) k)
@@ -2329,7 +2327,7 @@ let string_of_tycon_spec ?(policy=Print.default_policy) ?(refresh_tyvar_names=tr
   build_tyvar_names ~refresh_tyvar_names free_bound_tycon_type_vars [tycon];
   Print.tycon_spec Print.empty_context (policy (), Vars.tyvar_name_map) tycon
 
-let string_of_quantifier ?(policy=Print.default_policy) ?(refresh_tyvar_names=true) (quant : quantifier) =
+let string_of_quantifier ?(policy=Print.default_policy) ?(refresh_tyvar_names=true) (quant : Quantifier.t) =
   build_tyvar_names ~refresh_tyvar_names free_bound_quantifier_vars [quant];
   Print.quantifier (policy (), Vars.tyvar_name_map) quant
 
@@ -2655,12 +2653,11 @@ let pp_datatype : Format.formatter -> datatype -> unit = fun fmt t ->
     Format.pp_print_string fmt (string_of_datatype t)
   else
     pp_datatype fmt (DecycleTypes.datatype t)
-let pp_quantifier : Format.formatter -> quantifier -> unit = fun fmt t ->
+let pp_quantifier : Format.formatter -> Quantifier.t -> unit = fun fmt t ->
   if Settings.get print_types_pretty then
     Format.pp_print_string fmt (string_of_quantifier t)
   else
-    pp_quantifier fmt (DecycleTypes.quantifier t)
-let show_quantifier : quantifier -> string = (fun x -> Format.asprintf "%a" pp_quantifier x)
+    Quantifier.pp fmt (DecycleTypes.quantifier t)
 let pp_type_arg : Format.formatter -> type_arg -> unit = fun fmt t ->
   if Settings.get print_types_pretty then
     Format.pp_print_string fmt (string_of_type_arg t)

--- a/core/types.mli
+++ b/core/types.mli
@@ -12,9 +12,6 @@ module TypeVarMap : Utility.INTMAP
 (* points *)
 type 'a point = 'a Unionfind.point
 
-type kind = PrimaryKind.t * Subkind.t
-    [@@deriving eq,show]
-
 type 't meta_type_var_non_rec_basis =
     [ `Var of (int * Subkind.t * freedom)
     | `Body of 't ]
@@ -35,8 +32,8 @@ type 't meta_max_basis = 't meta_row_var_basis
 module Abstype :
 sig
   type t [@@deriving eq,show]
-  val make  : string -> kind list -> t
-  val arity : t -> kind list
+  val make  : string -> Kind.t list -> t
+  val arity : t -> Kind.t list
   val name  : t -> string
   val compare : t -> t -> int
 end
@@ -95,7 +92,7 @@ and rec_appl = {
   r_name: string;
   r_dual: bool;
   r_unique_name: string;
-  r_quantifiers : kind list;
+  r_quantifiers : Kind.t list;
   r_args: type_arg list;
   r_unwind: type_arg list -> bool -> typ;
   r_linear: unit -> bool option
@@ -110,7 +107,7 @@ and typ =
     | `Effect of row
     | `Table of typ * typ * typ
     | `Lens of Lens.Type.t
-    | `Alias of ((string * kind list * type_arg list) * typ)
+    | `Alias of ((string * Kind.t list * type_arg list) * typ)
     | `Application of (Abstype.t * type_arg list)
     | `RecursiveApplication of rec_appl
     | `MetaTypeVar of meta_type_var
@@ -124,7 +121,7 @@ and meta_type_var = (typ meta_type_var_basis) point
 and meta_row_var = (row meta_row_var_basis) point
 and meta_presence_var = (field_spec meta_presence_var_basis) point
 and meta_var = [ `Type of meta_type_var | `Row of meta_row_var | `Presence of meta_presence_var ]
-and quantifier = int * kind
+and quantifier = int * Kind.t
 and type_arg =
     [ `Type of typ | `Row of row | `Presence of field_spec ]
     [@@deriving show]
@@ -213,7 +210,7 @@ val free_bound_type_arg_type_vars : type_arg -> Vars.vars_list
 
 val var_of_quantifier : quantifier -> int
 val primary_kind_of_quantifier : quantifier -> PrimaryKind.t
-val kind_of_quantifier : quantifier -> kind
+val kind_of_quantifier : quantifier -> Kind.t
 val subkind_of_quantifier : quantifier -> Subkind.t
 val type_arg_of_quantifier : quantifier -> type_arg
 
@@ -252,7 +249,7 @@ val fresh_rigid_presence_variable : Subkind.t -> field_spec
 val fresh_type_quantifier : Subkind.t -> quantifier * datatype
 val fresh_row_quantifier : Subkind.t -> quantifier * row
 val fresh_presence_quantifier : Subkind.t -> quantifier * field_spec
-val fresh_quantifier : kind -> quantifier * type_arg
+val fresh_quantifier : Kind.t -> quantifier * type_arg
 
 (** {0 rows} *)
 (** empty row constructors *)

--- a/core/types.mli
+++ b/core/types.mli
@@ -6,7 +6,12 @@ type 'a stringmap = 'a Utility.StringMap.t [@@deriving show]
 type 'a field_env = 'a stringmap [@@deriving show]
 
 (* type var sets *)
-module TypeVarSet : Utility.INTSET
+module TypeVarSet : sig
+  include Utility.INTSET
+
+  val add_quantifiers : Quantifier.t list -> t -> t
+end
+
 module TypeVarMap : Utility.INTMAP
 
 (* points *)
@@ -211,8 +216,6 @@ val quantifier_of_type_arg : type_arg -> Quantifier.t
 val quantifiers_of_type_args : type_arg list -> Quantifier.t list
 
 val primary_kind_of_type_arg : type_arg -> PrimaryKind.t
-
-val add_quantified_vars : Quantifier.t list -> TypeVarSet.t -> TypeVarSet.t
 
 (** Fresh type variables *)
 val type_variable_counter : int ref

--- a/core/types.mli
+++ b/core/types.mli
@@ -13,7 +13,7 @@ module TypeVarMap : Utility.INTMAP
 type 'a point = 'a Unionfind.point
 
 type 't meta_type_var_non_rec_basis =
-    [ `Var of (int * Subkind.t * freedom)
+    [ `Var of (int * Subkind.t * Freedom.t)
     | `Body of 't ]
 
 
@@ -398,7 +398,7 @@ end
 type visit_context = Utility.StringSet.t * TypeVarSet.t * TypeVarSet.t
 class virtual type_predicate :
   object('self_type)
-    method var_satisfies : (int * Subkind.t * freedom) -> bool
+    method var_satisfies : (int * Subkind.t * Freedom.t) -> bool
     method type_satisfies : visit_context -> typ -> bool
     method point_satisfies :
       'a 'c . (visit_context -> 'a -> bool) ->

--- a/core/types.mli
+++ b/core/types.mli
@@ -206,20 +206,13 @@ val free_bound_type_vars          : typ      -> Vars.vars_list
 val free_bound_row_type_vars      : row      -> Vars.vars_list
 val free_bound_type_arg_type_vars : type_arg -> Vars.vars_list
 
-val var_of_quantifier : Quantifier.t -> int
-val primary_kind_of_quantifier : Quantifier.t -> PrimaryKind.t
-val kind_of_quantifier : Quantifier.t -> Kind.t
-val subkind_of_quantifier : Quantifier.t -> Subkind.t
 val type_arg_of_quantifier : Quantifier.t -> type_arg
+val quantifier_of_type_arg : type_arg -> Quantifier.t
+val quantifiers_of_type_args : type_arg list -> Quantifier.t list
 
 val primary_kind_of_type_arg : type_arg -> PrimaryKind.t
 
-val eq_quantifiers : Quantifier.t -> Quantifier.t -> bool
-
 val add_quantified_vars : Quantifier.t list -> TypeVarSet.t -> TypeVarSet.t
-
-val quantifier_of_type_arg : type_arg -> Quantifier.t
-val quantifiers_of_type_args : type_arg list -> Quantifier.t list
 
 (** Fresh type variables *)
 val type_variable_counter : int ref
@@ -238,7 +231,7 @@ val fresh_rigid_type_variable : Subkind.t -> datatype
 val fresh_row_variable : Subkind.t -> row_var
 val fresh_rigid_row_variable : Subkind.t -> row_var
 
-val fresh_session_variable : CommonTypes.Linearity.t -> datatype
+val fresh_session_variable : Linearity.t -> datatype
 
 val fresh_presence_variable : Subkind.t -> field_spec
 val fresh_rigid_presence_variable : Subkind.t -> field_spec

--- a/core/types.mli
+++ b/core/types.mli
@@ -80,10 +80,9 @@ module RecIdMap : RECIDMAP
 module type RECIDSET = Utility.Set with type elt = rec_id
 module RecIdSet : RECIDSET
 
-
 type tygroup = {
   id: int;
-  type_map: ((quantifier list * typ) Utility.StringMap.t);
+  type_map: ((Quantifier.t list * typ) Utility.StringMap.t);
   linearity_map: bool Utility.StringMap.t
 }
 
@@ -111,7 +110,7 @@ and typ =
     | `Application of (Abstype.t * type_arg list)
     | `RecursiveApplication of rec_appl
     | `MetaTypeVar of meta_type_var
-    | `ForAll of (quantifier list * typ)
+    | `ForAll of (Quantifier.t list * typ)
     | (typ, row) session_type_basis ]
 and field_spec = [ `Present of typ | `Absent | `Var of meta_presence_var ]
 and field_spec_map = field_spec field_env
@@ -121,7 +120,6 @@ and meta_type_var = (typ meta_type_var_basis) point
 and meta_row_var = (row meta_row_var_basis) point
 and meta_presence_var = (field_spec meta_presence_var_basis) point
 and meta_var = [ `Type of meta_type_var | `Row of meta_row_var | `Presence of meta_presence_var ]
-and quantifier = int * Kind.t
 and type_arg =
     [ `Type of typ | `Row of row | `Presence of field_spec ]
     [@@deriving show]
@@ -161,12 +159,12 @@ val get_restriction_constraint : Restriction.t -> (module Constraint) option
 val dual_row : row -> row
 val dual_type : datatype -> datatype
 
-type alias_type = quantifier list * typ [@@deriving show]
+type alias_type = Quantifier.t list * typ [@@deriving show]
 
 type tycon_spec = [
   | `Alias of alias_type
   | `Abstract of Abstype.t
-  | `Mutual of (quantifier list * tygroup ref) (* Type in same recursive group *)
+  | `Mutual of (Quantifier.t list * tygroup ref) (* Type in same recursive group *)
 ]
 
 type environment        = datatype Env.String.t
@@ -186,7 +184,7 @@ val normalise_datatype : datatype -> datatype
 val normalise_row : row -> row
 val normalise_typing_environment : typing_environment -> typing_environment
 
-val for_all : quantifier list * datatype -> datatype
+val for_all : Quantifier.t list * datatype -> datatype
 
 (** useful types *)
 val unit_type : datatype
@@ -208,20 +206,20 @@ val free_bound_type_vars          : typ      -> Vars.vars_list
 val free_bound_row_type_vars      : row      -> Vars.vars_list
 val free_bound_type_arg_type_vars : type_arg -> Vars.vars_list
 
-val var_of_quantifier : quantifier -> int
-val primary_kind_of_quantifier : quantifier -> PrimaryKind.t
-val kind_of_quantifier : quantifier -> Kind.t
-val subkind_of_quantifier : quantifier -> Subkind.t
-val type_arg_of_quantifier : quantifier -> type_arg
+val var_of_quantifier : Quantifier.t -> int
+val primary_kind_of_quantifier : Quantifier.t -> PrimaryKind.t
+val kind_of_quantifier : Quantifier.t -> Kind.t
+val subkind_of_quantifier : Quantifier.t -> Subkind.t
+val type_arg_of_quantifier : Quantifier.t -> type_arg
 
 val primary_kind_of_type_arg : type_arg -> PrimaryKind.t
 
-val eq_quantifiers : quantifier -> quantifier -> bool
+val eq_quantifiers : Quantifier.t -> Quantifier.t -> bool
 
-val add_quantified_vars : quantifier list -> TypeVarSet.t -> TypeVarSet.t
+val add_quantified_vars : Quantifier.t list -> TypeVarSet.t -> TypeVarSet.t
 
-val quantifier_of_type_arg : type_arg -> quantifier
-val quantifiers_of_type_args : type_arg list -> quantifier list
+val quantifier_of_type_arg : type_arg -> Quantifier.t
+val quantifiers_of_type_args : type_arg list -> Quantifier.t list
 
 (** Fresh type variables *)
 val type_variable_counter : int ref
@@ -246,10 +244,10 @@ val fresh_presence_variable : Subkind.t -> field_spec
 val fresh_rigid_presence_variable : Subkind.t -> field_spec
 
 (** fresh quantifiers *)
-val fresh_type_quantifier : Subkind.t -> quantifier * datatype
-val fresh_row_quantifier : Subkind.t -> quantifier * row
-val fresh_presence_quantifier : Subkind.t -> quantifier * field_spec
-val fresh_quantifier : Kind.t -> quantifier * type_arg
+val fresh_type_quantifier : Subkind.t -> Quantifier.t * datatype
+val fresh_row_quantifier : Subkind.t -> Quantifier.t * row
+val fresh_presence_quantifier : Subkind.t -> Quantifier.t * field_spec
+val fresh_quantifier : Kind.t -> Quantifier.t * type_arg
 
 (** {0 rows} *)
 (** empty row constructors *)
@@ -390,7 +388,7 @@ sig
     method meta_presence_var : meta_presence_var -> (meta_presence_var * 'self_type)
     method field_spec : field_spec -> (field_spec * 'self_type)
     method field_spec_map : field_spec_map -> (field_spec_map * 'self_type)
-    method quantifier : quantifier -> (quantifier * 'self_type)
+    method quantifier : Quantifier.t -> (Quantifier.t * 'self_type)
     method type_arg : type_arg -> (type_arg * 'self_type)
   end
 end

--- a/core/types.mli
+++ b/core/types.mli
@@ -12,11 +12,11 @@ module TypeVarMap : Utility.INTMAP
 (* points *)
 type 'a point = 'a Unionfind.point
 
-type kind = PrimaryKind.t * subkind
+type kind = PrimaryKind.t * Subkind.t
     [@@deriving eq,show]
 
 type 't meta_type_var_non_rec_basis =
-    [ `Var of (int * subkind * freedom)
+    [ `Var of (int * Subkind.t * freedom)
     | `Body of 't ]
 
 
@@ -214,7 +214,7 @@ val free_bound_type_arg_type_vars : type_arg -> Vars.vars_list
 val var_of_quantifier : quantifier -> int
 val primary_kind_of_quantifier : quantifier -> PrimaryKind.t
 val kind_of_quantifier : quantifier -> kind
-val subkind_of_quantifier : quantifier -> subkind
+val subkind_of_quantifier : quantifier -> Subkind.t
 val type_arg_of_quantifier : quantifier -> type_arg
 
 val primary_kind_of_type_arg : type_arg -> PrimaryKind.t
@@ -231,37 +231,37 @@ val type_variable_counter : int ref
 val fresh_raw_variable : unit -> int
 
 (** type variable construction *)
-val make_type_variable : int -> subkind -> datatype
-val make_rigid_type_variable : int -> subkind -> datatype
-val make_row_variable : int -> subkind -> row_var
-val make_rigid_row_variable : int -> subkind -> row_var
+val make_type_variable : int -> Subkind.t -> datatype
+val make_rigid_type_variable : int -> Subkind.t -> datatype
+val make_row_variable : int -> Subkind.t -> row_var
+val make_rigid_row_variable : int -> Subkind.t -> row_var
 
 (** fresh type variable generation *)
-val fresh_type_variable : subkind -> datatype
-val fresh_rigid_type_variable : subkind -> datatype
+val fresh_type_variable : Subkind.t -> datatype
+val fresh_rigid_type_variable : Subkind.t -> datatype
 
-val fresh_row_variable : subkind -> row_var
-val fresh_rigid_row_variable : subkind -> row_var
+val fresh_row_variable : Subkind.t -> row_var
+val fresh_rigid_row_variable : Subkind.t -> row_var
 
 val fresh_session_variable : CommonTypes.Linearity.t -> datatype
 
-val fresh_presence_variable : subkind -> field_spec
-val fresh_rigid_presence_variable : subkind -> field_spec
+val fresh_presence_variable : Subkind.t -> field_spec
+val fresh_rigid_presence_variable : Subkind.t -> field_spec
 
 (** fresh quantifiers *)
-val fresh_type_quantifier : subkind -> quantifier * datatype
-val fresh_row_quantifier : subkind -> quantifier * row
-val fresh_presence_quantifier : subkind -> quantifier * field_spec
+val fresh_type_quantifier : Subkind.t -> quantifier * datatype
+val fresh_row_quantifier : Subkind.t -> quantifier * row
+val fresh_presence_quantifier : Subkind.t -> quantifier * field_spec
 val fresh_quantifier : kind -> quantifier * type_arg
 
 (** {0 rows} *)
 (** empty row constructors *)
 val make_empty_closed_row : unit -> row
-val make_empty_open_row : subkind -> row
+val make_empty_open_row : Subkind.t -> row
 
 (** singleton row constructors *)
 val make_singleton_closed_row : (string * field_spec) -> row
-val make_singleton_open_row : (string * field_spec) -> subkind -> row
+val make_singleton_open_row : (string * field_spec) -> Subkind.t -> row
 
 (** row predicates *)
 val is_closed_row : row -> bool
@@ -401,7 +401,7 @@ end
 type visit_context = Utility.StringSet.t * TypeVarSet.t * TypeVarSet.t
 class virtual type_predicate :
   object('self_type)
-    method var_satisfies : (int * subkind * freedom) -> bool
+    method var_satisfies : (int * Subkind.t * freedom) -> bool
     method type_satisfies : visit_context -> typ -> bool
     method point_satisfies :
       'a 'c . (visit_context -> 'a -> bool) ->

--- a/core/typevarcheck.ml
+++ b/core/typevarcheck.ml
@@ -45,7 +45,7 @@ let rec is_guarded : TypeVarSet.t -> StringSet.t -> int -> datatype -> bool =
             isg f && isgr m && isg t
         | `ForAll (qs, t) ->
             is_guarded
-              (Types.add_quantified_vars qs bound_vars)
+              (TypeVarSet.add_quantifiers qs bound_vars)
               expanded_apps var t
         | `Record row ->
             begin
@@ -141,7 +141,7 @@ let rec is_negative : TypeVarSet.t -> StringSet.t -> int -> datatype -> bool =
             isp f || isnr m || isn t
         | `ForAll (qs, t) ->
             is_negative
-              (Types.add_quantified_vars qs bound_vars)
+              (TypeVarSet.add_quantifiers qs bound_vars)
               expanded_apps var t
         | `Record row -> isnr row
         | `Effect row
@@ -227,7 +227,7 @@ and is_positive : TypeVarSet.t -> StringSet.t -> int -> datatype -> bool =
             isn f || ispr m || isp t
         | `ForAll (qs, t) ->
             is_positive
-              (Types.add_quantified_vars qs bound_vars)
+              (TypeVarSet.add_quantifiers qs bound_vars)
               expanded_apps var t
         | `Record row -> ispr row
         | `Effect row

--- a/core/unify.ml
+++ b/core/unify.ml
@@ -174,7 +174,7 @@ and eq_sessions : (datatype * datatype) -> bool =
     eq_types (l, r)
   | `End, `End -> true
   | _, _ -> false
-and eq_quantifier : (quantifier * quantifier) -> bool =
+and eq_quantifier : (Quantifier.t * Quantifier.t) -> bool =
   function
     | (lvar, _), (rvar, _) -> lvar = rvar
 and eq_rows : (row * row) -> bool =

--- a/core/unify.ml
+++ b/core/unify.ml
@@ -722,7 +722,7 @@ and unify_presence' : unify_env -> (field_spec * field_spec -> unit) =
        | `Body f' -> unify_presence' rec_env (f, f')
      end
 
-and unify_rows' : ?var_sk:subkind -> unify_env -> ((row * row) -> unit) =
+and unify_rows' : ?var_sk:Subkind.t -> unify_env -> ((row * row) -> unit) =
   let unwrap_row r =
     let r', rvar = unwrap_row r in
     (* Debug.print (Printf.sprintf "Unwrapped row %s giving %s\n" (string_of_row r) (string_of_row r')); *)

--- a/core/unify.ml
+++ b/core/unify.ml
@@ -145,7 +145,7 @@ let rec eq_types : (datatype * datatype) -> bool =
       | `ForAll (qs, t) ->
           begin match unalias t2 with
             | `ForAll (qs', t') ->
-                List.for_all2 (fun q q' -> eq_quantifier (q, q')) qs qs' &&
+                List.for_all2 Quantifier.eq qs qs' &&
                   eq_types (t, t')
             | _ -> false
           end
@@ -174,9 +174,6 @@ and eq_sessions : (datatype * datatype) -> bool =
     eq_types (l, r)
   | `End, `End -> true
   | _, _ -> false
-and eq_quantifier : (Quantifier.t * Quantifier.t) -> bool =
-  function
-    | (lvar, _), (rvar, _) -> lvar = rvar
 and eq_rows : (row * row) -> bool =
   fun ((lfield_env, lrow_var, ldual), (rfield_env, rrow_var, rdual)) ->
     eq_field_envs (lfield_env, rfield_env) && eq_row_vars (lrow_var, rrow_var) && ldual=rdual
@@ -593,7 +590,7 @@ let rec unify' : unify_env -> (datatype * datatype) -> unit =
        unify_rec (RecAppl appl) t1
     | `ForAll l, `ForAll r ->
        let check_quantifier_kinds l r =
-         if Types.kind_of_quantifier l <> Types.kind_of_quantifier r then
+         if Quantifier.to_kind l <> Quantifier.to_kind r then
            raise (Failure (`Msg ("incompatible quantifier kinds")))
          else
            () in
@@ -624,8 +621,8 @@ let rec unify' : unify_env -> (datatype * datatype) -> unit =
          List.fold_left2
            (fun (lenv, rs) l r ->
              check_quantifier_kinds l r;
-             (IntMap.add (Types.var_of_quantifier l) (Types.var_of_quantifier r) lenv,
-              IntSet.add (Types.var_of_quantifier r) rs))
+             (IntMap.add (Quantifier.to_var l) (Quantifier.to_var r) lenv,
+              IntSet.add (Quantifier.to_var r) rs))
            qenv
            ls
            rs in

--- a/core/value.ml
+++ b/core/value.ml
@@ -1,3 +1,4 @@
+open CommonTypes
 open Utility
 open Notfound
 open ProcessTypes
@@ -406,7 +407,7 @@ module type CONTINUATION_EVALUATOR = sig
                result
 
   val trap : v t ->                        (* the continuation *)
-             (Ir.name * v) ->              (* operation name and its argument *)
+             (Name.t * v) ->              (* operation name and its argument *)
              trap_result
 end
 

--- a/core/value.mli
+++ b/core/value.mli
@@ -1,4 +1,5 @@
 (* Values and environments *)
+open CommonTypes
 open ProcessTypes
 
 class type otherfield
@@ -147,7 +148,7 @@ module type CONTINUATION_EVALUATOR = sig
 
   (* trap invocation *)
   val trap : v t ->                        (* the continuation *)
-             (Ir.name * v) ->              (* operation name and its argument *)
+             (Name.t * v) ->              (* operation name and its argument *)
              trap_result
 end
 


### PR DESCRIPTION
This is preliminary work for #637. I've taken various small datatypes and placed them in their own modules in `CommonTypes`. Notably:

  * there is now a `Name` module with `Name.t = string`, rather than having several modules defining `type name = string`.
  * I separated `quantifier` from large mutually recursive definition of types in `Types` and placed it, together with corresponding projection functions, in `CommonTypes.Quantifier` module. I am somewhat tempted to have that module renamed since what it really represents are kinded type variables, not just quantifiers. OTOH in most places where this module is used it really does handle quantifiers, so the name `Quantifier` is more informative than just `TyVar`. Thoughts?
  * I implemented @dhil's earlier suggestion to have `add_quantifiers` as part of `TypeVarSet` module.
  * sugartypes could use a similar cleanup, but that's a story for another day. Similarly for IR definitions. In particular I am not a huge fan of having a dozen of aliases to already existing types:
```
type scope = Var.Scope.t
  [@@deriving show]
(* term variables *)
type var = Var.var
  [@@deriving show,eq,yojson]
type var_info = Var.var_info
  [@@deriving show]
type binder = Var.binder
  [@@deriving show]

(* type variables *)
type tyvar = Quantifier.t
  [@@deriving show]
type tyarg = Types.type_arg
  [@@deriving show]

type name_set = Utility.stringset
  [@@deriving show]
type 'a name_map = 'a Utility.stringmap
  [@@deriving show]

type 'a var_map = 'a Utility.intmap
  [@@deriving show]

type language = string
  [@@deriving show]

type location = CommonTypes.Location.t
  [@@deriving show]
```
I understand this makes code shorter but it also makes it more obscure. But again, this is a separate story.