### PR TITLE
MVU: Commands

### DIFF
--- a/examples/mvu/commands.links
+++ b/examples/mvu/commands.links
@@ -1,0 +1,65 @@
+import MvuAttrs;
+import MvuHTML;
+import MvuCommands;
+import Mvu;
+
+typename Model = [| NotStarted | Waiting | Result:Int |];
+
+typename Message = [| StartComputation | DeliverResult:Int |];
+
+sig view : (Model) ~%~> MvuHTML.HTML(Message)
+fun view(model) {
+  open MvuAttrs;
+  open MvuHTML;
+
+  var a0 = MvuAttrs.empty;
+  var h0 = MvuHTML.empty;
+
+  var disabled = MvuAttrs.attr("disabled", "disabled");
+
+  var (text, buttonAttr) =
+    switch(model) {
+      case NotStarted -> ("Not started", a0)
+      case Waiting -> ("Waiting", disabled)
+      case Result(n) -> ("Result: " ^^ intToString(n), a0)
+    };
+
+  div(a0,
+    button(onClick(fun() { StartComputation }) +@ buttonAttr,
+      textNode("Start computation")) +*
+    textNode(text))
+}
+
+fun fib(n) {
+  if (n <= 0) {
+    0
+  } else if (n == 1) {
+    1
+  } else {
+    fib(n - 1) + fib(n - 2)
+  }
+}
+
+sig updt : (Message, Model) ~%~> (Model, MvuCommands.Command(Message))
+fun updt(msg, model) {
+  switch(msg) {
+    case StartComputation ->
+      var cmd =
+        MvuCommands.spawnProc(fun() { DeliverResult(fib(25)) });
+      (Waiting, cmd)
+    case DeliverResult(n) -> (Result(n), MvuCommands.empty)
+  }
+}
+
+fun mainPage() {
+  Mvu.runCmd("placeholder", NotStarted,
+      view, updt, MvuCommands.empty);
+  page
+    <html>
+      <body>
+        <div id="placeholder"></div>
+      </body>
+    </html>
+}
+
+serveThis(mainPage)

--- a/examples/mvu/keypress.links
+++ b/examples/mvu/keypress.links
@@ -3,6 +3,7 @@ open import MvuHTML;
 open import MvuAttrs;
 open import MvuEvents;
 open import MvuSubscriptions;
+import MvuCommands;
 
 typename Model = Maybe(KeyboardEvent);
 typename Msg = [| UpdateEvent: KeyboardEvent |];
