### PR TITLE
[Patch 2/2] Structured transforms with compilation state passing

### DIFF
--- a/bin/driver.ml
+++ b/bin/driver.ml
@@ -181,12 +181,6 @@ module Phases = struct
     Webserver.init (valenv, nenv, tenv) globals ffi_files;
     Evaluate.run result
 
-  (* Error handling wrapper for [whole_program] above. *)
-  let whole_program context filename =
-    Errors.display
-      ~default:(fun _ -> exit 1)
-      (lazy (whole_program context filename))
-
   let evaluate_string : Context.t -> string -> (Context.t * Types.datatype * Value.t)
     = fun initial_context source_code ->
     Parse.string initial_context source_code
@@ -195,10 +189,4 @@ module Phases = struct
     |> Compile.IR.run
     |> Transform.run
     |> Evaluate.run
-
-  (* Error handling wrapper for [evaluate_string] above. *)
-  let evaluate_string context source_code =
-    Errors.display
-      ~default:(fun _ -> exit 1)
-      (lazy (evaluate_string context source_code))
 end

--- a/bin/driver.ml
+++ b/bin/driver.ml
@@ -3,20 +3,6 @@ open Webserver
 open Performance
 open Utility
 
-module Eval = Evalir.Eval(Webserver)
-module Webif = Webif.WebIf(Webserver)
-
-type evaluation_env =   Value.env (* maps int identifiers to their values *)
-                      * Ir.var Env.String.t (* map string identifiers to int identifiers *)
-                      * Types.typing_environment (* typing info, using string identifiers *)
-
-type evaluation_result =
-  {
-    result_env : evaluation_env;
-    result_value : Value.t;
-    result_type : Types.datatype
-  }
-
 (** Name of the file containing the prelude code. *)
 let prelude_file =
   let prelude_dir =
@@ -36,140 +22,183 @@ let typecheck_only
               |> convert parse_bool
               |> sync)
 
-(** optimise and evaluate a program *)
-let process_program
-      (interacting : bool)
-      (envs : evaluation_env)
-      (program : Ir.program)
-      external_files
-          : (Value.env * Value.t) =
-  let (valenv, nenv, tyenv) = envs in
-  let tenv = (Var.varify_env (nenv, tyenv.Types.var_env)) in
+module Phases = struct
+  module Parse = struct
+    let run : Context.t -> string -> Sugartypes.program Loader.result
+      = Loader.load
 
