### PR TITLE
ounit fix

### DIFF
--- a/tests/unit/dune
+++ b/tests/unit/dune
@@ -2,5 +2,5 @@
   (name unitTests)
   (modes native)
   (flags :standard -safe-string -dtypes -w Ae-44-45-60 -g)
-  (libraries oUnit dynlink links.core links.lens links-postgresql result)
+  (libraries ounit.advanced ounit dynlink links.core links.lens links-postgresql result)
   (preprocess (pps ppx_deriving.std)))


### PR DESCRIPTION
ounit has switched to dune, which slightly changes how it is packaged.

Therefore, we need to use `ounit` and `ounit.advanced` rathern than `oUnit` in our dune files for *the unit tests*. Unfortunately, this breaks the unit tests for people using older versions of ounit. However, I assume that the unit tests are rarely run manually by people, as it is not part of `make tests`. 

