### PR TITLE
fix 755

### DIFF
--- a/core/typeSugar.ml
+++ b/core/typeSugar.ml
@@ -907,6 +907,7 @@ end
 
     let range_bound ~pos ~t1:_l ~t2:(_, _t) ~error:_ =
       die pos "Range bounds must be integers."
+
     let range_wild ~pos ~t1:(_, lt) ~t2:(_, rt) ~error:_ =
       build_tyvar_names [lt; rt];
       let ppr_rt = show_type rt in

--- a/tests/database.tests
+++ b/tests/database.tests
@@ -37,3 +37,13 @@ XML literals in query blocks (6)
 query {var x = <a {[("href", "foo.com")]}>{stringToXml("asdf")}</a>; [(a=1)]}
 stdout : [(a = 1)] : [(a:Int)]
 exit : 0
+
+Ranges are wild (1)
+query {for (x <- [1..3] ) [(num=x)]}
+stderr : @..*
+exit : 1
+
+Ranges are wild, but can appear outside of query blocks (2)
+for (x <- [1..3] ) [(num=x)]
+stdout : [(num = 1), (num = 2), (num = 3)] : [(num:Int)]
+exit : 0


### PR DESCRIPTION
Makes it an error to do 
```
links> query {for (x <- [1..3] ) [(num=x)]};
<stdin>:1: Type error: Ranges are wild
    `(wild|a)'
but the currently allowed effects are
    `()'
In expression: [1..3].
```

Let's see if this breaks anything, now back to what I should have been doing.

If successful, closes #755.