-  let perform_optimisations = Settings.get Backend.optimise && not interacting in
-
-  let (globals, _main) as post_backend_pipeline_program =
-    Backend.transform_program perform_optimisations tenv program in
-
-
-  (if Settings.get typecheck_only then exit 0);
-
-  Webserver.init (valenv, nenv, tyenv) globals external_files;
-
-  lazy (Eval.run_program valenv post_backend_pipeline_program) |>measure_as<| "run_program"
-
-
-let process_program  interacting envs program external_files =
-  lazy (process_program  interacting envs program external_files) |>measure_as<| "process_program"
-
-let die_on_exception f x =
-  Errors.display ~default:(fun _ -> exit 1) (lazy (f x))
-
-let die_on_exception_unless_interacting is_interacting f x =
-  let handle exc =
-    if is_interacting then
-      raise exc
-    else
-      exit 1 in
-  Errors.display ~default:handle (lazy (f x))
-
-
-(** Read Links source code, then optimise and run it. *)
-let evaluate
-      ?(handle_errors=die_on_exception_unless_interacting)
-      interacting
-      parse_fun
-      (envs : evaluation_env)
-      filename
-          : evaluation_result =
-  let (_, nenv, tyenv) = envs in
-  let evaluate_inner f =
-    let (program, t), (nenv', tyenv'), external_files = parse_fun (nenv, tyenv) f in
-
-    let valenv, v = process_program interacting envs program external_files in
-    {
-    result_env = (valenv,
-      Env.String.extend nenv nenv',
-      Types.extend_typing_environment tyenv tyenv');
-    result_value = v;
-    result_type = t
-    }
-  in
-  let evaluate_inner f = lazy (evaluate_inner f) |>measure_as<| "evaluate" in
-  handle_errors interacting evaluate_inner filename
-
-
-(* For non-REPL use only *)
-module NonInteractive =
-struct
-
-  let show_lib_function_env
-    = Settings.(flag "show_lib_function_env"
-                |> synopsis "Print the lib.ml functions and their types. In particular, map their integer identifiers to their original names"
-                |> convert parse_bool
-                |> sync)
-
-  let run_file prelude envs filename : evaluation_result =
-    Webserver.set_prelude prelude;
-    let parse_and_desugar (nenv, tyenv) filename =
-      let source =
-        die_on_exception_unless_interacting false (Loader.load_file (nenv, tyenv)) filename
+    let string : Context.t -> string -> Sugartypes.program Loader.result
+      = fun context source_code ->
+      let program, pos_context =
+        Parse.parse_string
+          ~pp:(from_option "" (Settings.get Parse.pp))
+          Parse.program
+          source_code
       in
-        let open Loader in
-        let (nenv, tyenv) = source.envs in
-        let (globals, (locals, main), t) = source.program in
-        let external_files = source.external_dependencies in
-        ((globals @ locals, main), t), (nenv, tyenv), external_files
+      let context' = Context.({ context with source_code = pos_context }) in
+      Loader.({ program_ = program; context = context' })
+
+    let interactive : string -> Context.t -> Sugartypes.sentence Loader.result
+      = fun ps1 context ->
+      let program, pos_context =
+        Parse.Readline.parse ps1
+      in
+      let context' = Context.({ context with source_code = pos_context }) in
+      Loader.({ program_ = program; context = context' })
+  end
+
+  module Desugar = struct
+    let run : Sugartypes.program Loader.result -> Sugartypes.program Frontend.result
+      = fun Loader.({ context; program_ }) ->
+      Frontend.program context program_
+
+    let interactive : Sugartypes.sentence Loader.result -> Sugartypes.sentence Frontend.result
+      = fun Loader.({ context; program_ }) ->
+      Frontend.interactive context program_
+  end
+
+  module Compile = struct
+    module IR = struct
+      let run : Sugartypes.program Frontend.result -> Sugartoir.result
+        = fun Frontend.({ context; datatype; program }) ->
+        Sugartoir.program context datatype program
+    end
+  end
+
+  module Transform = struct
+    let run : Sugartoir.result -> Backend.result
+      = fun Sugartoir.({ context; datatype; globals; program }) ->
+      let program' =
+        Ir.with_bindings globals program (* TODO(dhil): This looks silly, and I think it may be wrong... *)
+      in
+      Backend.program context datatype program'
+  end
+
+  module Evaluate = struct
+    module Eval = Evalir.Eval(Webserver)
+
+    let run : Backend.result -> (Context.t * Types.datatype * Value.t)
+      = fun Backend.({ context; program; datatype }) ->
+      let valenv = Context.value_environment context in
+      let (valenv', v) =
+        lazy (Eval.run_program valenv program) |>measure_as<| "run_program"
+      in
+      (Context.({ context with value_environment = valenv' }), datatype, v)
+  end
+
+  module Interactive = struct
+    type result =
+      { context: Context.t;
+        sentence: [ `Definitions of Ir.binding list
+                  | `Expression of Types.datatype * Value.t
+                  | `Directive of string * string list ] }
+
+    let readline : string -> Context.t -> result
+      = fun ps1 context ->
+      let Frontend.({ context; program = sentence; datatype })
+        = Parse.interactive ps1 context
+          |> Desugar.interactive
+      in
+      let context, sentence =
+        match sentence with
+        | Sugartypes.Definitions defs ->
+           let program' = (defs, None) in
+           let Backend.({ program; _ }) as result =
+             Compile.IR.run Frontend.({ context; datatype; program = program' })
+             |> Transform.run
+           in
+           let (context', _, _) = Evaluate.run result in
+           context', `Definitions (fst program)
+        | Sugartypes.Expression expr ->
+           let program' = ([], Some expr) in
+           let result =
+             Compile.IR.run Frontend.({ context; datatype; program = program' })
+             |> Transform.run
+           in
+           let (context', datatype, value) = Evaluate.run result in
+           context', `Expression (datatype, value)
+        | Sugartypes.Directive d ->
+           context, `Directive d
+      in
+      { context; sentence }
+  end
+
+  let dump_lib : out_channel -> unit
+    = fun oc ->
+    Printf.fprintf oc "lib.ml mappings:\n%!";
+    Env.String.iter
+      (fun name var ->
+        let (datatype : string) =
+          Types.string_of_datatype
+            (Env.String.lookup Lib.typing_env.Types.var_env name)
+        in
+        Printf.fprintf oc " %d -> %s : %s\n%!" var name datatype)
+      Lib.nenv
+
+  (* Loads the prelude, and returns the 'initial' compilation context. *)
+  let initialise : unit -> Context.t
+    = fun () ->
+    let context = Context.({ empty with name_environment = Lib.nenv;
+                                        typing_environment = Lib.typing_env })
     in
-      evaluate false parse_and_desugar envs filename
-
-
-  let run_file prelude envs filename =
-    lazy (run_file prelude envs filename) |>measure_as<| ("run_file "^filename)
-
-
-
-  let evaluate_string_in envs  v =
-    let parse_and_desugar (nenv, tyenv) s =
-      let sugar, pos_context = Parse.parse_string ~pp:(from_option "" (Settings.get Parse.pp)) Parse.program s in
-      let (program, t, _), _ = Frontend.Pipeline.program tyenv pos_context sugar in
-
-      let tenv = Var.varify_env (nenv, tyenv.Types.var_env) in
-
-      let globals, (locals, main), _nenv = Sugartoir.desugar_program (nenv, tenv, tyenv.Types.effect_row) program in
-      ((globals @ locals, main), t), (nenv, tyenv), []
+    let filename = val_of (Settings.get prelude_file) in
+    let result =
+      Parse.run context filename
+      |> Desugar.run
+      |> (fun result ->
+        let context = result.Frontend.context in
+        let venv =
+          Var.varify_env (Lib.nenv, Lib.typing_env.Types.var_env)
+        in
+        let context' = Context.({ context with variable_environment = venv }) in
+        Compile.IR.run Frontend.({ result with context = context' }))
+      |> Transform.run
     in
-      evaluate false parse_and_desugar envs v
+    let context', _, _ = Evaluate.run result in
+    let nenv = Context.name_environment context' in
+    let tenv = Context.typing_environment context' in
+    let venv = Var.varify_env (nenv, tenv.Types.var_env) in
+    (* Prepare the webserver. *)
+    Webserver.set_prelude (fst result.Backend.program);
+    (* Return the 'initial' compiler context. *)
+    Context.({ context' with variable_environment = venv })
 
+  let whole_program : Context.t -> string -> (Context.t * Types.datatype * Value.t)
+    = fun initial_context filename ->
+    (* Process source file (and its dependencies. *)
+    let result =
+      Parse.run initial_context filename
+      |> Desugar.run
+      |> (fun result -> if Settings.get typecheck_only then exit 0 else result)
+      |> Compile.IR.run
+      |> Transform.run
+    in
+    let context, (globals, _) = result.Backend.context, result.Backend.program in
+    let valenv    = Context.value_environment context in
+    let nenv      = Context.name_environment context in
+    let tenv      = Context.typing_environment context in
+    let ffi_files = Context.ffi_files context in
+    Webserver.init (valenv, nenv, tenv) globals ffi_files;
+    Evaluate.run result
 
+  (* Error handling wrapper for [whole_program] above. *)
+  let whole_program context filename =
+    Errors.display
+      ~default:(fun _ -> exit 1)
+      (lazy (whole_program context filename))
 
-  (* TODO: Remove special handling of prelude once module processing is in place *)
-  let load_prelude () =
-    (if Settings.get show_lib_function_env then
-      (Debug.print "lib.ml mappings:";
-      Env.String.iter (fun name var -> Debug.print (string_of_int var ^ " -> " ^ name ^ " :: " ^
-        Types.string_of_datatype (Env.String.lookup Lib.typing_env.Types.var_env name ) )) Lib.nenv));
+  let evaluate_string : Context.t -> string -> (Context.t * Types.datatype * Value.t)
+    = fun initial_context source_code ->
+    Parse.string initial_context source_code
+    |> Desugar.run
+    |> (fun result -> if Settings.get typecheck_only then exit 0 else result)
+    |> Compile.IR.run
+    |> Transform.run
+    |> Evaluate.run
 
-    let load_prelude_inner () =
-      let open Loader in
-      let source =
-        (die_on_exception_unless_interacting false
-          (Loader.load_file (Lib.nenv, Lib.typing_env)) (val_of (Settings.get prelude_file)))
-      in
-      let (nenv, tyenv) = source.envs in
-      let (globals, _, _) = source.program in
-
-      let tenv = (Var.varify_env (Lib.nenv, Lib.typing_env.Types.var_env)) in
-
-      let globals = Backend.transform_prelude tenv globals in
-
-      let valenv = Eval.run_defs Value.Env.empty globals in
-      let envs =
-        (valenv,
-        Env.String.extend Lib.nenv nenv,
-        Types.extend_typing_environment Lib.typing_env tyenv)
-      in
-        globals, envs
-   in
-   die_on_exception load_prelude_inner ()
+  (* Error handling wrapper for [evaluate_string] above. *)
+  let evaluate_string context source_code =
+    Errors.display
+      ~default:(fun _ -> exit 1)
+      (lazy (evaluate_string context source_code))
 end

--- a/bin/links.ml
+++ b/bin/links.ml
@@ -1,5 +1,4 @@
 open Links_core
-open Performance
 open Utility
 
 module BS = Basicsettings
@@ -46,21 +45,40 @@ let _ =
             |> sync)
 
 
-let print_simple rtype value =
-  print_string (Value.string_of_value value);
-  print_endline
-    (if Settings.get (Repl.printing_types) then
-          " : " ^ Types.string_of_datatype rtype
-        else
-          "")
+let print_simple datatype value =
+  let oc = stdout in
+  if Settings.get Repl.printing_types
+  then Printf.fprintf oc
+         "%s : %s\n%!"
+         (Value.string_of_value value)
+         (Types.string_of_datatype datatype)
+  else Printf.fprintf oc "%s\n%!" (Value.string_of_value value)
 
-let process_filearg prelude envs file =
-  let result = Driver.NonInteractive.run_file prelude envs file in
-  print_simple result.Driver.result_type result.Driver.result_value
+let process_file context file =
+  let (context', datatype, value) = Driver.Phases.whole_program context file in
+  print_simple datatype value; context'
 
-let process_exprarg envs expr =
-  let result = Driver.NonInteractive.evaluate_string_in envs expr in
-  print_simple result.Driver.result_type result.Driver.result_value
+let process_expr context expr_string =
+  let (context', datatype, value) = Driver.Phases.evaluate_string context expr_string in
+  print_simple datatype value; context'
+
+let isolate
+  = Settings.(flag ~default:true "isolation"
+              |> synopsis "Run file and expression arguments in isolation"
+              |> privilege `System
+              |> convert parse_bool
+              |> CLI.(add (long "isolate"))
+              |> sync)
+
+let for_each : Context.t -> (Context.t -> string -> Context.t) -> string list -> Context.t
+  = fun context f xs ->
+  List.fold_left
+    (fun context x ->
+      let context' = f context x in
+      if Settings.get isolate
+      then context
+      else context')
+    context xs
 
 let main () =
   (* Attempt to synchronise all settings. If any setting commands are
@@ -70,14 +88,15 @@ let main () =
   let file_list = Settings.get_anonymous_arguments () in
   let to_evaluate = Settings.get to_evaluate in
 
-  let prelude, envs = measure "prelude" Driver.NonInteractive.load_prelude () in
-
-  for_each to_evaluate (process_exprarg envs);
-    (* TBD: accumulate type/value environment so that "interact" has access *)
-
-  for_each file_list (process_filearg prelude envs);
+  let context = Driver.Phases.initialise () in
+  let context' =
+    for_each context process_expr to_evaluate
+  in
+  let context'' =
+    for_each context' process_file file_list
+  in
   match file_list, to_evaluate with
-  | [], [] -> Repl.interact envs
+  | [], [] -> Repl.interact context''
   | _, _ -> ()
 
 let _ =
@@ -86,6 +105,5 @@ let _ =
     | Some _ -> Settings.set BS.web_mode true
     | None -> ()
   end;
-
   main()
 

--- a/bin/links.ml
+++ b/bin/links.ml
@@ -54,12 +54,19 @@ let print_simple datatype value =
          (Types.string_of_datatype datatype)
   else Printf.fprintf oc "%s\n%!" (Value.string_of_value value)
 
+let handle_errors comp =
+  Errors.display ~default:(fun _ -> exit 1) comp
+
 let process_file context file =
-  let (context', datatype, value) = Driver.Phases.whole_program context file in
+  let (context', datatype, value) =
+    handle_errors (lazy (Driver.Phases.whole_program context file))
+  in
   print_simple datatype value; context'
 
 let process_expr context expr_string =
-  let (context', datatype, value) = Driver.Phases.evaluate_string context expr_string in
+  let (context', datatype, value) =
+    handle_errors (lazy (Driver.Phases.evaluate_string context expr_string))
+  in
   print_simple datatype value; context'
 
 let isolate

--- a/bin/links.mli
+++ b/bin/links.mli
@@ -1,0 +1,1 @@
+(* Intentionally left blank. *)

--- a/bin/repl.mli
+++ b/bin/repl.mli
@@ -1,0 +1,3 @@
+open Links_core
+val printing_types : bool Settings.setting
+val interact : Context.t -> unit

--- a/core/backend.ml
+++ b/core/backend.ml
@@ -35,209 +35,107 @@ let optimise
               |> CLI.(add (long "optimise"))
               |> sync)
 
-(* let print_program _ p =
- *   Debug.print (Ir.string_of_program p)w;p *)
-
-(* let print_bindings _ bs =
- *   List.iter (Debug.print -<- Ir.string_of_binding) bs;bs *)
-
-
-(* let run pipeline tyenv p =
- *   List.fold_left (fun p transformer -> transformer tyenv p) p (pipeline ()) *)
-
-(* let measure name func tyenv p = Performance.measure name (uncurry func) (tyenv, p) *)
-
-(* let perform_for_side_effects side_effecting_transformer tyenv p =
- *   side_effecting_transformer tyenv p;p *)
-
 type result = { program: Ir.program;
                 datatype: Types.datatype;
                 context: Context.t }
 
-module Pipeline: sig
-  val program : Context.t -> Types.datatype -> Ir.program -> result
-end = struct
-  type transformer = (module IrTransform.S)
-  type transforms = (string * transformer) array
+type transformer = (module IrTransform.S)
+type transforms = (string * transformer) array
 
-  module Pipeline(T : sig
-               val transforms : transforms
-             end) : IrTransform.S = struct
-    let program state program =
-      let apply : IrTransform.result -> (string * transformer) -> IrTransform.result
-        = fun (IrTransform.Result { state; program }) (_, (module T)) ->
-        T.program state program
-      in
-      Array.fold_left
-        apply (IrTransform.return state program) T.transforms
-  end
-
-  let lift : transforms -> transformer
-    = fun transforms ->
-    (module Pipeline(struct let transforms = transforms end))
-
-
-  module Conditional(T : sig
-               include IrTransform.S
-               val condition : unit -> bool
-             end) : IrTransform.S = struct
-    let program state program =
-      if T.condition ()
-      then T.program state program
-      else IrTransform.return state program
-  end
-
-  let only_if : bool Settings.setting -> (module IrTransform.S) -> transformer
-    = fun setting (module T) ->
-    (module Conditional(struct include T let condition () = Settings.get setting end))
-
-  let only_if_any : bool Settings.setting list -> (module IrTransform.S) -> transformer
-    = fun settings (module T) ->
-    (module Conditional(struct include T let condition () = List.exists Settings.get settings end))
-
-  module PerformEffect(T : sig val perform : IrTransform.state -> Ir.program -> unit end) : IrTransform.S = struct
-    let program state program =
-      T.perform state program;
-      IrTransform.return state program
-  end
-
-  let debug_tell : string -> transformer
-    = fun msg ->
-    only_if
-      Debug.enabled
-      (module PerformEffect(struct let perform _ _ = Debug.print msg end))
-
-  let print_program : transformer
-    = (module PerformEffect(struct let perform _ program = Debug.print (Ir.string_of_program program) end))
-
-
-  module Measure(T : sig include IrTransform.S val name : string end) = struct
-    let program state program =
-      Performance.measure_l T.name (lazy (T.program state program))
-  end
-
-  let measure : string -> transformer -> transformer
-    = fun name (module T) ->
-    (module Measure(struct include T let name = name end))
-
-  let optimisations : transforms
-    = [| "debug", debug_tell "optimising IR"
-       ; "ElimDeadDefs", (module IrTraversals.ElimDeadDefs)
-       ; "inline", (module IrTraversals.Inline)
-       ; "debug", debug_tell "optimised IR" |]
-
-  let typechecking : transforms
-    = [| "debug", debug_tell "typechecking IR"
-       ; "Typecheck", (module IrCheck.Typecheck) (* TODO FIXME check against the carried datatype. *)
-       ; "debug", debug_tell "typechecked IR" |]
-
-  let simplify_type_structure : transforms
-    = [| "debug", debug_tell "simplifying types"
-       ; "ElimBodiesFromMetaTypeVars", (module IrTraversals.ElimBodiesFromMetaTypeVars)
-       ; "debug", debug_tell "simplified types" |]
-
-  let pipeline : transformer array
-    = [| only_if optimise (measure "optimise" (lift optimisations))
-       ; (module Closures)
-       ; (module PerformEffect(struct let perform = BuildTables.program end))
-       ; only_if_any [IrCheck.typecheck; simplify_types] (lift simplify_type_structure)
-       ; only_if IrCheck.typecheck (lift typechecking)
-       ; only_if show_compiled_ir_after_backend_transformations print_program |]
-
-  let program context' datatype program =
-    let apply : IrTransform.result -> transformer -> IrTransform.result
-      = fun (IrTransform.Result { program; state }) (module T) ->
-        (* TODO run verification logic? *)
-        T.program state program
+module Pipeline(T : sig
+             val transforms : transforms
+           end) : IrTransform.S = struct
+  let program state program =
+    let apply : IrTransform.result -> (string * transformer) -> IrTransform.result
+      = fun (IrTransform.Result { state; program }) (_, (module T)) ->
+      T.program state program
     in
-    let initial_state =
-      IrTransform.{ datatype; context = context'; primitive_vars = Lib.primitive_vars }
-    in
-    let IrTransform.(Result { program; state = { context; datatype; _ } }) =
-      Array.fold_left apply (IrTransform.return initial_state program) pipeline
-    in
-    { program; context; datatype }
+    Array.fold_left
+      apply (IrTransform.return state program) T.transforms
 end
 
-(* module Pipelines =
- * struct
- * 
- *     let optimisation_pipeline () = [
- *         debug_tell "optimising IR";
- *         IrTraversals.ElimDeadDefs.program';
- *         IrTraversals.Inline.program;
- *         debug_tell "optimised IR"
- *       ]
- * 
- *     let simplify_type_structure_program () = [
- *         debug_tell "simplifying types";
- *         (\*IrTraversals.NormaliseTypes.program;
- *         IrTraversals.ElimRecursiveTypeCycles.program;*\)
- *         (\* IrTraversals.ElimTypeAliases.program; *\)
- *         IrTraversals.ElimBodiesFromMetaTypeVars.program;
- *         debug_tell "simplified types";
- *         (only_if_set show_compiled_ir_after_backend_transformations print_program)
- *       ]
- * 
- *     let simplify_type_structure_bindings () = [
- *         debug_tell "simplifying types";
- *         (\*IrTraversals.NormaliseTypes.bindings;
- *         IrTraversals.ElimRecursiveTypeCycles.bindings;*\)
- *         (\* IrTraversals.ElimTypeAliases.bindings; *\)
- *         IrTraversals.ElimBodiesFromMetaTypeVars.bindings;
- *         debug_tell "simplified types";
- *         (only_if_set show_compiled_ir_after_backend_transformations print_bindings);
- *       ]
- * 
- *     let typechecking_pipeline () = [
- *         debug_tell "typechecking IR";
- *         IrCheck.Typecheck.program;
- *         debug_tell "typechecked IR"
- *       ]
- * 
- *     let prelude_typechecking_pipeline () = [
- *         debug_tell "typechecking prelude IR";
- *         IrCheck.Typecheck.bindings;
- *         debug_tell "typechecked prelude IR";
- *       ]
- * 
- * 
- *     let main_pipeline perform_optimisations () = [
- *         only_if
- *           perform_optimisations
- *           (measure "optimise" (run optimisation_pipeline));
- *         Closures.program Lib.primitive_vars;
- *         perform_for_side_effects
- *           (BuildTables.program Lib.primitive_vars);
- *         only_if_any_set
- *           [IrCheck.typecheck; simplify_types]
- *           (run simplify_type_structure_program);
- *         only_if_set
- *           IrCheck.typecheck
- *           (run typechecking_pipeline);
- *       ]
- * 
- *     let prelude_pipeline () = [
- *         (\* May perform some optimisations here that are safe to do on the prelude *\)
- *         (fun tenv globals -> Closures.bindings tenv Lib.primitive_vars globals);
- *         (fun tenv globals -> BuildTables.bindings tenv Lib.primitive_vars globals; globals);
- *         only_if_any_set
- *           [IrCheck.typecheck; simplify_types]
- *           (run simplify_type_structure_bindings);
- *         only_if_set
- *           IrCheck.typecheck
- *           (run prelude_typechecking_pipeline);
- *       ]
- * 
- * end *)
+let lift : transforms -> transformer
+  = fun transforms ->
+  (module Pipeline(struct let transforms = transforms end))
 
 
-let program : Context.t -> Types.datatype -> Ir.program -> result
-  = fun context datatype program ->
-  Pipeline.program context datatype program
+module Conditional(T : sig
+             include IrTransform.S
+             val condition : unit -> bool
+           end) : IrTransform.S = struct
+  let program state program =
+    if T.condition ()
+    then T.program state program
+    else IrTransform.return state program
+end
 
-let transform_program _perform_optimisations _tyenv _p = assert false
-  (* run (Pipelines.main_pipeline perform_optimisations) tyenv p *)
+let only_if : bool Settings.setting -> (module IrTransform.S) -> transformer
+  = fun setting (module T) ->
+  (module Conditional(struct include T let condition () = Settings.get setting end))
 
-let transform_prelude _tyenv _bindings = assert false
-  (* run Pipelines.prelude_pipeline tyenv bindings *)
+let only_if_any : bool Settings.setting list -> (module IrTransform.S) -> transformer
+  = fun settings (module T) ->
+  (module Conditional(struct include T let condition () = List.exists Settings.get settings end))
+
+module PerformEffect(T : sig val perform : IrTransform.state -> Ir.program -> unit end) : IrTransform.S = struct
+  let program state program =
+    T.perform state program;
+    IrTransform.return state program
+end
+
+let debug_tell : string -> transformer
+  = fun msg ->
+  only_if
+    Debug.enabled
+    (module PerformEffect(struct let perform _ _ = Debug.print msg end))
+
+let print_program : transformer
+  = (module PerformEffect(struct let perform _ program = Debug.print (Ir.string_of_program program) end))
+
+
+module Measure(T : sig include IrTransform.S val name : string end) = struct
+  let program state program =
+    Performance.measure_l T.name (lazy (T.program state program))
+end
+
+let measure : string -> transformer -> transformer
+  = fun name (module T) ->
+  (module Measure(struct include T let name = name end))
+
+let optimisations : transforms
+  = [| "debug", debug_tell "optimising IR"
+     ; "ElimDeadDefs", (module IrTraversals.ElimDeadDefs)
+     ; "inline", (module IrTraversals.Inline)
+     ; "debug", debug_tell "optimised IR" |]
+
+let typechecking : transforms
+  = [| "debug", debug_tell "typechecking IR"
+     ; "Typecheck", (module IrCheck.Typecheck) (* TODO FIXME check against the carried datatype. *)
+     ; "debug", debug_tell "typechecked IR" |]
+
+let simplify_type_structure : transforms
+  = [| "debug", debug_tell "simplifying types"
+     ; "ElimBodiesFromMetaTypeVars", (module IrTraversals.ElimBodiesFromMetaTypeVars)
+     ; "debug", debug_tell "simplified types" |]
+
+let pipeline : transformer array
+  = [| only_if optimise (measure "optimise" (lift optimisations))
+     ; (module Closures)
+     ; (module PerformEffect(struct let perform = BuildTables.program end))
+     ; only_if_any [IrCheck.typecheck; simplify_types] (lift simplify_type_structure)
+     ; only_if IrCheck.typecheck (lift typechecking)
+     ; only_if show_compiled_ir_after_backend_transformations print_program |]
+
+let program context' datatype program =
+  let apply : IrTransform.result -> transformer -> IrTransform.result
+    = fun (IrTransform.Result { program; state }) (module T) ->
+    (* TODO run verification logic? *)
+    T.program state program
+  in
+  let initial_state =
+    IrTransform.{ datatype; context = context'; primitive_vars = Lib.primitive_vars }
+  in
+  let IrTransform.(Result { program; state = { context; datatype; _ } }) =
+    Array.fold_left apply (IrTransform.return initial_state program) pipeline
+  in
+  { program; context; datatype }

--- a/core/backend.ml
+++ b/core/backend.ml
@@ -35,113 +35,209 @@ let optimise
               |> CLI.(add (long "optimise"))
               |> sync)
 
+(* let print_program _ p =
+ *   Debug.print (Ir.string_of_program p)w;p *)
 
-let only_if predicate transformer =
-              if predicate then transformer else (fun _ x -> x)
-let only_if_set setting =
-             only_if (Settings.get setting)
-
-let only_if_any_set settings transformer =
-  if Utility.any_true (List.map Settings.get settings)
-  then transformer
-  else (fun _ x -> x)
-
-let debug_tell msg =
-  only_if_set
-    Debug.enabled
-    (fun _tyenv prog ->
-      Debug.print msg; prog)
-
-let print_program _ p =
-  Debug.print (Ir.string_of_program p);p
-
-let print_bindings _ bs =
-  List.iter (Debug.print -<- Ir.string_of_binding) bs;bs
+(* let print_bindings _ bs =
+ *   List.iter (Debug.print -<- Ir.string_of_binding) bs;bs *)
 
 
-let run pipeline tyenv p =
-  List.fold_left (fun p transformer -> transformer tyenv p) p (pipeline ())
+(* let run pipeline tyenv p =
+ *   List.fold_left (fun p transformer -> transformer tyenv p) p (pipeline ()) *)
 
-let measure name func tyenv p = Performance.measure name (uncurry func) (tyenv, p)
+(* let measure name func tyenv p = Performance.measure name (uncurry func) (tyenv, p) *)
 
-let perform_for_side_effects side_effecting_transformer tyenv p =
-  side_effecting_transformer tyenv p;p
+(* let perform_for_side_effects side_effecting_transformer tyenv p =
+ *   side_effecting_transformer tyenv p;p *)
 
-module Pipelines =
-struct
+type result = { program: Ir.program;
+                datatype: Types.datatype;
+                context: Context.t }
 
-    let optimisation_pipeline () = [
-        debug_tell "optimising IR";
-        IrTraversals.ElimDeadDefs.program;
-        IrTraversals.Inline.program;
-        debug_tell "optimised IR"
-      ]
+module Pipeline: sig
+  val program : Context.t -> Types.datatype -> Ir.program -> result
+end = struct
+  type transformer = (module IrTransform.S)
+  type transforms = (string * transformer) array
 
-    let simplify_type_structure_program () = [
-        debug_tell "simplifying types";
-        (*IrTraversals.NormaliseTypes.program;
-        IrTraversals.ElimRecursiveTypeCycles.program;*)
-        (* IrTraversals.ElimTypeAliases.program; *)
-        IrTraversals.ElimBodiesFromMetaTypeVars.program;
-        debug_tell "simplified types";
-        (only_if_set show_compiled_ir_after_backend_transformations print_program)
-      ]
+  module Pipeline(T : sig
+               val transforms : transforms
+             end) : IrTransform.S = struct
+    let program state program =
+      let apply : IrTransform.result -> (string * transformer) -> IrTransform.result
+        = fun (IrTransform.Result { state; program }) (_, (module T)) ->
+        T.program state program
+      in
+      Array.fold_left
+        apply (IrTransform.return state program) T.transforms
+  end
 
-    let simplify_type_structure_bindings () = [
-        debug_tell "simplifying types";
-        (*IrTraversals.NormaliseTypes.bindings;
-        IrTraversals.ElimRecursiveTypeCycles.bindings;*)
-        (* IrTraversals.ElimTypeAliases.bindings; *)
-        IrTraversals.ElimBodiesFromMetaTypeVars.bindings;
-        debug_tell "simplified types";
-        (only_if_set show_compiled_ir_after_backend_transformations print_bindings);
-      ]
-
-    let typechecking_pipeline () = [
-        debug_tell "typechecking IR";
-        IrCheck.Typecheck.program;
-        debug_tell "typechecked IR"
-      ]
-
-    let prelude_typechecking_pipeline () = [
-        debug_tell "typechecking prelude IR";
-        IrCheck.Typecheck.bindings;
-        debug_tell "typechecked prelude IR";
-      ]
+  let lift : transforms -> transformer
+    = fun transforms ->
+    (module Pipeline(struct let transforms = transforms end))
 
 
-    let main_pipeline perform_optimisations () = [
-        only_if
-          perform_optimisations
-          (measure "optimise" (run optimisation_pipeline));
-        Closures.program Lib.primitive_vars;
-        perform_for_side_effects
-          (BuildTables.program Lib.primitive_vars);
-        only_if_any_set
-          [IrCheck.typecheck; simplify_types]
-          (run simplify_type_structure_program);
-        only_if_set
-          IrCheck.typecheck
-          (run typechecking_pipeline);
-      ]
+  module Conditional(T : sig
+               include IrTransform.S
+               val condition : unit -> bool
+             end) : IrTransform.S = struct
+    let program state program =
+      if T.condition ()
+      then T.program state program
+      else IrTransform.return state program
+  end
 
-    let prelude_pipeline () = [
-        (* May perform some optimisations here that are safe to do on the prelude *)
-        (fun tenv globals -> Closures.bindings tenv Lib.primitive_vars globals);
-        (fun tenv globals -> BuildTables.bindings tenv Lib.primitive_vars globals; globals);
-        only_if_any_set
-          [IrCheck.typecheck; simplify_types]
-          (run simplify_type_structure_bindings);
-        only_if_set
-          IrCheck.typecheck
-          (run prelude_typechecking_pipeline);
-      ]
+  let only_if : bool Settings.setting -> (module IrTransform.S) -> transformer
+    = fun setting (module T) ->
+    (module Conditional(struct include T let condition () = Settings.get setting end))
 
+  let only_if_any : bool Settings.setting list -> (module IrTransform.S) -> transformer
+    = fun settings (module T) ->
+    (module Conditional(struct include T let condition () = List.exists Settings.get settings end))
+
+  module PerformEffect(T : sig val perform : IrTransform.state -> Ir.program -> unit end) : IrTransform.S = struct
+    let program state program =
+      T.perform state program;
+      IrTransform.return state program
+  end
+
+  let debug_tell : string -> transformer
+    = fun msg ->
+    only_if
+      Debug.enabled
+      (module PerformEffect(struct let perform _ _ = Debug.print msg end))
+
+  let print_program : transformer
+    = (module PerformEffect(struct let perform _ program = Debug.print (Ir.string_of_program program) end))
+
+
+  module Measure(T : sig include IrTransform.S val name : string end) = struct
+    let program state program =
+      Performance.measure_l T.name (lazy (T.program state program))
+  end
+
+  let measure : string -> transformer -> transformer
+    = fun name (module T) ->
+    (module Measure(struct include T let name = name end))
+
+  let optimisations : transforms
+    = [| "debug", debug_tell "optimising IR"
+       ; "ElimDeadDefs", (module IrTraversals.ElimDeadDefs)
+       ; "inline", (module IrTraversals.Inline)
+       ; "debug", debug_tell "optimised IR" |]
+
+  let typechecking : transforms
+    = [| "debug", debug_tell "typechecking IR"
+       ; "Typecheck", (module IrCheck.Typecheck) (* TODO FIXME check against the carried datatype. *)
+       ; "debug", debug_tell "typechecked IR" |]
+
+  let simplify_type_structure : transforms
+    = [| "debug", debug_tell "simplifying types"
+       ; "ElimBodiesFromMetaTypeVars", (module IrTraversals.ElimBodiesFromMetaTypeVars)
+       ; "debug", debug_tell "simplified types" |]
+
+  let pipeline : transformer array
+    = [| only_if optimise (measure "optimise" (lift optimisations))
+       ; (module Closures)
+       ; (module PerformEffect(struct let perform = BuildTables.program end))
+       ; only_if_any [IrCheck.typecheck; simplify_types] (lift simplify_type_structure)
+       ; only_if IrCheck.typecheck (lift typechecking)
+       ; only_if show_compiled_ir_after_backend_transformations print_program |]
+
+  let program context' datatype program =
+    let apply : IrTransform.result -> transformer -> IrTransform.result
+      = fun (IrTransform.Result { program; state }) (module T) ->
+        (* TODO run verification logic? *)
+        T.program state program
+    in
+    let initial_state =
+      IrTransform.{ datatype; context = context'; primitive_vars = Lib.primitive_vars }
+    in
+    let IrTransform.(Result { program; state = { context; datatype; _ } }) =
+      Array.fold_left apply (IrTransform.return initial_state program) pipeline
+    in
+    { program; context; datatype }
 end
 
+(* module Pipelines =
+ * struct
+ * 
+ *     let optimisation_pipeline () = [
+ *         debug_tell "optimising IR";
+ *         IrTraversals.ElimDeadDefs.program';
+ *         IrTraversals.Inline.program;
+ *         debug_tell "optimised IR"
+ *       ]
+ * 
+ *     let simplify_type_structure_program () = [
+ *         debug_tell "simplifying types";
+ *         (\*IrTraversals.NormaliseTypes.program;
+ *         IrTraversals.ElimRecursiveTypeCycles.program;*\)
+ *         (\* IrTraversals.ElimTypeAliases.program; *\)
+ *         IrTraversals.ElimBodiesFromMetaTypeVars.program;
+ *         debug_tell "simplified types";
+ *         (only_if_set show_compiled_ir_after_backend_transformations print_program)
+ *       ]
+ * 
+ *     let simplify_type_structure_bindings () = [
+ *         debug_tell "simplifying types";
+ *         (\*IrTraversals.NormaliseTypes.bindings;
+ *         IrTraversals.ElimRecursiveTypeCycles.bindings;*\)
+ *         (\* IrTraversals.ElimTypeAliases.bindings; *\)
+ *         IrTraversals.ElimBodiesFromMetaTypeVars.bindings;
+ *         debug_tell "simplified types";
+ *         (only_if_set show_compiled_ir_after_backend_transformations print_bindings);
+ *       ]
+ * 
+ *     let typechecking_pipeline () = [
+ *         debug_tell "typechecking IR";
+ *         IrCheck.Typecheck.program;
+ *         debug_tell "typechecked IR"
+ *       ]
+ * 
+ *     let prelude_typechecking_pipeline () = [
+ *         debug_tell "typechecking prelude IR";
+ *         IrCheck.Typecheck.bindings;
+ *         debug_tell "typechecked prelude IR";
+ *       ]
+ * 
+ * 
+ *     let main_pipeline perform_optimisations () = [
+ *         only_if
+ *           perform_optimisations
+ *           (measure "optimise" (run optimisation_pipeline));
+ *         Closures.program Lib.primitive_vars;
+ *         perform_for_side_effects
+ *           (BuildTables.program Lib.primitive_vars);
+ *         only_if_any_set
+ *           [IrCheck.typecheck; simplify_types]
+ *           (run simplify_type_structure_program);
+ *         only_if_set
+ *           IrCheck.typecheck
+ *           (run typechecking_pipeline);
+ *       ]
+ * 
+ *     let prelude_pipeline () = [
+ *         (\* May perform some optimisations here that are safe to do on the prelude *\)
+ *         (fun tenv globals -> Closures.bindings tenv Lib.primitive_vars globals);
+ *         (fun tenv globals -> BuildTables.bindings tenv Lib.primitive_vars globals; globals);
+ *         only_if_any_set
+ *           [IrCheck.typecheck; simplify_types]
+ *           (run simplify_type_structure_bindings);
+ *         only_if_set
+ *           IrCheck.typecheck
+ *           (run prelude_typechecking_pipeline);
+ *       ]
+ * 
+ * end *)
 
-let transform_program perform_optimisations tyenv p =
-  run (Pipelines.main_pipeline perform_optimisations) tyenv p
 
-let transform_prelude tyenv bindings =
-  run Pipelines.prelude_pipeline tyenv bindings
+let program : Context.t -> Types.datatype -> Ir.program -> result
+  = fun context datatype program ->
+  Pipeline.program context datatype program
+
+let transform_program _perform_optimisations _tyenv _p = assert false
+  (* run (Pipelines.main_pipeline perform_optimisations) tyenv p *)
+
+let transform_prelude _tyenv _bindings = assert false
+  (* run Pipelines.prelude_pipeline tyenv bindings *)

--- a/core/backend.mli
+++ b/core/backend.mli
@@ -1,0 +1,6 @@
+type result =
+  { program: Ir.program;
+    datatype: Types.datatype;
+    context: Context.t }
+
+val program : Context.t -> Types.datatype -> Ir.program -> result

--- a/core/buildTables.ml
+++ b/core/buildTables.ml
@@ -256,16 +256,11 @@ struct
     let _ = (new visitor tyenv bound_vars cont_vars)#computation e in ()
 end
 
-let bindings : IrTraversals.Transform.environment -> intset -> Ir.binding list -> unit =
-  fun tyenv bound_vars bs ->
-    FunDefs.bindings Tables.fun_defs bs;
-    ScopesAndContDefs.primitives Tables.scopes;
-    ScopesAndContDefs.bindings tyenv Tables.scopes Tables.cont_defs bs;
-    ClosureTable.bindings tyenv bound_vars Tables.cont_vars bs
-
-let program : intset -> IrTraversals.Transform.environment -> Ir.program -> unit =
-  fun bound_vars tyenv program ->
-    FunDefs.program Tables.fun_defs program;
-    ScopesAndContDefs.primitives Tables.scopes;
-    ScopesAndContDefs.program tyenv Tables.scopes Tables.cont_defs program;
-    ClosureTable.program tyenv bound_vars Tables.cont_vars program
+let program state program =
+  let open IrTransform in
+  let tenv = Context.variable_environment (context state) in
+  let globals = state.primitive_vars in
+  FunDefs.program Tables.fun_defs program;
+  ScopesAndContDefs.primitives Tables.scopes;
+  ScopesAndContDefs.program tenv Tables.scopes Tables.cont_defs program;
+  ClosureTable.program tenv globals Tables.cont_vars program

--- a/core/checkXmlQuasiquotes.ml
+++ b/core/checkXmlQuasiquotes.ml
@@ -96,3 +96,15 @@ object (o)
       super#phrase phrase
     | _ -> assert false
 end
+
+module Untyped = struct
+  open Transform.Untyped
+
+  let program state program =
+    ignore (checker#program program);
+    return state program
+
+  let sentence state sentence =
+    ignore (checker#sentence sentence);
+    return state sentence
+end

--- a/core/checkXmlQuasiquotes.ml
+++ b/core/checkXmlQuasiquotes.ml
@@ -100,6 +100,8 @@ end
 module Untyped = struct
   open Transform.Untyped
 
+  let name = "check_xml_quasi_quotes"
+
   let program state program =
     ignore (checker#program program);
     return state program

--- a/core/closures.ml
+++ b/core/closures.ml
@@ -677,6 +677,8 @@ struct
     e
 end
 
+let name = "closure_conversion"
+
 let program state program =
   let open IrTransform in
   let globals = state.primitive_vars in

--- a/core/closures.ml
+++ b/core/closures.ml
@@ -677,20 +677,11 @@ struct
     e
 end
 
-let program globals tyenv program =
-  (* Debug.print ("Before closure conversion: " ^ Ir.show_program program); *)
-  (* ensure that all top-level bindings are marked as global
-     (desugaring can break this invariant) *)
-  let program = Globalise.program program in
-  let fenv = ClosureVars.program tyenv globals program in
-  (* Debug.print ("fenv: " ^ Closures.show_fenv fenv); *)
-  let program = ClosureConvert.program tyenv fenv program in
-  (* Debug.print ("After closure conversion: " ^ Ir.show_program program); *)
-  program
-
-let bindings tyenv globals bs =
-  (* List.iter (fun b -> Debug.print (Ir.show_binding b)) bs; *)
-  let bs = Globalise.bindings bs in
-  let fenv = ClosureVars.bindings tyenv globals bs in
-  let bs = ClosureConvert.bindings tyenv fenv bs in
-  bs
+let program state program =
+  let open IrTransform in
+  let globals = state.primitive_vars in
+  let tenv = Context.variable_environment (context state) in
+  let program' = Globalise.program program in
+  let fenv = ClosureVars.program tenv globals program' in
+  let program'' = ClosureConvert.program tenv fenv program' in
+  return state program''

--- a/core/context.ml
+++ b/core/context.ml
@@ -1,0 +1,13 @@
+(* Compiler (functional) context/state. *)
+type t =
+  { typing_environment: Types.typing_environment;
+    source_code: SourceCode.source_code }
+
+let empty_code = new SourceCode.source_code
+
+let empty =
+  { typing_environment = Types.empty_typing_environment;
+    source_code = empty_code }
+
+let typing_environment { typing_environment; _ } = typing_environment
+let source_code { source_code; _ } = source_code

--- a/core/context.ml
+++ b/core/context.ml
@@ -1,13 +1,26 @@
 (* Compiler (functional) context/state. *)
+(* TODO localise environment within their associated compilation units. *)
 type t =
-  { typing_environment: Types.typing_environment;
-    source_code: SourceCode.source_code }
+  { typing_environment: Types.typing_environment; (* TODO remove. *)
+    name_environment: Ir.var Env.String.t;        (* TODO remove. *)
+    value_environment: Value.env;
+    variable_environment: Types.datatype Env.Int.t; (* TODO remove. *)
+    source_code: SourceCode.source_code;          (* TODO remove. *)
+    ffi_files: string list }                      (* TODO remove. *)
 
 let empty_code = new SourceCode.source_code
 
 let empty =
   { typing_environment = Types.empty_typing_environment;
-    source_code = empty_code }
+    variable_environment = Env.Int.empty;
+    name_environment = Env.String.empty;
+    value_environment = Value.Env.empty;
+    source_code = empty_code;
+    ffi_files = [] }
 
 let typing_environment { typing_environment; _ } = typing_environment
+let name_environment { name_environment; _ } = name_environment
+let value_environment { value_environment; _ } = value_environment
 let source_code { source_code; _ } = source_code
+let variable_environment { variable_environment; _ } = variable_environment
+let ffi_files { ffi_files; _ } = ffi_files

--- a/core/desugarCP.ml
+++ b/core/desugarCP.ml
@@ -140,12 +140,6 @@ end
 
 let desugar_cp env = ((new desugar_cp env) : desugar_cp :> TransformSugar.transform)
 
-let desugar_program : TransformSugar.program_transformer =
-  fun env program -> snd3 ((desugar_cp env)#program program)
-
-let desugar_sentence : TransformSugar.sentence_transformer =
-  fun env sentence -> snd3 ((desugar_cp env)#sentence sentence)
-
 module Typeable
   = Transform.Typeable.Make(struct
         let obj env = (desugar_cp env : TransformSugar.transform :> Transform.Typeable.sugar_transformer)

--- a/core/desugarCP.ml
+++ b/core/desugarCP.ml
@@ -142,6 +142,7 @@ let desugar_cp env = ((new desugar_cp env) : desugar_cp :> TransformSugar.transf
 
 module Typeable
   = Transform.Typeable.Make(struct
+        let name = "cp"
         let obj env = (desugar_cp env : TransformSugar.transform :> Transform.Typeable.sugar_transformer)
       end)
 

--- a/core/desugarCP.ml
+++ b/core/desugarCP.ml
@@ -144,4 +144,10 @@ let desugar_program : TransformSugar.program_transformer =
   fun env program -> snd3 ((desugar_cp env)#program program)
 
 let desugar_sentence : TransformSugar.sentence_transformer =
-  fun env sentence -> snd ((desugar_cp env)#sentence sentence)
+  fun env sentence -> snd3 ((desugar_cp env)#sentence sentence)
+
+module Typeable
+  = Transform.Typeable.Make(struct
+        let obj env = (desugar_cp env : TransformSugar.transform :> Transform.Typeable.sugar_transformer)
+      end)
+

--- a/core/desugarCP.mli
+++ b/core/desugarCP.mli
@@ -1,4 +1,1 @@
-val desugar_program : TransformSugar.program_transformer
-val desugar_sentence : TransformSugar.sentence_transformer
-
 include Transform.Typeable.S

--- a/core/desugarCP.mli
+++ b/core/desugarCP.mli
@@ -1,2 +1,4 @@
 val desugar_program : TransformSugar.program_transformer
 val desugar_sentence : TransformSugar.sentence_transformer
+
+include Transform.Typeable.S

--- a/core/desugarDatatypes.ml
+++ b/core/desugarDatatypes.ml
@@ -42,6 +42,10 @@
           - When visiting an effect row, we insert presence variables according
             to the previously determined operation map. *)
 
+module Transform' = Transform (* One of the modules below defines a
+                                 module named 'Transform' which
+                                 shadows the compilation unit
+                                 'Transform'. *)
 open CommonTypes
 open Types
 open SourceCode
@@ -1092,3 +1096,17 @@ let read ~aliases s =
   let _, var_env = Desugar.generate_var_mapping (typevars#datatype dt)#tyvar_list in
   let _, ty = Generalise.generalise Env.String.empty (Desugar.datatype var_env aliases dt) in
   ty
+
+module Untyped = struct
+  open Transform'.Untyped
+
+  let program state program' =
+    let tyenv = Context.typing_environment (context state) in
+    let program'' = program tyenv program' in
+    return state program''
+
+  let sentence state sentence' =
+    let tyenv = Context.typing_environment (context state) in
+    let sentence'' = sentence tyenv sentence' in
+    return state sentence''
+end

--- a/core/desugarDatatypes.ml
+++ b/core/desugarDatatypes.ml
@@ -1100,6 +1100,8 @@ let read ~aliases s =
 module Untyped = struct
   open Transform'.Untyped
 
+  let name = "datatypes"
+
   let program state program' =
     let tyenv = Context.typing_environment (context state) in
     let program'' = program tyenv program' in

--- a/core/desugarDatatypes.mli
+++ b/core/desugarDatatypes.mli
@@ -11,3 +11,5 @@ val program :
     Sugartypes.program
 
 val all_datatypes_desugared : SugarTraversals.predicate
+
+include Transform.Untyped.S

--- a/core/desugarFormlets.ml
+++ b/core/desugarFormlets.ml
@@ -187,11 +187,17 @@ end
 
 let desugar_formlets env = ((new desugar_formlets env) : desugar_formlets :> TransformSugar.transform)
 
-let desugar_program : TransformSugar.program_transformer =
-  fun env program -> snd3 ((desugar_formlets env)#program program)
+let has_no_formlets =
+object
+  inherit SugarTraversals.predicate as super
 
-let desugar_sentence : TransformSugar.sentence_transformer =
-  fun env sentence -> snd3 ((desugar_formlets env)#sentence sentence)
+  val has_no_formlets = true
+  method satisfied = has_no_formlets
+
+  method! phrasenode = function
+    | Formlet _ -> {< has_no_formlets = false >}
+    | e -> super#phrasenode e
+end
 
 module Typeable
   = Transform.Typeable.Make(struct

--- a/core/desugarFormlets.ml
+++ b/core/desugarFormlets.ml
@@ -191,16 +191,9 @@ let desugar_program : TransformSugar.program_transformer =
   fun env program -> snd3 ((desugar_formlets env)#program program)
 
 let desugar_sentence : TransformSugar.sentence_transformer =
-  fun env sentence -> snd ((desugar_formlets env)#sentence sentence)
+  fun env sentence -> snd3 ((desugar_formlets env)#sentence sentence)
 
-let has_no_formlets =
-object
-  inherit SugarTraversals.predicate as super
-
-  val has_no_formlets = true
-  method satisfied = has_no_formlets
-
-  method! phrasenode = function
-    | Formlet _ -> {< has_no_formlets = false >}
-    | e -> super#phrasenode e
-end
+module Typeable
+  = Transform.Typeable.Make(struct
+        let obj env = (desugar_formlets env : TransformSugar.transform :> Transform.Typeable.sugar_transformer)
+      end)

--- a/core/desugarFormlets.ml
+++ b/core/desugarFormlets.ml
@@ -201,5 +201,6 @@ end
 
 module Typeable
   = Transform.Typeable.Make(struct
+        let name = "formlets"
         let obj env = (desugar_formlets env : TransformSugar.transform :> Transform.Typeable.sugar_transformer)
       end)

--- a/core/desugarFormlets.mli
+++ b/core/desugarFormlets.mli
@@ -1,4 +1,2 @@
-val desugar_program : TransformSugar.program_transformer
-val desugar_sentence : TransformSugar.sentence_transformer
-
+val has_no_formlets  : SugarTraversals.predicate
 include Transform.Typeable.S

--- a/core/desugarFormlets.mli
+++ b/core/desugarFormlets.mli
@@ -1,5 +1,4 @@
 val desugar_program : TransformSugar.program_transformer
 val desugar_sentence : TransformSugar.sentence_transformer
 
-(* val desugar_formlets : SugarTraversals.map *)
-val has_no_formlets  : SugarTraversals.predicate
+include Transform.Typeable.S

--- a/core/desugarFors.ml
+++ b/core/desugarFors.ml
@@ -192,11 +192,17 @@ end
 let desugar_fors env = ((new desugar_fors env)
                           : desugar_fors :> TransformSugar.transform)
 
-let desugar_program : TransformSugar.program_transformer =
-  fun env program -> snd3 ((desugar_fors env)#program program)
+let has_no_fors =
+object
+  inherit SugarTraversals.predicate as super
 
-let desugar_sentence : TransformSugar.sentence_transformer =
-  fun env sentence -> snd3 ((desugar_fors env)#sentence sentence)
+  val has_no_fors = true
+  method satisfied = has_no_fors
+
+  method! phrasenode = function
+    | Iteration _ -> {< has_no_fors = false >}
+    | e -> super#phrasenode e
+end
 
 module Typeable
   = Transform.Typeable.Make(struct

--- a/core/desugarFors.ml
+++ b/core/desugarFors.ml
@@ -196,16 +196,9 @@ let desugar_program : TransformSugar.program_transformer =
   fun env program -> snd3 ((desugar_fors env)#program program)
 
 let desugar_sentence : TransformSugar.sentence_transformer =
-  fun env sentence -> snd ((desugar_fors env)#sentence sentence)
+  fun env sentence -> snd3 ((desugar_fors env)#sentence sentence)
 
-let has_no_fors =
-object
-  inherit SugarTraversals.predicate as super
-
-  val has_no_fors = true
-  method satisfied = has_no_fors
-
-  method! phrasenode = function
-    | Iteration _ -> {< has_no_fors = false >}
-    | e -> super#phrasenode e
-end
+module Typeable
+  = Transform.Typeable.Make(struct
+        let obj env = (desugar_fors env : TransformSugar.transform :> Transform.Typeable.sugar_transformer)
+      end)

--- a/core/desugarFors.ml
+++ b/core/desugarFors.ml
@@ -206,5 +206,6 @@ end
 
 module Typeable
   = Transform.Typeable.Make(struct
+        let name = "fors"
         let obj env = (desugar_fors env : TransformSugar.transform :> Transform.Typeable.sugar_transformer)
       end)

--- a/core/desugarFors.mli
+++ b/core/desugarFors.mli
@@ -1,3 +1,4 @@
 val desugar_program : TransformSugar.program_transformer
 val desugar_sentence : TransformSugar.sentence_transformer
-val has_no_fors  : SugarTraversals.predicate
+
+include Transform.Typeable.S

--- a/core/desugarFors.mli
+++ b/core/desugarFors.mli
@@ -1,4 +1,2 @@
-val desugar_program : TransformSugar.program_transformer
-val desugar_sentence : TransformSugar.sentence_transformer
-
+val has_no_fors : SugarTraversals.predicate
 include Transform.Typeable.S

--- a/core/desugarFuns.ml
+++ b/core/desugarFuns.ml
@@ -190,5 +190,6 @@ end
 
 module Typeable
   = Transform.Typeable.Make(struct
+        let name = "funs"
         let obj env = (desugar_funs env : TransformSugar.transform :> Transform.Typeable.sugar_transformer)
       end)

--- a/core/desugarFuns.ml
+++ b/core/desugarFuns.ml
@@ -161,11 +161,32 @@ end
 
 let desugar_funs env = ((new desugar_funs env) : desugar_funs :> TransformSugar.transform)
 
-let desugar_program : TransformSugar.program_transformer =
-  fun env program -> snd3 ((desugar_funs env)#program program)
+let has_no_funs =
+object
+  inherit SugarTraversals.predicate as super
 
-let desugar_sentence : TransformSugar.sentence_transformer =
-  fun env sentence -> snd3 ((desugar_funs env)#sentence sentence)
+  val has_no_funs = true
+  method satisfied = has_no_funs
+
+  method! phrasenode = function
+    | FunLit _ -> {< has_no_funs = false >}
+    | e -> super#phrasenode e
+
+  method! bindingnode = function
+    | Fun { fun_definition = (_, ([_], _)); _ } as b -> super#bindingnode b
+    | Fun _ -> {< has_no_funs = false >}
+    | Funs defs as b ->
+        if
+          List.exists
+            (function
+               | {WithPos.node={ rec_definition = (_, ([_], _)); _ }; _ } -> false
+               | _ -> true) defs
+        then
+          {< has_no_funs = false >}
+        else
+          super#bindingnode b
+    | b -> super#bindingnode b
+end
 
 module Typeable
   = Transform.Typeable.Make(struct

--- a/core/desugarFuns.mli
+++ b/core/desugarFuns.mli
@@ -1,4 +1,2 @@
-val desugar_program : TransformSugar.program_transformer
-val desugar_sentence : TransformSugar.sentence_transformer
-
+val has_no_funs : SugarTraversals.predicate
 include Transform.Typeable.S

--- a/core/desugarFuns.mli
+++ b/core/desugarFuns.mli
@@ -1,4 +1,4 @@
 val desugar_program : TransformSugar.program_transformer
 val desugar_sentence : TransformSugar.sentence_transformer
 
-val has_no_funs  : SugarTraversals.predicate
+include Transform.Typeable.S

--- a/core/desugarInners.ml
+++ b/core/desugarInners.ml
@@ -236,5 +236,6 @@ end
 
 module Typeable
   = Transform.Typeable.Make(struct
+        let name = "inners"
         let obj env = (desugar_inners env : TransformSugar.transform :> Transform.Typeable.sugar_transformer)
       end)

--- a/core/desugarInners.mli
+++ b/core/desugarInners.mli
@@ -1,4 +1,4 @@
 val desugar_program : TransformSugar.program_transformer
 val desugar_sentence : TransformSugar.sentence_transformer
 
-val has_no_inners  : SugarTraversals.predicate
+include Transform.Typeable.S

--- a/core/desugarInners.mli
+++ b/core/desugarInners.mli
@@ -1,4 +1,2 @@
-val desugar_program : TransformSugar.program_transformer
-val desugar_sentence : TransformSugar.sentence_transformer
-
+val has_no_inners : SugarTraversals.predicate
 include Transform.Typeable.S

--- a/core/desugarLAttributes.ml
+++ b/core/desugarLAttributes.ml
@@ -184,4 +184,7 @@ object (_self)
     | e -> super#phrase e
 end
 
-module Untyped = Transform.Untyped.Make.Transformer(struct let obj = desugar_lattributes end)
+module Untyped
+  = Transform.Untyped.Make.Transformer(struct
+        let name = "lattributes"
+        let obj = desugar_lattributes end)

--- a/core/desugarLAttributes.ml
+++ b/core/desugarLAttributes.ml
@@ -183,3 +183,5 @@ object (_self)
         {< no_lattributes = false >}
     | e -> super#phrase e
 end
+
+module Untyped = Transform.Untyped.Make.Transformer(struct let obj = desugar_lattributes end)

--- a/core/desugarLAttributes.mli
+++ b/core/desugarLAttributes.mli
@@ -1,2 +1,4 @@
 val desugar_lattributes : SugarTraversals.map
 val has_no_lattributes : SugarTraversals.predicate
+
+include Transform.Untyped.S

--- a/core/desugarModules.ml
+++ b/core/desugarModules.ml
@@ -537,3 +537,15 @@ let desugar_sentence : Sugartypes.sentence -> Sugartypes.sentence
   let visitor = desugar ~toplevel:true !renamer !scope in
   let result = visitor#sentence sentence in
   scope := visitor#get_scope; renamer := visitor#get_renamer; result
+
+module Untyped = struct
+  open Transform.Untyped
+
+  let program state program =
+    let program' = desugar_program program in
+    return state program'
+
+  let sentence state sentence =
+    let sentence' = desugar_sentence sentence in
+    return state sentence'
+end

--- a/core/desugarModules.ml
+++ b/core/desugarModules.ml
@@ -541,6 +541,8 @@ let desugar_sentence : Sugartypes.sentence -> Sugartypes.sentence
 module Untyped = struct
   open Transform.Untyped
 
+  let name = "modules"
+
   let program state program =
     let program' = desugar_program program in
     return state program'

--- a/core/desugarModules.mli
+++ b/core/desugarModules.mli
@@ -1,2 +1,4 @@
 val desugar_program : Sugartypes.program -> Sugartypes.program
 val desugar_sentence : Sugartypes.sentence -> Sugartypes.sentence
+
+include Transform.Untyped.S

--- a/core/desugarPages.ml
+++ b/core/desugarPages.ml
@@ -79,11 +79,17 @@ object
     | e -> super#phrasenode e
 end
 
-let desugar_program : TransformSugar.program_transformer =
-  fun env program -> snd3 ((desugar_pages env)#program program)
+let is_pageless =
+object
+  inherit SugarTraversals.predicate as super
 
-let desugar_sentence : TransformSugar.sentence_transformer =
-  fun env sentence -> snd3 ((desugar_pages env)#sentence sentence)
+  val pageless = true
+  method satisfied = pageless
+
+  method! phrasenode = function
+    | Page _ -> {< pageless = false >}
+    | e -> super#phrasenode e
+end
 
 module Typeable
   = Transform.Typeable.Make(struct

--- a/core/desugarPages.ml
+++ b/core/desugarPages.ml
@@ -93,5 +93,6 @@ end
 
 module Typeable
   = Transform.Typeable.Make(struct
+        let name = "pages"
         let obj env = (desugar_pages env : TransformSugar.transform :> Transform.Typeable.sugar_transformer)
       end)

--- a/core/desugarPages.ml
+++ b/core/desugarPages.ml
@@ -83,16 +83,9 @@ let desugar_program : TransformSugar.program_transformer =
   fun env program -> snd3 ((desugar_pages env)#program program)
 
 let desugar_sentence : TransformSugar.sentence_transformer =
-  fun env sentence -> snd ((desugar_pages env)#sentence sentence)
+  fun env sentence -> snd3 ((desugar_pages env)#sentence sentence)
 
-let is_pageless =
-object
-  inherit SugarTraversals.predicate as super
-
-  val pageless = true
-  method satisfied = pageless
-
-  method! phrasenode = function
-    | Page _ -> {< pageless = false >}
-    | e -> super#phrasenode e
-end
+module Typeable
+  = Transform.Typeable.Make(struct
+        let obj env = (desugar_pages env : TransformSugar.transform :> Transform.Typeable.sugar_transformer)
+      end)

--- a/core/desugarPages.mli
+++ b/core/desugarPages.mli
@@ -1,4 +1,2 @@
-val desugar_program : TransformSugar.program_transformer
-val desugar_sentence : TransformSugar.sentence_transformer
-
+val is_pageless : SugarTraversals.predicate
 include Transform.Typeable.S

--- a/core/desugarPages.mli
+++ b/core/desugarPages.mli
@@ -1,3 +1,4 @@
 val desugar_program : TransformSugar.program_transformer
 val desugar_sentence : TransformSugar.sentence_transformer
-val is_pageless : SugarTraversals.predicate
+
+include Transform.Typeable.S

--- a/core/desugarProcesses.ml
+++ b/core/desugarProcesses.ml
@@ -95,17 +95,9 @@ let desugar_program : TransformSugar.program_transformer =
   fun env program -> snd3 ((desugar_processes env)#program program)
 
 let desugar_sentence : TransformSugar.sentence_transformer =
-  fun env sentence -> snd ((desugar_processes env)#sentence sentence)
+  fun env sentence -> snd3 ((desugar_processes env)#sentence sentence)
 
-let has_no_processes =
-object
-  inherit SugarTraversals.predicate as super
-
-  val has_no_processes = true
-  method satisfied = has_no_processes
-
-  method! phrasenode = function
-    | Spawn _
-    | Receive _ -> {< has_no_processes = false >}
-    | e -> super#phrasenode e
-end
+module Typeable
+  = Transform.Typeable.Make(struct
+        let obj env = (desugar_processes env : TransformSugar.transform :> Transform.Typeable.sugar_transformer)
+      end)

--- a/core/desugarProcesses.ml
+++ b/core/desugarProcesses.ml
@@ -91,11 +91,18 @@ end
 
 let desugar_processes env = ((new desugar_processes env) : desugar_processes :> TransformSugar.transform)
 
-let desugar_program : TransformSugar.program_transformer =
-  fun env program -> snd3 ((desugar_processes env)#program program)
+let has_no_processes =
+object
+  inherit SugarTraversals.predicate as super
 
-let desugar_sentence : TransformSugar.sentence_transformer =
-  fun env sentence -> snd3 ((desugar_processes env)#sentence sentence)
+  val has_no_processes = true
+  method satisfied = has_no_processes
+
+  method! phrasenode = function
+    | Spawn _
+    | Receive _ -> {< has_no_processes = false >}
+    | e -> super#phrasenode e
+end
 
 module Typeable
   = Transform.Typeable.Make(struct

--- a/core/desugarProcesses.ml
+++ b/core/desugarProcesses.ml
@@ -106,5 +106,6 @@ end
 
 module Typeable
   = Transform.Typeable.Make(struct
+        let name = "processes"
         let obj env = (desugar_processes env : TransformSugar.transform :> Transform.Typeable.sugar_transformer)
       end)

--- a/core/desugarProcesses.mli
+++ b/core/desugarProcesses.mli
@@ -1,4 +1,2 @@
-val desugar_program : TransformSugar.program_transformer
-val desugar_sentence : TransformSugar.sentence_transformer
-
+val has_no_processes : SugarTraversals.predicate
 include Transform.Typeable.S

--- a/core/desugarProcesses.mli
+++ b/core/desugarProcesses.mli
@@ -1,4 +1,4 @@
 val desugar_program : TransformSugar.program_transformer
 val desugar_sentence : TransformSugar.sentence_transformer
 
-val has_no_processes  : SugarTraversals.predicate
+include Transform.Typeable.S

--- a/core/desugarRegexes.ml
+++ b/core/desugarRegexes.ml
@@ -101,13 +101,9 @@ let desugar_program : TransformSugar.program_transformer =
   fun env program -> snd3 ((desugar_regexes env)#program program)
 
 let desugar_sentence : TransformSugar.sentence_transformer =
-  fun env sentence -> snd ((desugar_regexes env)#sentence sentence)
+  fun env sentence -> snd3 ((desugar_regexes env)#sentence sentence)
 
-let has_no_regexes =
-object
-  inherit SugarTraversals.predicate
-
-  val no_regexes = true
-  method satisfied = no_regexes
-  method! regex _ = {< no_regexes = false >}
-end
+module Typeable
+  = Transform.Typeable.Make(struct
+        let obj env = (desugar_regexes env : TransformSugar.transform :> Transform.Typeable.sugar_transformer)
+      end)

--- a/core/desugarRegexes.ml
+++ b/core/desugarRegexes.ml
@@ -108,5 +108,6 @@ end
 
 module Typeable
   = Transform.Typeable.Make(struct
+        let name = "regexes"
         let obj env = (desugar_regexes env : TransformSugar.transform :> Transform.Typeable.sugar_transformer)
       end)

--- a/core/desugarRegexes.ml
+++ b/core/desugarRegexes.ml
@@ -97,11 +97,14 @@ object(self)
     | _ -> super#phrase ph
 end
 
-let desugar_program : TransformSugar.program_transformer =
-  fun env program -> snd3 ((desugar_regexes env)#program program)
+let has_no_regexes =
+object
+  inherit SugarTraversals.predicate
 
-let desugar_sentence : TransformSugar.sentence_transformer =
-  fun env sentence -> snd3 ((desugar_regexes env)#sentence sentence)
+  val no_regexes = true
+  method satisfied = no_regexes
+  method! regex _ = {< no_regexes = false >}
+end
 
 module Typeable
   = Transform.Typeable.Make(struct

--- a/core/desugarRegexes.mli
+++ b/core/desugarRegexes.mli
@@ -1,4 +1,2 @@
-val desugar_program : TransformSugar.program_transformer
-val desugar_sentence : TransformSugar.sentence_transformer
-
+val has_no_regexes : SugarTraversals.predicate
 include Transform.Typeable.S

--- a/core/desugarRegexes.mli
+++ b/core/desugarRegexes.mli
@@ -1,3 +1,4 @@
 val desugar_program : TransformSugar.program_transformer
 val desugar_sentence : TransformSugar.sentence_transformer
-val has_no_regexes : SugarTraversals.predicate
+
+include Transform.Typeable.S

--- a/core/desugarSessionExceptions.ml
+++ b/core/desugarSessionExceptions.ml
@@ -209,11 +209,12 @@ let desugar_session_exceptions env =
 
 module Typeable
   = Transform.Typeable.Make(struct
+        let name = "session_exceptions (typeable)"
         let obj env = (desugar_session_exceptions env : TransformSugar.transform :> Transform.Typeable.sugar_transformer)
       end)
 module Untyped = struct
   open Transform.Untyped
-
+  let name = "session_exceptions (untyped)"
   let program state program =
     let program' = wrap_linear_handlers#program program in
     return state program'

--- a/core/desugarSessionExceptions.ml
+++ b/core/desugarSessionExceptions.ml
@@ -21,6 +21,16 @@ module TyEnv = Env.String
 
 let failure_op_name = Value.session_exception_operation
 
+let extension_guard pos =
+  let exceptions_enabled =
+    Basicsettings.Sessions.exceptions_enabled
+  in
+  let get_setting_name () =
+    Settings.get_name exceptions_enabled
+  in
+  Settings.get Basicsettings.Sessions.exceptions_enabled
+  || raise (Errors.disabled_extension ~pos ~setting:(get_setting_name (), true) "Session exceptions")
+
 class insert_toplevel_handlers env =
 object (o: 'self_type)
   inherit (TransformSugar.transform env) as super
@@ -69,7 +79,7 @@ object (o : 'self_type)
   inherit (TransformSugar.transform env) as super
 
   method! phrase = function
-    | { node = Raise; pos } ->
+    | { node = Raise; pos } when extension_guard pos ->
         (* Compile `raise` as the following:
          * switch (do SessionFail) { }
          *
@@ -80,7 +90,8 @@ object (o : 'self_type)
         let with_pos x = SourceCode.WithPos.make ~pos x in
         (o, with_pos (Switch (with_pos doOp, [], Some ty)), ty)
     | { node = TryInOtherwise (_, _, _, _, None); _} -> assert false
-    | { node = TryInOtherwise (try_phr, pat, as_phr, otherwise_phr, (Some dt)); pos } ->
+    | { node = TryInOtherwise (try_phr, pat, as_phr, otherwise_phr, (Some dt)); pos }
+      when extension_guard pos ->
         let (o, try_phr, try_dt) = o#phrase try_phr in
         let envs = o#backup_envs in
         let (o, pat) = o#pattern pat in
@@ -138,21 +149,6 @@ object (o : 'self_type)
 end
 
 
-let contains_session_exceptions prog =
-  let o =
-    object
-      inherit SugarTraversals.predicate as super
-      val has_exceptions = false
-      method satisfied = has_exceptions
-
-      method! phrasenode = function
-        | TryInOtherwise _
-        | Raise -> {< has_exceptions = true >}
-        | p -> super#phrasenode p
-    end in
-  (o#program prog)#satisfied
-
-
 (*
  * The "naive" typing rule for try-in-otherwise is unsound
  * as it allows possibly-linear variables to be used twice:
@@ -203,15 +199,6 @@ let wrap_linear_handlers =
       | p -> super#phrase p
   end
 
-let settings_check prog =
-  if not (contains_session_exceptions prog) then ()
-  else if not (Settings.get Basicsettings.Sessions.exceptions_enabled)
-  then raise (
-           Errors.settings_error
-             ("File contains session exceptions but session_exceptions not enabled. " ^
-                "Please set 'session_exceptions' configuration flag to true."))
-  else ()
-
 let insert_toplevel_handlers env =
   ((new insert_toplevel_handlers env) :
     insert_toplevel_handlers :> TransformSugar.transform)
@@ -223,7 +210,18 @@ let desugar_session_exceptions env =
 let desugar_program : TransformSugar.program_transformer =
   fun env program -> snd3 ((desugar_session_exceptions env)#program program)
 
+module Typeable
+  = Transform.Typeable.Make(struct
+        let obj env = (desugar_session_exceptions env : TransformSugar.transform :> Transform.Typeable.sugar_transformer)
+      end)
+module Untyped = struct
+  open Transform.Untyped
 
-let show prog =
-  Printf.printf "%s\n\n" (Sugartypes.show_program prog);
-  prog
+  let program state program =
+    let program' = wrap_linear_handlers#program program in
+    return state program'
+
+  let sentence state sentence =
+    let sentence' = wrap_linear_handlers#sentence sentence in
+    return state sentence'
+end

--- a/core/desugarSessionExceptions.ml
+++ b/core/desugarSessionExceptions.ml
@@ -199,16 +199,13 @@ let wrap_linear_handlers =
       | p -> super#phrase p
   end
 
-let insert_toplevel_handlers env =
+let _insert_toplevel_handlers env =
   ((new insert_toplevel_handlers env) :
     insert_toplevel_handlers :> TransformSugar.transform)
 
 let desugar_session_exceptions env =
   ((new desugar_session_exceptions env) :
     desugar_session_exceptions :> TransformSugar.transform)
-
-let desugar_program : TransformSugar.program_transformer =
-  fun env program -> snd3 ((desugar_session_exceptions env)#program program)
 
 module Typeable
   = Transform.Typeable.Make(struct

--- a/core/desugarSessionExceptions.mli
+++ b/core/desugarSessionExceptions.mli
@@ -2,5 +2,6 @@ val insert_toplevel_handlers : Types.typing_environment -> TransformSugar.transf
 val desugar_session_exceptions : Types.typing_environment -> TransformSugar.transform
 val wrap_linear_handlers : SugarTraversals.map
 val desugar_program : TransformSugar.program_transformer
-val show : Sugartypes.program -> Sugartypes.program
-val settings_check : Sugartypes.program -> unit
+
+include Transform.Typeable.S
+include Transform.Untyped.S

--- a/core/desugarSessionExceptions.mli
+++ b/core/desugarSessionExceptions.mli
@@ -1,7 +1,2 @@
-val insert_toplevel_handlers : Types.typing_environment -> TransformSugar.transform
-val desugar_session_exceptions : Types.typing_environment -> TransformSugar.transform
-val wrap_linear_handlers : SugarTraversals.map
-val desugar_program : TransformSugar.program_transformer
-
 include Transform.Typeable.S
 include Transform.Untyped.S

--- a/core/env.ml
+++ b/core/env.ml
@@ -21,6 +21,8 @@ sig
   val fold : (name -> 'a -> 'b -> 'b) -> 'a t -> 'b -> 'b
   val filter : (name -> 'a -> bool) -> 'a t -> 'a t
   val filter_map : (name -> 'a -> 'b option) -> 'a t -> 'b t
+
+  val complement : 'a t -> 'a t -> 'a t
 end
 
 module Make (Ord : Utility.OrderedShow) :
@@ -50,6 +52,13 @@ struct
   let show = M.show
   let filter = M.filter
   let filter_map = M.filter_map
+  let complement env env' =
+    fold
+      (fun key value env'' ->
+        if has env key
+        then env''
+        else bind env'' (key, value))
+    env' empty
 end
 
 module String

--- a/core/env.mli
+++ b/core/env.mli
@@ -53,6 +53,8 @@ sig
   val filter : (name -> 'a -> bool) -> 'a t -> 'a t
 
   val filter_map : (name -> 'a -> 'b option) -> 'a t -> 'b t
+
+  val complement : 'a t -> 'a t -> 'a t
 end
 (** Output signature of the functor {!Env.Make}. *)
 

--- a/core/frontend.ml
+++ b/core/frontend.ml
@@ -222,6 +222,7 @@ module Typeability_preserving = struct
            ignore (TypeSugar.Check.program
                      { tyenv with Types.desugared = true }
                      payload.program)
+                  (* TODO(dhil): Verify post-transformation invariants. *)
          with exn ->
            let stacktrace = Printexc.get_raw_backtrace () in
            trace_type_error name Sugartypes.pp_program program payload.program stacktrace exn);
@@ -259,6 +260,7 @@ module Typeability_preserving = struct
            ignore (TypeSugar.Check.sentence
                      { tyenv with Types.desugared = true }
                      payload.program)
+                  (* TODO(dhil): Verify post-transformation invariants. *)
          with exn ->
            let stacktrace = Printexc.get_raw_backtrace () in
            trace_type_error name Sugartypes.pp_sentence program payload.program stacktrace exn);

--- a/core/frontend.ml
+++ b/core/frontend.ml
@@ -1,5 +1,13 @@
 open Utility
 
+let _show s program =
+  Debug.print (s ^ ": " ^ Sugartypes.show_program program);
+  program
+
+let _show_sentence s sentence =
+  Debug.print (s ^ ": " ^ Sugartypes.show_sentence sentence);
+  sentence
+
 (* Shall we re-run the frontend type-checker after each TransformSugar transformation? *)
 let check_frontend_transformations =
   Settings.(flag "recheck_frontend_transformations"
@@ -40,8 +48,8 @@ let verify_transformation transformer =
     | Some filter -> String.split_on_char '\n' filter |> List.mem transformer
 
 
-let trace_type_check_error name print before after stacktrace exn =
-  Debug.f "Error during desugaring pass '%s'\n%!" name;
+let trace_type_error transform_name print program program' stacktrace exn =
+  Debug.f "error: transformation pass '%s' produced an ill-typed program.\n%!" transform_name;
   let print x =
     let buffer = Buffer.create 1024 in
     let formatter = Format.formatter_of_buffer buffer in
@@ -51,292 +59,246 @@ let trace_type_check_error name print before after stacktrace exn =
     Buffer.contents buffer
   in
   Debug.if_set check_frontend_transformations_dump
-    (fun () -> Printf.sprintf "Before %s:\n%s\n\n" name (print before));
-  Debug.if_set check_frontend_transformations_dump
-    (fun () -> Printf.sprintf "After %s:\n%s\n\n" name (print after));
+    (fun () ->
+      Printf.sprintf "Program before transformation:\n%s\n\nProgram after transformation:\n%s\n\n"
+        (print program) (print program'));
   Printexc.raise_with_backtrace exn stacktrace
 
 
-(* Alternative pipeline *)
+(* Pipeline infrastructure. *)
 type 'a result =
   { program: 'a;
     datatype: Types.datatype;
     context: Context.t }
 
-module Pipeline': sig
-  val program : Context.t ->
-                Sugartypes.program ->
-                Sugartypes.program result
+open Transform
 
-  val interactive : Context.t ->
-                    Sugartypes.sentence ->
-                    Sugartypes.sentence result
-end = struct
-  let _show s program =
-    Debug.print (s ^ ": " ^ Sugartypes.show_program program);
-    program
+(* The [Untyped] module contains the infrastructure for untyped
+   transform passes. *)
+module Untyped = struct
+  type transformer = (module Untyped.S)
 
-  let _show_sentence s sentence =
-    Debug.print (s ^ ": " ^ Sugartypes.show_sentence sentence);
-    sentence
+  (* This functor constructs a conditional transformer from a given
+     transformer and a (side-effecting) condition. *)
+  module Conditional(T : sig
+               include Untyped.S
+               val condition : unit -> bool
+             end) = struct
 
-  open Transform
+    module Untyped = struct
+      let program state program =
+        if T.condition ()
+        then T.Untyped.program state program
+        else Identity.Untyped.program state program
 
-  module Untyped = struct
-    type transformer = (module Untyped.S)
-
-    (* This functor constructs a conditional transformer from a given
-       transformer and a (side-effecting) condition. *)
-    module Conditional(T : sig
-                 include Untyped.S
-                 val condition : unit -> bool
-               end) = struct
-
-      module Untyped = struct
-        let program state program =
-          if T.condition ()
-          then T.Untyped.program state program
-          else Identity.Untyped.program state program
-
-        let sentence state sentence =
-          if T.condition ()
-          then T.Untyped.sentence state sentence
-          else Identity.Untyped.sentence state sentence
-      end
+      let sentence state sentence =
+        if T.condition ()
+        then T.Untyped.sentence state sentence
+        else Identity.Untyped.sentence state sentence
     end
-
-    let only_if : bool Settings.setting -> (module Untyped.S) -> transformer
-      = fun setting (module T) ->
-      (module Conditional(struct include T let condition () = Settings.get setting end))
-
-    (* Collection of transformers. *)
-    let transformers : transformer array
-      = [| (module ResolvePositions)
-         ; (module CheckXmlQuasiquotes)
-         ; (module DesugarModules)
-         ; only_if Basicsettings.Sessions.exceptions_enabled (module DesugarSessionExceptions)
-         ; (module DesugarLAttributes)
-         ; (module LiftRecursive)
-         ; (module DesugarDatatypes)
-         |]
-
-    let run : Context.t -> ((module Untyped.S) -> Context.t -> 'a -> 'a Transform.Untyped.result) -> 'a -> 'a result
-      = fun context' select program ->
-      let module TU = Transform.Untyped in
-      let apply : 'a TU.result -> transformer -> 'a TU.result
-        = fun (TU.Result { program; state }) (module T) ->
-        select (module T) state program
-      in
-      let (TU.Result { state; program }) =
-        Array.fold_left apply TU.(return context' program) transformers
-      in
-      { context = state; program;
-        datatype = `Not_typed (* Slight abuse! *) }
-
-    let run_sentence : Context.t ->
-                       Sugartypes.sentence ->
-                       Sugartypes.sentence result
-      = fun context sentence ->
-      run context (fun (module T) -> T.Untyped.sentence) sentence
-
-    let run_program : Context.t ->
-                      Sugartypes.program ->
-                      Sugartypes.program result
-      = fun context program ->
-      run context (fun (module T) -> T.Untyped.program) program
   end
 
-  module Typeability_preserving = struct
-    type transformer = (module Typeable.S)
+  let only_if : bool Settings.setting -> (module Untyped.S) -> transformer
+    = fun setting (module T) ->
+    (module Conditional(struct include T let condition () = Settings.get setting end))
 
-    (* This functor constructs a conditional transformer from a given
-       transformer and a (side-effecting) condition. *)
-    module Conditional(T : sig
-                 include Typeable.S
-                 val condition : unit -> bool
-               end) = struct
+  module Collect_FFI_Files : Untyped.S = struct
+    open Untyped
+    module Untyped = struct
+      let program state program =
+        let ffi_files' = ModuleUtils.get_ffi_files program in
+        let context'  = context state in
+        let context'' = Context.({ context' with ffi_files = ffi_files' }) in
+        return context'' program
 
-      module Typeable = struct
-        let program state program =
-          if T.condition ()
-          then T.Typeable.program state program
-          else Identity.Typeable.program state program
-
-        let sentence state sentence =
-          if T.condition ()
-          then T.Typeable.sentence state sentence
-          else Identity.Typeable.sentence state sentence
-      end
+      let sentence state sentence =
+        return state sentence (* TODO FIXME bug. A sentence can contain an alien declaration. *)
     end
-
-    let only_if : bool Settings.setting -> (module Typeable.S) -> transformer
-      = fun setting (module T) ->
-      (module Conditional(struct include T let condition () = Settings.get setting end))
-
-    (* let only_interactive : (module Typeable.S) -> transformer
-     *   = fun (module T) -> only_if Basicsettings.interactive_mode (module T) *)
-
-    (* Collection of transformers. *)
-    let transformers : (string * transformer) array
-      = [| "cp", (module DesugarCP)
-         ; "inners", (module DesugarInners)
-         ; "session_execeptions", only_if
-                                    Basicsettings.Sessions.exceptions_enabled
-                                    (module DesugarSessionExceptions)
-         ; "processes", (module DesugarProcesses)
-         ; "fors", (module DesugarFors)
-         ; "regexes", (module DesugarRegexes)
-         ; "formlets", (module DesugarFormlets)
-         ; "pages", (module DesugarPages)
-         ; "funs", (module DesugarFuns) |]
-
-    (* Run program transformers. *)
-    let run_program : Context.t ->
-                      Types.datatype ->
-                      Sugartypes.program ->
-                      Sugartypes.program result
-      = fun context' datatype program ->
-      let apply : Sugartypes.program Transform.Typeable.result -> (string * transformer) -> Sugartypes.program Transform.Typeable.result
-        = fun (Transform.Typeable.Result { state; program }) (name, (module T)) ->
-        let (Transform.Typeable.Result payload) as result =
-          T.Typeable.program state program
-        in
-        (if verify_transformation name then
-           let tyenv =
-             Context.typing_environment payload.state.Transform.Typeable.context
-           in
-           try
-             ignore (TypeSugar.Check.program
-                       { tyenv with Types.desugared = true }
-                       payload.program)
-           with _exn -> failwith "TODO");
-        result
-      in
-      let (Transform.Typeable.Result { state; program }) =
-        let initial_state = Transform.Typeable.{ datatype; context = context' } in
-        Array.fold_left apply Transform.Typeable.(return initial_state program) transformers
-      in
-      { datatype = state.Transform.Typeable.datatype;
-        context  = state.Transform.Typeable.context;
-        program }
-
-    (* Run sentence transformers. *)
-    let run_sentence : Context.t ->
-                       Types.datatype ->
-                       Sugartypes.sentence ->
-                       Sugartypes.sentence result
-      = fun context' datatype program ->
-      let apply : Sugartypes.sentence Transform.Typeable.result -> (string * transformer) -> Sugartypes.sentence Transform.Typeable.result
-        = fun (Transform.Typeable.Result { state; program }) (name, (module T)) ->
-        let (Transform.Typeable.Result payload) as result =
-          T.Typeable.sentence state program
-        in
-        (if verify_transformation name then
-           let tyenv =
-             Context.typing_environment payload.state.Transform.Typeable.context
-           in
-           try
-             ignore (TypeSugar.Check.sentence
-                       { tyenv with Types.desugared = true }
-                       payload.program)
-           with _exn -> failwith "TODO");
-        result
-      in
-      let (Transform.Typeable.Result { state; program }) =
-        let initial_state = Transform.Typeable.{ datatype; context = context' } in
-        Array.fold_left apply Transform.Typeable.(return initial_state program) transformers
-      in
-      { datatype = state.Transform.Typeable.datatype;
-        context  = state.Transform.Typeable.context;
-        program }
   end
 
-  let program context program =
-    (* Untyped transformations. *)
-    let { program; context; _ } =
-      Untyped.run_program context program
-    in
-    (* Typechecking. *)
-    let (program, datatype, tyenv) =
-      TypeSugar.Check.program Context.(typing_environment context) program
-    in
-    (* Typeability preserving transformations. *)
-    let result =
-      let open Typeability_preserving in
-      let result = run_program context datatype program in
-      { result with context = Context.{ context with typing_environment = tyenv } }
-    in
-    result
+  (* Collection of transformers. *)
+  let transformers : transformer array
+    = [| (module ResolvePositions)
+       ; (module CheckXmlQuasiquotes)
+       ; (module DesugarModules)
+       ; (module Collect_FFI_Files)
+       ; only_if Basicsettings.Sessions.exceptions_enabled (module DesugarSessionExceptions)
+       ; (module DesugarLAttributes)
+       ; (module LiftRecursive)
+       ; (module DesugarDatatypes)
+      |]
 
-  let interactive context program =
-    (* Untyped transformations. *)
-    let { program; context; _ } =
-      Untyped.run_sentence context program
+  let run : Context.t -> ((module Untyped.S) -> Context.t -> 'a -> 'a Transform.Untyped.result) -> 'a -> 'a result
+    = fun context' select program ->
+    let module TU = Transform.Untyped in
+    let apply : 'a TU.result -> transformer -> 'a TU.result
+      = fun (TU.Result { program; state }) (module T) ->
+      select (module T) state program
     in
-    (* Typechecking. *)
-    let (program, datatype, tyenv) =
-      TypeSugar.Check.sentence Context.(typing_environment context) program
+    let (TU.Result { state; program }) =
+      Array.fold_left apply TU.(return context' program) transformers
     in
-    (* Typeability preserving transformations. *)
-    let result =
-      let open Typeability_preserving in
-      let result = run_sentence context datatype program in
-      { result with context = Context.{ context with typing_environment = tyenv } }
-    in
-    result
+    { context = state; program;
+      datatype = `Not_typed (* Slight abuse! *) }
+
+  let run_sentence : Context.t ->
+                     Sugartypes.sentence ->
+                     Sugartypes.sentence result
+    = fun context sentence ->
+    run context (fun (module T) -> T.Untyped.sentence) sentence
+
+  let run_program : Context.t ->
+                    Sugartypes.program ->
+                    Sugartypes.program result
+    = fun context program ->
+    run context (fun (module T) -> T.Untyped.program) program
 end
 
-(* TODO: Replace this 'Pipeline' by 'Pipeline''. *)
-module Pipeline :
-sig
-  val program :
-    Types.typing_environment ->
-    SourceCode.source_code ->
-    Sugartypes.program ->
-    ((Sugartypes.program * Types.datatype * Types.typing_environment) * string list)
-  val interactive :
-    Types.typing_environment ->
-    SourceCode.source_code ->
-    Sugartypes.sentence ->
-    Sugartypes.sentence * Types.datatype * Types.typing_environment
-end
-=
-struct
-  [@ocaml.warning "-23"]
-  let program prev_tyenv pos_context program =
-    if Settings.get show_pre_frontend_ast then
-      Debug.print ("Pre-Frontend AST:\n" ^ Sugartypes.show_program program);
+(* The [Typeability_preserving] module runs transformation passes
+   which _must_ preserve typeability, i.e. the preimage and image of
+   the transform must be typeable. *)
+module Typeability_preserving = struct
+  type transformer = (module Typeable.S)
 
-    let { program; datatype; context }  =
-      Pipeline'.program Context.({ empty with
-                                   typing_environment = prev_tyenv;
-                                   source_code = pos_context})
-        program
+  (* This functor constructs a conditional transformer from a given
+       transformer and a (side-effecting) condition. *)
+  module Conditional(T : sig
+               include Typeable.S
+               val condition : unit -> bool
+             end) = struct
+
+    module Typeable = struct
+      let program state program =
+        if T.condition ()
+        then T.Typeable.program state program
+        else Identity.Typeable.program state program
+
+      let sentence state sentence =
+        if T.condition ()
+        then T.Typeable.sentence state sentence
+        else Identity.Typeable.sentence state sentence
+    end
+  end
+
+  let only_if : bool Settings.setting -> (module Typeable.S) -> transformer
+    = fun setting (module T) ->
+    (module Conditional(struct include T let condition () = Settings.get setting end))
+
+  (* Collection of transformers. *)
+  let transformers : (string * transformer) array
+    = [| "cp", (module DesugarCP)
+       ; "inners", (module DesugarInners)
+       ; "session_execeptions", only_if
+                                  Basicsettings.Sessions.exceptions_enabled
+                                  (module DesugarSessionExceptions)
+       ; "processes", (module DesugarProcesses)
+       ; "fors", (module DesugarFors)
+       ; "regexes", (module DesugarRegexes)
+       ; "formlets", (module DesugarFormlets)
+       ; "pages", (module DesugarPages)
+       ; "funs", (module DesugarFuns) |]
+
+  (* Run program transformers. *)
+  let run_program : Context.t ->
+                    Types.datatype ->
+                    Sugartypes.program ->
+                    Sugartypes.program result
+    = fun context' datatype program ->
+    let apply : Sugartypes.program Transform.Typeable.result -> (string * transformer) -> Sugartypes.program Transform.Typeable.result
+      = fun (Transform.Typeable.Result { state; program }) (name, (module T)) ->
+      let (Transform.Typeable.Result payload) as result =
+        T.Typeable.program state program
+      in
+      (if verify_transformation name then
+         let tyenv =
+           Context.typing_environment payload.state.Transform.Typeable.context
+         in
+         (* TODO(dhil): Ultimately we may want to move from
+            typeability preserving transformations to type-preserving
+            transformations in which case the type checker should
+            check *against* the datatype in transformation state
+            [payload]. *)
+         try
+           ignore (TypeSugar.Check.program
+                     { tyenv with Types.desugared = true }
+                     payload.program)
+         with exn ->
+           let stacktrace = Printexc.get_raw_backtrace () in
+           trace_type_error name Sugartypes.pp_program program payload.program stacktrace exn);
+      result
     in
-
-    let ffi_files = ModuleUtils.get_ffi_files program in (* TODO associate FFI dependencies with their compilation units. *)
-
-    if Settings.get show_post_frontend_ast then
-      Debug.print ("Post-Frontend AST:\n" ^ Sugartypes.show_program program);
-
-    (program, datatype, (* typing_environment *) Context.(typing_environment context)), ffi_files
-
-
-  let interactive prev_tyenv pos_context sentence =
-    if Settings.get show_pre_frontend_ast then
-      Debug.print ("Pre-Frontend AST:\n" ^ Sugartypes.show_sentence sentence);
-
-    let { program = sentence; datatype; context } =
-      Pipeline'.interactive Context.({ empty with
-                                       typing_environment = prev_tyenv;
-                                       source_code = pos_context })
-        sentence
+    let (Transform.Typeable.Result { state; program }) =
+      let initial_state = Transform.Typeable.{ datatype; context = context' } in
+      Array.fold_left apply Transform.Typeable.(return initial_state program) transformers
     in
+    { datatype = state.Transform.Typeable.datatype;
+      context  = state.Transform.Typeable.context;
+      program }
 
-    if Settings.get show_post_frontend_ast then
-      Debug.print ("Post-Frontend AST:\n" ^ Sugartypes.show_sentence sentence);
-
-    (sentence, datatype, Context.(typing_environment context))
-
-
+  (* Run sentence transformers. *)
+  let run_sentence : Context.t ->
+                     Types.datatype ->
+                     Sugartypes.sentence ->
+                     Sugartypes.sentence result
+    = fun context' datatype program ->
+    let apply : Sugartypes.sentence Transform.Typeable.result -> (string * transformer) -> Sugartypes.sentence Transform.Typeable.result
+      = fun (Transform.Typeable.Result { state; program }) (name, (module T)) ->
+      let (Transform.Typeable.Result payload) as result =
+        T.Typeable.sentence state program
+      in
+      (if verify_transformation name then
+         let tyenv =
+           Context.typing_environment payload.state.Transform.Typeable.context
+         in
+         (* TODO(dhil): Ultimately we may want to move from
+            typeability preserving transformations to type-preserving
+            transformations in which case the type checker should
+            check *against* the datatype in transformation state
+            [payload]. *)
+         try
+           ignore (TypeSugar.Check.sentence
+                     { tyenv with Types.desugared = true }
+                     payload.program)
+         with exn ->
+           let stacktrace = Printexc.get_raw_backtrace () in
+           trace_type_error name Sugartypes.pp_sentence program payload.program stacktrace exn);
+      result
+    in
+    let (Transform.Typeable.Result { state; program }) =
+      let initial_state = Transform.Typeable.{ datatype; context = context' } in
+      Array.fold_left apply Transform.Typeable.(return initial_state program) transformers
+    in
+    { datatype = state.Transform.Typeable.datatype;
+      context  = state.Transform.Typeable.context;
+      program }
 end
+
+(* Parametric transformation runner. *)
+let transform show untyped_run typeable_run typechecker_run context program =
+  (* Dump the undecorated AST. *)
+  Debug.if_set show_pre_frontend_ast
+    (fun () -> Printf.sprintf "AST before frontend transformations:\n%s\n\n" (show program));
+  (* Untyped transformations. *)
+  let { program; context; _ } =
+    untyped_run context program
+  in
+  (* Typechecking. *)
+  let (program, datatype, tenv) =
+    typechecker_run Context.(typing_environment context) program
+  in
+  (* Typeability preserving transformations. *)
+  let result =
+    let result = typeable_run context datatype program in
+    let tenv' = Context.(typing_environment result.context) in
+    { result with context = Context.{ context with typing_environment = Types.extend_typing_environment tenv' tenv } }
+  in
+  (* Dump the decorated AST. *)
+  Debug.if_set show_post_frontend_ast
+    (fun () -> Printf.sprintf "AST after frontend transformations:\n%s\n\n" (show program));
+  result
+
+let program =
+  transform Sugartypes.show_program Untyped.run_program Typeability_preserving.run_program TypeSugar.Check.program
+
+let interactive =
+  transform Sugartypes.show_sentence Untyped.run_sentence Typeability_preserving.run_sentence TypeSugar.Check.sentence

--- a/core/frontend.mli
+++ b/core/frontend.mli
@@ -1,0 +1,7 @@
+type 'a result =
+  { program: 'a;
+    datatype: Types.datatype;
+    context: Context.t }
+
+val program : Context.t -> Sugartypes.program -> Sugartypes.program result
+val interactive : Context.t -> Sugartypes.sentence -> Sugartypes.sentence result

--- a/core/ir.ml
+++ b/core/ir.ml
@@ -135,6 +135,9 @@ let rec is_atom =
 
 let with_bindings bs' (bs, tc) = (bs' @ bs, tc)
 
+let unit = Extend (Utility.StringMap.empty, None)
+let unit_comp = ([], Return unit)
+
 type program = computation
   [@@deriving show]
 

--- a/core/ir.mli
+++ b/core/ir.mli
@@ -108,6 +108,9 @@ val letm : ?tyvars:tyvar list -> binder * tail_computation -> binding
 val letmv : binder * value -> binding
 (*val letv : tybinder * value -> binding*)
 
+val unit : value
+val unit_comp : computation
+
 type program = computation
   [@@deriving show]
 

--- a/core/irCheck.ml
+++ b/core/irCheck.ml
@@ -1291,10 +1291,19 @@ struct
     method! get_type_environment : environment = tyenv
   end
 
-  let program tyenv p =
-    let lazy_check =
-      lazy (let p, _, _ = (checker tyenv)#computation p in p) in
-   handle_ir_type_error lazy_check p (SProg p)
+  (* let program tyenv p =
+   *   let lazy_check =
+   *     lazy (let p, _, _ = (checker tyenv)#computation p in p) in
+   *  handle_ir_type_error lazy_check p (SProg p) *)
+
+  let program state program =
+    let open IrTransform in
+    let tenv = Context.variable_environment (context state) in
+    let check =
+      lazy (let program', _, _ = (checker tenv)#program program in program')
+    in
+    let program'' = handle_ir_type_error check program (SProg program) in
+    return state program''
 
   let bindings tyenv b =
     let lazy_check =

--- a/core/irCheck.ml
+++ b/core/irCheck.ml
@@ -27,7 +27,6 @@ type ir_snippet =
   | SVal   of value
   | SSpec  of special
   | SBind  of binding
-  | SBinds of binding list
   | SProg  of program
   | SNone
 
@@ -49,10 +48,6 @@ let string_of_occurrence : ir_snippet -> string =
     "occurring in IR binding:" ^
     nl ^
     Ir.string_of_binding b
-  | SBinds bs ->
-    "occurring in IR binding list:" ^
-    nl ^
-    String.concat nl (List.map Ir.string_of_binding bs)
   | SProg p ->
     "occurring in IR program:" ^
     nl ^
@@ -1291,10 +1286,7 @@ struct
     method! get_type_environment : environment = tyenv
   end
 
-  (* let program tyenv p =
-   *   let lazy_check =
-   *     lazy (let p, _, _ = (checker tyenv)#computation p in p) in
-   *  handle_ir_type_error lazy_check p (SProg p) *)
+  let name = "ir_typechecker"
 
   let program state program =
     let open IrTransform in
@@ -1304,9 +1296,4 @@ struct
     in
     let program'' = handle_ir_type_error check program (SProg program) in
     return state program''
-
-  let bindings tyenv b =
-    let lazy_check =
-      lazy (let b, _ = (checker tyenv)#bindings b in b) in
-    handle_ir_type_error lazy_check b (SBinds b)
 end

--- a/core/irCheck.mli
+++ b/core/irCheck.mli
@@ -3,6 +3,7 @@ open Ir
 val typecheck : bool Settings.setting
 
 module Typecheck : sig
-   val program : Types.datatype Env.Int.t -> program -> program
+  (* val program : Types.datatype Env.Int.t -> program -> program *)
+  val program : IrTransform.state -> program -> IrTransform.result
    val bindings : Types.datatype Env.Int.t -> binding list  -> binding list
 end

--- a/core/irCheck.mli
+++ b/core/irCheck.mli
@@ -1,9 +1,2 @@
-open Ir
-
 val typecheck : bool Settings.setting
-
-module Typecheck : sig
-  (* val program : Types.datatype Env.Int.t -> program -> program *)
-  val program : IrTransform.state -> program -> IrTransform.result
-   val bindings : Types.datatype Env.Int.t -> binding list  -> binding list
-end
+module Typecheck : IrTransform.S

--- a/core/irTransform.ml
+++ b/core/irTransform.ml
@@ -1,0 +1,34 @@
+(* IR transformations are typeability preserving. *)
+
+type state = { context: Context.t;
+               primitive_vars: Utility.IntSet.t;
+               datatype: Types.datatype }
+
+type result = Result of { state: state;
+                          program: Ir.program }
+
+let context : state -> Context.t
+  = fun { context; _ } -> context
+
+let return : state -> Ir.program -> result
+  = fun state program -> Result { state; program }
+
+let with_type : Types.datatype -> state -> state
+  = fun datatype state -> { state with datatype }
+
+module type S = sig
+  val program : state -> Ir.program -> result
+end
+
+class virtual ir_transformer =
+        object (_ : 'self)
+          method virtual program : Ir.program -> Ir.program * Types.datatype * 'self
+        end
+
+module Make(T : sig val obj : Types.typing_environment -> ir_transformer end) = struct
+  let program : state -> Ir.program -> result
+    = fun state program ->
+    let tyenv = Context.typing_environment state.context in
+    let (program', datatype, _) = (T.obj tyenv)#program program in
+    return (with_type datatype state) program'
+end

--- a/core/irTransform.ml
+++ b/core/irTransform.ml
@@ -17,6 +17,7 @@ let with_type : Types.datatype -> state -> state
   = fun datatype state -> { state with datatype }
 
 module type S = sig
+  val name : string
   val program : state -> Ir.program -> result
 end
 
@@ -25,7 +26,10 @@ class virtual ir_transformer =
           method virtual program : Ir.program -> Ir.program * Types.datatype * 'self
         end
 
-module Make(T : sig val obj : Types.typing_environment -> ir_transformer end) = struct
+module Make(T : sig
+             val name : string
+             val obj : Types.typing_environment -> ir_transformer end) = struct
+  let name = T.name
   let program : state -> Ir.program -> result
     = fun state program ->
     let tyenv = Context.typing_environment state.context in

--- a/core/irTransform.mli
+++ b/core/irTransform.mli
@@ -1,0 +1,24 @@
+type state = { context: Context.t;
+               primitive_vars: Utility.IntSet.t;
+               datatype: Types.datatype }
+
+type result = Result of { state: state;
+                          program: Ir.program }
+
+val context : state -> Context.t
+val return : state -> Ir.program -> result
+val with_type : Types.datatype -> state -> state
+
+module type S = sig
+  val name : string
+  val program : state -> Ir.program -> result
+end
+
+class virtual ir_transformer:
+        object('self)
+          method virtual program : Ir.program -> Ir.program * Types.datatype * 'self
+        end
+
+module Make(T : sig
+             val name : string
+             val obj : Types.typing_environment -> ir_transformer end) : S

--- a/core/irTraversals.ml
+++ b/core/irTraversals.ml
@@ -60,11 +60,6 @@ module type IR_VISITOR = sig
   end
 end
 
-module type PROGRAM_TRANSFORM =
-sig
-  val program : IrTransform.state -> program -> IrTransform.result
-end
-
 module Transform : IR_VISITOR =
 struct
   open Types
@@ -514,8 +509,7 @@ end
 
 
 
-module Inline =
-struct
+module Inline = struct
   let rec is_inlineable_value =
     function
       | v when is_atom v -> true
@@ -559,6 +553,8 @@ struct
               end
         | [] -> [], o
   end
+
+  let name = "inline"
 
   let program state program =
     let open IrTransform in
@@ -791,6 +787,8 @@ module ElimDeadDefs = struct
         | [] -> [], o
   end
 
+  let name = "elim_dead_defs"
+
   let program state program =
     let open IrTransform in
     let tenv = Context.variable_environment (context state) in
@@ -849,8 +847,7 @@ let ir_type_mod_visitor tyenv type_visitor =
 
 
 (* Debugging traversal that checks if we have eliminated all cyclic recursive types *)
-module CheckForCycles =
-  struct
+module CheckForCycles = struct
 
     let check_cycles =
       object (o: 'self_type)
@@ -889,10 +886,7 @@ module CheckForCycles =
 
       end
 
-
-    (* let program tyenv p =
-     *   let p, _, _ = (ir_type_mod_visitor tyenv check_cycles)#program p in
-     *   p *)
+    let name = "check_for_cycles"
     let program state program =
       let open IrTransform in
       let tenv = Context.variable_environment (context state) in
@@ -920,9 +914,7 @@ module ElimBodiesFromMetaTypeVars = struct
       end
 
 
-    (* let program tyenv p =
-     *   let p, _, _ = (ir_type_mod_visitor tyenv elim_bodies)#program p in
-     *   p *)
+    let name = "elim_bodies_from_meta_type_vars"
 
     let program state program =
       let open IrTransform in
@@ -941,6 +933,7 @@ module ElimTypeAliases = struct
           | other -> super#typ other
       end
 
+    let name = "elim_type_aliases"
     let program state program =
       let open IrTransform in
       let tenv = Context.variable_environment (context state) in

--- a/core/irTraversals.mli
+++ b/core/irTraversals.mli
@@ -51,18 +51,13 @@ sig
   end
 end
 
-module type PROGRAM_TRANSFORM =
-sig
-  val program : IrTransform.state -> program -> IrTransform.result
-end
-
 module Transform : IR_VISITOR
 
-module Inline : PROGRAM_TRANSFORM
-module ElimDeadDefs : PROGRAM_TRANSFORM
-module ElimBodiesFromMetaTypeVars : PROGRAM_TRANSFORM
-module CheckForCycles : PROGRAM_TRANSFORM
-module ElimTypeAliases : PROGRAM_TRANSFORM
+module Inline : IrTransform.S
+module ElimDeadDefs : IrTransform.S
+module ElimBodiesFromMetaTypeVars : IrTransform.S
+module CheckForCycles : IrTransform.S
+module ElimTypeAliases : IrTransform.S
 module InstantiateTypes :
 sig
   val computation : Types.datatype Env.Int.t -> (Types.datatype IntMap.t * Types.row IntMap.t * Types.field_spec IntMap.t) -> computation -> computation

--- a/core/irTraversals.mli
+++ b/core/irTraversals.mli
@@ -51,20 +51,18 @@ sig
   end
 end
 
-module type PROGTRANSFORM =
+module type PROGRAM_TRANSFORM =
 sig
-   val program : Types.datatype Env.Int.t -> program -> program
-   val bindings : Types.datatype Env.Int.t -> binding list -> binding list
+  val program : IrTransform.state -> program -> IrTransform.result
 end
-
 
 module Transform : IR_VISITOR
 
-module Inline : PROGTRANSFORM
-module ElimDeadDefs : PROGTRANSFORM
-module ElimBodiesFromMetaTypeVars : PROGTRANSFORM
-module CheckForCycles : PROGTRANSFORM
-module ElimTypeAliases : PROGTRANSFORM
+module Inline : PROGRAM_TRANSFORM
+module ElimDeadDefs : PROGRAM_TRANSFORM
+module ElimBodiesFromMetaTypeVars : PROGRAM_TRANSFORM
+module CheckForCycles : PROGRAM_TRANSFORM
+module ElimTypeAliases : PROGRAM_TRANSFORM
 module InstantiateTypes :
 sig
   val computation : Types.datatype Env.Int.t -> (Types.datatype IntMap.t * Types.row IntMap.t * Types.field_spec IntMap.t) -> computation -> computation

--- a/core/liftRecursive.ml
+++ b/core/liftRecursive.ml
@@ -39,4 +39,8 @@ object ((self : 'self_type))
       | _ -> super#binding b
 end
 
-module Untyped = Transform.Untyped.Make.Transformer(struct let obj = lift_funs end)
+module Untyped
+  = Transform.Untyped.Make.Transformer(struct
+        let name = "lift_recursive"
+        let obj = lift_funs
+      end)

--- a/core/liftRecursive.ml
+++ b/core/liftRecursive.ml
@@ -38,3 +38,5 @@ object ((self : 'self_type))
           WithPos.make ~pos node
       | _ -> super#binding b
 end
+
+module Untyped = Transform.Untyped.Make.Transformer(struct let obj = lift_funs end)

--- a/core/liftRecursive.mli
+++ b/core/liftRecursive.mli
@@ -1,1 +1,3 @@
 val lift_funs : SugarTraversals.map
+
+include Transform.Untyped.S

--- a/core/loader.ml
+++ b/core/loader.ml
@@ -1,69 +1,15 @@
-open Utility
-open Performance
+type 'a result =
+  { program_ : 'a;
+    context: Context.t }
 
-type envs = Var.var Env.String.t * Types.typing_environment
-type program = Ir.binding list * Ir.computation * Types.datatype
-
-(* Filename of an external dependency *)
-type ext_dep = string
-
-(* Result of loading a file *)
-type source = {
-  envs: envs;
-  program: program;
-  external_dependencies: ext_dep list
-}
-
-
-
-(** Unmarshal an IR program from a file along with naming and typing
-    environments and the fresh variable counters.
-*)
-let read_a filename : ('a) =
-  let x, (gc, tc, vc) =
-    call_with_open_infile filename ~binary:true Marshal.from_channel
+let load : Context.t -> string -> Sugartypes.program result
+  = fun context filename ->
+  let program, pos_context =
+    ModuleUtils.try_parse_file filename
   in
-    Utility.gensym_counter := gc;
-    Types.type_variable_counter := tc;
-    Var.variable_counter := vc;
-    x
-
-let read_program filename : (envs * program) = read_a filename
-
-(* measuring only *)
-let read_program filename : (envs * program) =
-  measure ("read_program "^filename) read_program filename
-
-
-
-(** Read source code from a file, parse, infer types and desugar to
-    the IR *)
-let read_file_source (nenv, tyenv) (filename:string) =
-  let sugar, pos_context =
-    ModuleUtils.try_parse_file filename in
-  (* printf "AST: \n %s \n" (Sugartypes.show_program sugar); *)
-  let ((program, t, tenv), ffi_files) = Frontend.Pipeline.program tyenv pos_context sugar in
-  let globals, main, nenv =
-    Sugartoir.desugar_program
-      (nenv,
-       Var.varify_env (nenv, tyenv.Types.var_env),
-       tyenv.Types.effect_row) program
-  in
-  {
-    envs = (nenv, tenv);
-    program = (globals, main, t);
-    external_dependencies = ffi_files
-  }
-
-
-
-(** Loads a named file and prints it as syntax *)
-let print filename =
-   let _envs, (globals, (locals, main), _t) = read_program filename in
-     print_string (Ir.show_program (globals @ locals, main))
-
-
-let load_file = read_file_source
+  let context' = Context.{ context with source_code = pos_context } in
+  { context   = context';
+    program_  = program }
 
 
 

--- a/core/loader.mli
+++ b/core/loader.mli
@@ -1,17 +1,5 @@
-type envs = Var.var Env.String.t * Types.typing_environment
+type 'a result =
+  { program_ : 'a;
+    context: Context.t }
 
-type program = Ir.binding list * Ir.computation * Types.datatype
-
-(* Filename of an external dependency *)
-type ext_dep = string
-
-type source = {
-  envs: envs;
-  program: program;
-  external_dependencies: ext_dep list
-}
-
-val read_file_source : envs -> string -> source
-val load_file : envs -> string -> source
-
-val print : string -> unit
+val load : Context.t -> string -> Sugartypes.program result

--- a/core/page.ml
+++ b/core/page.ml
@@ -116,7 +116,7 @@ module Make_RealPage (C : JS_PAGE_COMPILER) (G : JS_CODEGEN) = struct
   let page : ?cgi_env:(string * string) list ->
              wsconn_url:(Webserver_types.websocket_url option) ->
              (Var.var Env.String.t * Types.typing_environment) ->
-             Ir.binding list -> (Value.env * Value.t) -> Loader.ext_dep list -> string
+             Ir.binding list -> (Value.env * Value.t) -> string list -> string
     = fun ?(cgi_env=[]) ~wsconn_url (nenv, tyenv) defs (valenv, v) deps ->
     let open Json in
     let req_data = Value.Env.request_data valenv in

--- a/core/resolvePositions.ml
+++ b/core/resolvePositions.ml
@@ -15,6 +15,8 @@ end
 module Untyped = struct
   open Transform.Untyped
 
+  let name = "resolve_positions"
+
   let program state program =
     let pos_context = Context.source_code (context state) in
     let program' = (resolve_positions pos_context)#program program in

--- a/core/resolvePositions.ml
+++ b/core/resolvePositions.ml
@@ -11,3 +11,17 @@ object
       | _ -> assert false
     )
 end
+
+module Untyped = struct
+  open Transform.Untyped
+
+  let program state program =
+    let pos_context = Context.source_code (context state) in
+    let program' = (resolve_positions pos_context)#program program in
+    return state program'
+
+  let sentence state sentence =
+    let pos_context = Context.source_code (context state) in
+    let sentence' = (resolve_positions pos_context)#sentence sentence in
+    return state sentence'
+end

--- a/core/resolvePositions.mli
+++ b/core/resolvePositions.mli
@@ -1,1 +1,3 @@
 val resolve_positions : SourceCode.source_code -> SugarTraversals.map
+
+include Transform.Untyped.S

--- a/core/settings.mli
+++ b/core/settings.mli
@@ -37,6 +37,7 @@ end
 val sync : 'a setting -> 'a setting
 
 (* Miscellaneous. *)
+val get_name : 'a setting -> string
 val from_string_option : string option -> string
 val string_of_paths : string list -> string
 val parse_paths : string -> string list

--- a/core/sugartoir.mli
+++ b/core/sugartoir.mli
@@ -13,3 +13,11 @@ val desugar_definitions : env -> Sugartypes.binding list ->
   Ir.binding list * nenv
 val desugar_program : env -> Sugartypes.program ->
   Ir.binding list * Ir.computation * nenv
+
+type result =
+  { globals: Ir.binding list;
+    program: Ir.program;
+    datatype: Types.datatype;
+    context: Context.t }
+
+val program : Context.t -> Types.datatype -> Sugartypes.program -> result

--- a/core/sugartypes.ml
+++ b/core/sugartypes.ml
@@ -354,7 +354,6 @@ type sentence =
   | Definitions of binding list
   | Expression  of phrase
   | Directive   of directive
-
     [@@deriving show]
 
 type program = binding list * phrase option

--- a/core/transform.ml
+++ b/core/transform.ml
@@ -1,0 +1,183 @@
+module type INTERFACE = sig
+  type state
+  type 'a result
+
+  val program : state ->
+                Sugartypes.program ->
+                Sugartypes.program result
+
+  val sentence : state ->
+                 Sugartypes.sentence ->
+                 Sugartypes.sentence result
+end
+
+module type UNTYPED = sig
+  type state = Context.t
+  type 'a result = Result of { program: 'a;
+                               state: state }
+
+
+  val return : state -> 'a -> 'a result
+  val context : state -> Context.t
+
+  module type S = sig
+    module Untyped: sig
+      include INTERFACE with type state := state and type 'a result := 'a result
+    end
+  end
+
+  module Make: sig
+    module Transformer(T : sig val obj : SugarTraversals.map end): sig
+      include INTERFACE with type state := state and type 'a result := 'a result
+    end
+  end
+end
+
+module Untyped : UNTYPED = struct
+  type 'a transformer = 'a -> 'a
+
+  type state = Context.t
+  type 'a result = Result of { program: 'a;
+                               state: state }
+  let context state = state
+  let return state program =
+    Result { program; state }
+
+  (* Interface for untyped transformations. *)
+  module type S = sig
+    module Untyped: sig
+      val program : state ->
+                    Sugartypes.program ->
+                    Sugartypes.program result
+
+      val sentence : state ->
+                     Sugartypes.sentence ->
+                     Sugartypes.sentence result
+    end
+  end
+
+  let apply_transformer : state -> 'a transformer -> 'a -> 'a result
+    = fun state transform program ->
+    return state (transform program)
+
+  module Make = struct
+    module Transformer(T : sig val obj : SugarTraversals.map end) = struct
+      let program state program =
+        apply_transformer state T.obj#program program
+
+      let sentence state sentence =
+        apply_transformer state T.obj#sentence sentence
+    end
+  end
+end
+
+module type TYPEABLE = sig
+  type state =
+    { datatype: Types.datatype;
+      context: Context.t }
+
+  type 'a result = Result of { program: 'a;
+                               state: state }
+
+  val return : state -> 'a -> 'a result
+  val with_type : Types.datatype option -> state -> state
+  val context : state -> Context.t
+
+  module type S = sig
+    module Typeable: sig
+      include INTERFACE with type state := state and type 'a result := 'a result
+    end
+  end
+
+  (* This virtual class helps break the dependency cycle:
+
+     Value -> DesugarDatatypes -> Transform -> TransformSugar -> DesugarDatatypes -> Transform
+
+   *)
+  class virtual sugar_transformer:
+  object ('self)
+    method virtual program : Sugartypes.program -> ('self * Sugartypes.program * Types.datatype option)
+    method virtual sentence : Sugartypes.sentence -> ('self * Sugartypes.sentence * Types.datatype option)
+  end
+
+  module Make(T : sig val obj : Types.typing_environment -> sugar_transformer end): sig
+    include INTERFACE with type state := state and type 'a result := 'a result
+  end
+
+end
+
+module Typeable : TYPEABLE = struct
+  class virtual sugar_transformer =
+          object (_ : 'self)
+            method virtual program : Sugartypes.program -> ('self * Sugartypes.program * Types.datatype option)
+            method virtual sentence : Sugartypes.sentence -> ('self * Sugartypes.sentence * Types.datatype option)
+          end
+
+  type 'a transformer = 'a -> (sugar_transformer * 'a * Types.datatype option)
+  type state =
+    { datatype: Types.datatype;
+      context: Context.t }
+
+  type 'a result = Result of { program: 'a;
+                               state: state }
+
+  let return state program =
+    Result { program; state }
+
+  let with_type : Types.datatype option -> state -> state
+    = fun t st ->
+    match t with
+    | None -> st
+    | Some t -> { st with datatype = t }
+
+  let context { context; _ } = context
+
+  let apply : state -> 'a transformer -> 'a -> 'a result
+    = fun st transform program ->
+    let (_, program', t) =
+      transform program
+    in
+    return (with_type t st) program'
+
+  (* Interface for typeability preserving transformations. *)
+  module type S = sig
+    module Typeable: sig
+      val program : state ->
+                    Sugartypes.program ->
+                    Sugartypes.program result
+
+      val sentence : state ->
+                     Sugartypes.sentence ->
+                     Sugartypes.sentence result
+    end
+  end
+
+  module Make(T : sig val obj : Types.typing_environment -> sugar_transformer end) = struct
+    let program state program =
+      let open Context in
+      apply state (T.obj (typing_environment state.context))#program program
+
+    let sentence state sentence =
+      let open Context in
+      apply state (T.obj (typing_environment state.context))#sentence sentence
+  end
+end
+
+(* Identity transformer. *)
+module Identity = struct
+  module Untyped = struct
+    let identity state program =
+      Untyped.return state program
+
+    let program = identity
+    let sentence = identity
+  end
+
+  module Typeable = struct
+    let identity state program =
+      Typeable.return state program
+
+    let program = identity
+    let sentence = identity
+  end
+end

--- a/core/transform.mli
+++ b/core/transform.mli
@@ -1,0 +1,78 @@
+module type INTERFACE = sig
+  type state
+  type 'a result
+
+  val program : state ->
+                Sugartypes.program ->
+                Sugartypes.program result
+
+  val sentence : state ->
+                 Sugartypes.sentence ->
+                 Sugartypes.sentence result
+end
+
+module type UNTYPED = sig
+  type state = Context.t
+  type 'a result = Result of { program: 'a;
+                               state: state }
+
+
+  val return : state -> 'a -> 'a result
+  val context : state -> Context.t
+
+  module type S = sig
+    module Untyped: sig
+      include INTERFACE with type state := state and type 'a result := 'a result
+    end
+  end
+
+  module Make: sig
+    module Transformer(T : sig val obj : SugarTraversals.map end): sig
+      include INTERFACE with type state := state and type 'a result := 'a result
+    end
+  end
+end
+
+module Untyped : UNTYPED
+
+
+module type TYPEABLE = sig
+  type state =
+    { datatype: Types.datatype;
+      context: Context.t }
+
+  type 'a result = Result of { program: 'a;
+                               state: state }
+
+  val return : state -> 'a -> 'a result
+  val with_type : Types.datatype option -> state -> state
+  val context : state -> Context.t
+
+  module type S = sig
+    module Typeable: sig
+      include INTERFACE with type state := state and type 'a result := 'a result
+    end
+  end
+
+  (* This virtual class helps break the dependency cycle:
+
+     Value -> DesugarDatatypes -> Transform -> TransformSugar -> DesugarDatatypes -> Transform
+
+   *)
+  class virtual sugar_transformer:
+                  object ('self)
+                    method virtual program : Sugartypes.program -> ('self * Sugartypes.program * Types.datatype option)
+                    method virtual sentence : Sugartypes.sentence -> ('self * Sugartypes.sentence * Types.datatype option)
+                  end
+
+  module Make(T : sig val obj : Types.typing_environment -> sugar_transformer end): sig
+    include INTERFACE with type state := state and type 'a result := 'a result
+  end
+end
+
+module Typeable : TYPEABLE
+
+module Identity: sig
+  include Untyped.S
+  include Typeable.S
+end

--- a/core/transform.mli
+++ b/core/transform.mli
@@ -2,6 +2,8 @@ module type INTERFACE = sig
   type state
   type 'a result
 
+  val name : string
+
   val program : state ->
                 Sugartypes.program ->
                 Sugartypes.program result
@@ -27,7 +29,9 @@ module type UNTYPED = sig
   end
 
   module Make: sig
-    module Transformer(T : sig val obj : SugarTraversals.map end): sig
+    module Transformer(T : sig
+                 val name : string
+                 val obj : SugarTraversals.map end): sig
       include INTERFACE with type state := state and type 'a result := 'a result
     end
   end
@@ -65,7 +69,9 @@ module type TYPEABLE = sig
                     method virtual sentence : Sugartypes.sentence -> ('self * Sugartypes.sentence * Types.datatype option)
                   end
 
-  module Make(T : sig val obj : Types.typing_environment -> sugar_transformer end): sig
+  module Make(T : sig
+               val name : string
+               val obj : Types.typing_environment -> sugar_transformer end): sig
     include INTERFACE with type state := state and type 'a result := 'a result
   end
 end

--- a/core/transformSugar.ml
+++ b/core/transformSugar.ml
@@ -203,13 +203,17 @@ class transform (env : Types.typing_environment) =
       fun section ->
         (o, section, type_section var_env section)
 
-    method sentence : sentence -> ('self_type * sentence) =
+    method sentence : sentence -> ('self_type * sentence * Types.datatype option) =
       function
       | Definitions defs ->
-          let (o, defs) = listu o (fun o -> o#binding) defs
-          in (o, Definitions defs)
-      | Expression e -> let (o, e, _) = o#phrase e in (o, Expression e)
-      | Directive d -> (o, Directive d)
+         let (o, defs) =
+           listu o (fun o -> o#binding) defs
+         in (o, Definitions defs, Some Types.unit_type)
+      | Expression e ->
+         let (o, e, t) = o#phrase e in
+         (o, Expression e, Some t)
+      | Directive d ->
+         (o, Directive d, None)
 
     method regex : regex -> ('self_type * regex) =
       function
@@ -237,7 +241,7 @@ class transform (env : Types.typing_environment) =
       fun (bs, e) ->
         let (o, bs) = listu o (fun o -> o#binding) bs in
         let (o, e, t) = option o (fun o -> o#phrase) e
-        in (o, (bs, e), t)
+        in (o, (bs, e), opt_map Types.normalise_datatype t)
 
     method given_spawn_location :
       given_spawn_location ->

--- a/core/transformSugar.mli
+++ b/core/transformSugar.mli
@@ -84,7 +84,7 @@ object ('self)
   method program         : program -> 'self * program * Types.datatype option
   method regex           : regex -> 'self * regex
   method section         : Section.t -> 'self * Section.t * Types.datatype
-  method sentence        : sentence -> 'self * sentence
+  method sentence        : sentence -> 'self * sentence * Types.datatype option
 (*
   method sentence'       : sentence' -> 'self * sentence'
   method directive       : directive -> 'self * directive

--- a/core/webserver_types.ml
+++ b/core/webserver_types.ml
@@ -35,7 +35,7 @@ sig
   val get_internal_base_url : unit -> string option
   val get_external_base_url : unit -> string option
 
-  val init : (Value.env * Ir.var Env.String.t * Types.typing_environment) -> Ir.binding list -> Loader.ext_dep list -> unit
+  val init : (Value.env * Ir.var Env.String.t * Types.typing_environment) -> Ir.binding list -> string list -> unit
   val set_prelude : Ir.binding list -> unit
   val add_route : bool -> string -> (string * (string * string) list, request_handler_fn) either -> unit
   val start : Value.env -> unit Lwt.t

--- a/core/webserver_types.mli
+++ b/core/webserver_types.mli
@@ -15,7 +15,7 @@ sig
   val get_internal_base_url : unit -> string option
   val get_external_base_url : unit -> string option
 
-  val init : (Value.env * Ir.var Env.String.t * Types.typing_environment) -> Ir.binding list -> Loader.ext_dep list -> unit
+  val init : (Value.env * Ir.var Env.String.t * Types.typing_environment) -> Ir.binding list -> string list -> unit
   val set_prelude : Ir.binding list -> unit
   val add_route : bool -> string -> (string * (string * string) list, request_handler_fn) either -> unit
 


### PR DESCRIPTION
This patch is an overhaul of the whole frontend and backend transformation pipelines and it brings structure to our ad-hoc transformation framework. 

Frontend transformations now state explicitly whether they are "untyped" or "typeability preserving". It also fixes a crucial bug in the frontend pipeline which would always return the initial inferred type of its given program rather than the type of the transformed program. 

The most substantial change is that the compilation state (known as `Context`) is now threaded through all of the frontend and backend transforms. The motivation for this change is to pave the way for the introduction of compilation units, which need to be accessible in all of the various transformation passes. Currently, the `Context` assumes whole program compilation and exposes fairly low-level details such as the various environments. This is will change with the upcoming compilation unit patch, where querying will happen through an interface rather than directly on the environments.

I have also managed to eliminate many of the distinct handling of `sentence` and `program`. The REPL and whole program compiler now uses the same pipeline, which I hope will help towards making the REPL more robust (past changes have often ignored the REPL).

I have also simplified `Loader`, `Links`, `Repl`, and `Driver` compilation units. In particular, the latter unit now explicitly identifies the various phases of the Links compiler, making it easy to run each phase separately. Hopefully this will help toward #415 and #629.

This patch depends on patch #769. This patch is a prerequisite for #603. 

**Merge strategy**: Please use rebase when merging this PR.