@@ -49,7 +50,9 @@ fun subscriptions(_) {
 }
 
 fun mainPage(_) {
-  run("placeholder", Nothing, view, updt, subscriptions);
+  run("placeholder", Nothing, view,
+      fun (msg, model) { (updt(msg, model), MvuCommands.empty) }, subscriptions,
+      MvuCommands.empty);
   page
   <html>
     <head>

--- a/examples/mvu/mousetest.links
+++ b/examples/mvu/mousetest.links
@@ -3,6 +3,7 @@ open import MvuHTML;
 open import MvuAttrs;
 open import MvuEvents;
 open import MvuSubscriptions;
+import MvuCommands;
 
 typename Model = Maybe(MouseEvent);
 typename Msg = [| UpdateMouseEvent: MouseEvent |];
@@ -77,7 +78,9 @@ fun subscriptions(model) {
 
 fun mainPage(_) {
   var evtHandler =
-    run("placeholder", Nothing, view, updt, subscriptions);
+    run("placeholder", Nothing, view,
+        fun (msg, model) { (updt(msg, model), MvuCommands.empty) },
+        subscriptions, MvuCommands.empty);
   page
   <html>
     <head>

--- a/examples/mvu/pong.links
+++ b/examples/mvu/pong.links
@@ -3,6 +3,7 @@ open import MvuAttrs;
 open import MvuEvents;
 open import MvuSubscriptions;
 import Mvu;
+import MvuCommands;
 
 typename Ball = (x : Float, y: Float, vx : Float, vy : Float);
 
@@ -211,7 +212,9 @@ fun subscriptions(model) {
 
 
 fun mainPage(_) {
-  Mvu.run("placeholder", defaultGame, view, updt, subscriptions);
+  Mvu.run("placeholder", defaultGame, view,
+      fun(msg, model) { (updt(msg, model), MvuCommands.empty) },
+      subscriptions, MvuCommands.empty);
   page
   <html>
     <head>

--- a/examples/mvu/time.links
+++ b/examples/mvu/time.links
@@ -3,6 +3,7 @@ import MvuHTML;
 open import MvuAttrs;
 open import MvuEvents;
 open import MvuSubscriptions;
+import MvuCommands;
 
 typename Model = (seconds : Int, minutes : Int, paused: Bool);
 typename Msg = [| Tick | Reset | TogglePause | Stop | NoOp |];
@@ -100,7 +101,9 @@ fun subscriptions(model) {
 
 fun mainPage(_) {
   var initialModel = (seconds = 0, minutes = 0, paused = true);
-  var evtHandler = Mvu.run("placeholder", initialModel, view, updt, subscriptions);
+  var evtHandler = Mvu.run("placeholder", initialModel, view,
+      fun(msg, model) { (updt(msg, model), MvuCommands.empty) },
+      subscriptions, MvuCommands.empty);
   page
   <html>
     <head>

--- a/lib/stdlib/dune
+++ b/lib/stdlib/dune
@@ -6,5 +6,6 @@
          (mvuAttrs.links as stdlib/mvuAttrs.links)
          (mvuEvents.links as stdlib/mvuEvents.links)
          (mvuHTML.links as stdlib/mvuHTML.links)
+         (mvuCommands.links as stdlib/mvuCommands.links)
          (mvuSubscriptions.links as stdlib/mvuSubscriptions.links))
   (package links))

--- a/lib/stdlib/mvu.links
+++ b/lib/stdlib/mvu.links
@@ -3,6 +3,7 @@ open import MvuAttrs;
 open import MvuEvents;
 open import MvuHTML;
 open import MvuSubscriptions;
+open import MvuCommands;
 
 # Needed to ensure that virtual-dom is open
 module VirtualDom {
@@ -28,13 +29,14 @@ sig evtLoop :
   (AP(?msg.End),
    model,
    (model) ~e~> HTML(msg),
-   (msg, model) ~e~> model,
+   (msg, model) ~e~> (model, Command(msg)),
    (model) ~e~> Sub(msg),
    Sub(msg)) ~e~> ()
 fun evtLoop(ap, model, view, updt, subscriptionsFn, prevSubscriptions) {
   var (message, s) = receive(accept(ap));
   close(s);
-  var model = updt(message, model);
+  var (model, cmd) = updt(message, model);
+  processCommand(cmd, ap);
   # Get new subscriptions
   var newSubscriptions = subscriptionsFn(model);
   # Update DOM
@@ -49,15 +51,27 @@ sig run:
   (String,
     model,
     (model) ~e~> HTML(msg),
-    (msg, model) ~e~> (model),
-    (model) ~e~> Sub(msg)) ~f~> ()
-fun run(placeholder, model, view, updt, subscriptions) {
+    (msg, model) ~e~> (model, Command(msg)),
+    (model) ~e~> Sub(msg),
+    Command(msg)) ~f~> ()
+fun run(placeholder, model, view, updt, subscriptions, cmd) {
   var evtHandler = spawnClient {
     var ap = new();
+    processCommand(cmd, ap);
     VDom.runDom(placeholder, view(model), ap, subscriptions(model));
     evtLoop(ap, model, view, updt, subscriptions, subscriptions(model))
   };
   ()
+}
+
+sig runCmd: forall msg, model, e :: Row, f :: Row.
+  (String,
+    model,
+    (model) ~e~> HTML(msg),
+    (msg, model) ~e~> (model, Command(msg)),
+    Command(msg)) ~f~> ()
+fun runCmd(placeholder, model, view, updt, cmd) {
+  run(placeholder, model, view, updt, fun(_) { SubEmpty }, cmd )
 }
 
 sig runSimple : forall msg, model, e :: Row, f :: Row.
@@ -66,7 +80,9 @@ sig runSimple : forall msg, model, e :: Row, f :: Row.
     (model) ~e~> HTML(msg),
     (msg, model) ~e~> model) ~f~> ()
 fun runSimple(placeholder, model, view, updt) {
-  run(placeholder, model, view, updt, fun(_) { SubEmpty } )
+  run(placeholder, model, view,
+      fun(msg, model) { (updt(msg, model), MvuCommands.empty) },
+      fun(_) { SubEmpty }, MvuCommands.empty )
 }
 
 sig runStatic :

--- a/lib/stdlib/mvuCommands.links
+++ b/lib/stdlib/mvuCommands.links
@@ -1,0 +1,48 @@
+# Commands: Allow things to be processed asynchronously and produce messages
+
+typename Command(a :: Type(Any, Any)) =
+  [| NoCommand
+   | CommandAppend : (Command(a), Command(a))
+   | Spawn: (() {}~> a)
+   |];
+
+var empty = NoCommand;
+
+sig spawnProc:
+  forall a :: Type(Any, Any) .
+    (() {}~> a) {}~> Command(a)
+fun spawnProc(f) { Spawn(f) }
+
+sig append : forall a :: Type(Any, Any), e :: Row .
+  (Command(a), Command(a)) -e-> Command(a)
+fun append(a1, a2) {
+  switch ((a1, a2)) {
+    case (NoCommand, a2) -> a2
+    case (a1, NoCommand) -> a1
+    case (a1, a2) -> CommandAppend(a1, a2)
+  }
+}
+
+
+sig +$ : forall a :: Type(Any, Any), e :: Row . (Command(a), Command(a)) -e-> Command(a)
+op a1 +$ a2 { append(a1, a2) }
+
+sig applySpawn: forall a :: Type(Any, Any) .
+  (() {}~> a) {}~> a
+fun applySpawn(f) { f() }
+
+sig processCommand :
+  forall msg :: Type(Any, Any), e :: Row . (Command(msg), AP(?msg.End)) ~e~> ()
+fun processCommand(cmd, ap) {
+  switch(cmd) {
+    case NoCommand -> ()
+    case CommandAppend(c1, c2) ->
+      processCommand(c1, ap);
+      processCommand(c2, ap)
+    case Spawn(f) ->
+      ignore(
+        spawn {
+          close(send(applySpawn(f), request(ap)))
+        })
+  }
+}

--- a/tests/typecheck_examples.tests
+++ b/tests/typecheck_examples.tests
@@ -897,3 +897,8 @@ Typecheck example file examples/examplesPage.links
 examples/examplesPage.links
 filemode : true
 args : --config=tests/examples_default.config
+
+Typecheck example file examples/mvu/commands.links
+examples/mvu/commands.links
+filemode : true
+args : --config=tests/examples_default.config


### PR DESCRIPTION
Commands in Elm allow side-effecting computations to be performed inside the MVU event loop. A particularly important side-effect is to spawn a computation which evaluates asynchronously, returning a message when it is complete.

This patch adds commands to the Links MVU library. It's existed in various branches of mine for a while, but I'm finding it necessary for the GtoPdb curation tool so thought it might be nice to have it in master. I'd say the primary use right now is to allow RPCs and MVU to coexist nicely.

Key changes: 
  - add a new type, `Command(Message)` which describes a computation which will produce a message of type `Message`
  - revise most general type of `updt` function from `(Message, Model) ~> Model` to `(Message, Model) ~> (Model, Command(Message))`

You can see the gist of the new functionality in the `examples/mvu/commands.links` example, which spawns an expensive computation asynchronously and awaits the result.