### PR TITLE
Type variable refreshing and subsitution in types and terms 

### DIFF
--- a/core/refreshTypeVariables.ml
+++ b/core/refreshTypeVariables.ml
@@ -161,7 +161,6 @@ let refresher (* sync_quantifiers_tyvars *) =
 
 
 
-
    method! function_definition : Sugartypes.function_definition -> 'self * Sugartypes.function_definition =
      fun { fun_binder;
            fun_linearity;
@@ -211,20 +210,12 @@ let refresher (* sync_quantifiers_tyvars *) =
 
 
 
-
-
     method handle_function =
       fun param_pats tyvars typ signature phrase ->
       let typ', _ = (refreshing_type_visitor maps)#typ typ in
 
 
       let tyvars', new_maps =
-        (* TODO: Implement this once we agreed on how to handle
-         quantifiers in signatures *)
-        (* if sync_quantifiers_tyvars then
-          let tyvars_typ', _ = TypeUtils.split_quantified_type typ' in
-          tyvars_typ', replace_quantifiers tyvars maps tyvars_typ'
-        else *)
           freshen_quantifiers tyvars maps
       in
 
@@ -237,12 +228,6 @@ let refresher (* sync_quantifiers_tyvars *) =
       let o, signature' = o#option (fun o -> o#datatype') signature in
 
       (* TODO: What to do with the patterns? *)
-
       o, (param_pats, tyvars', typ', signature', phrase')
-
-
-
-
-
 
     end

--- a/core/refreshTypeVariables.ml
+++ b/core/refreshTypeVariables.ml
@@ -1,0 +1,140 @@
+
+open Utility
+
+
+type instantiation_maps =
+  (Types.meta_type_var IntMap.t *
+   Types.meta_row_var IntMap.t *
+   Types.meta_presence_var IntMap.t)
+
+let add_type var t (ty_map, r_map, p_map) =
+  (IntMap.add var t ty_map), r_map, p_map
+let add_row var r (ty_map, r_map, p_map) =
+  ty_map, (IntMap.add var r r_map), p_map
+let add_presence var p (ty_map, r_map, p_map) =
+  ty_map, r_map, (IntMap.add var p p_map)
+
+
+let unwrap_type_point = function
+    | `MetaTypeVar point -> point
+    | _ -> assert false
+
+let unwrap_row_point = snd3
+
+let unwrap_presence_point = function
+    | `Var point -> point
+    | _ -> assert false
+
+
+let freshen_quantifiers
+      (qs : Types.quantifier list)
+      (instantiation_maps : instantiation_maps)
+    : (Types.quantifier list * instantiation_maps) =
+  let open CommonTypes.PrimaryKind in
+  List.fold_right
+    (fun q (new_qs, imaps) ->
+      match q with
+      | (var, (Type, subkind)) ->
+         let q, t = Types.fresh_type_quantifier subkind in
+         (q :: new_qs), add_type var (unwrap_type_point t) imaps
+      | (var, (Row, subkind)) ->
+         let q, r = Types.fresh_row_quantifier subkind in
+         (q :: new_qs), add_row var (unwrap_row_point r) imaps
+      | (var, (Presence, subkind)) ->
+         let q, f = Types.fresh_presence_quantifier subkind in
+         (q :: new_qs), add_presence var (unwrap_presence_point f) imaps)
+    qs ([], instantiation_maps)
+
+
+
+let refreshing_type_visitor instantiation_map =
+  let open Types in
+  object ((o : 'self_type))
+    inherit Transform.visitor as super
+
+    val inst_maps : instantiation_maps = instantiation_map
+
+    method set_maps new_inst_maps =
+      {< inst_maps = new_inst_maps >}
+
+
+    method! typ : datatype -> (datatype * 'self_type) = function
+      | `ForAll (qs, t) ->
+         let (qs', inst_maps') = freshen_quantifiers qs inst_maps in
+         let old_maps = inst_maps in
+         let o_new_maps = o#set_maps inst_maps' in
+
+         let (substed_t, substed_o) = o_new_maps#typ t in
+         let o' = substed_o#set_maps old_maps in
+
+         `ForAll (qs', substed_t), o'
+
+      | t -> super#typ t
+
+
+    method! meta_type_var : meta_type_var -> (meta_type_var * 'self_type) = fun point ->
+      match Unionfind.find point with
+        | `Var (var, _, _) ->
+           begin match IntMap.lookup var (fst3 inst_maps) with
+             | Some subst_p -> subst_p, o
+             | None -> point, o
+           end
+        | _ -> super#meta_type_var point
+
+    method! meta_row_var : meta_row_var -> (meta_row_var * 'self_type) = fun point ->
+      match Unionfind.find point with
+        | `Var (var, _, _) ->
+           begin match IntMap.lookup var (snd3 inst_maps) with
+             | Some subst_p -> subst_p, o
+             | None -> point, o
+           end
+        | _ -> super#meta_row_var point
+
+    method! meta_presence_var :  meta_presence_var -> (meta_presence_var * 'self_type) =
+      fun point ->
+      match Unionfind.find point with
+      | `Var (id, _, _) ->
+         begin match IntMap.lookup id (thd3 inst_maps) with
+         | Some subst_p -> subst_p, o
+         | None -> point, o
+         end
+      | _ -> super#meta_presence_var point
+
+
+  end
+
+
+
+
+
+
+(* let refresher program =
+ *   object(self : 'self_type)
+ *     inherit SugarTraversals.fold_map as super
+ *
+ *     val maps : Instantiate.instantiation_maps =
+ *       (IntMap.empty, IntMap.empty, IntMap.empty)
+ *
+ *
+ *     method bindingnode : bindingnode -> ('self_type * bindingnode) =
+ *       function
+ *       | Val (pat, (tyvars, phrase), loc, typ) ->
+ *           let (o, pat   ) = o#pattern pat in
+ *
+ *
+ *
+ *           let (o, _x_i2) = o#phrase _x_i2 in
+ *           let (o, _x_i3) = o#location _x_i3 in
+ *           let (o, _x_i4) = o#option (fun o -> o#datatype') _x_i4
+ *           in (o, (Val ((_x, (_x_i1, _x_i2), _x_i3, _x_i4))))
+ *       | other -> o#bindingnode other
+ *
+ *
+ *     method handle_scoped_phrase =
+ *       fun tyvars typ signature phrase -> (tyvars, typ, signature, phrase)
+ *
+ *
+ *
+ *
+ *
+ *     end *)

--- a/core/renameTypeVariables.ml
+++ b/core/renameTypeVariables.ml
@@ -1,5 +1,7 @@
 
 open Utility
+open CommonTypes
+
 
 let internal_error message =
   Errors.internal_error ~filename:"renameTypeVariables.ml" ~message
@@ -28,9 +30,9 @@ let unwrap_presence_point = function
     | _ -> assert false
 
 let freshen_quantifiers
-      (qs : Types.quantifier list)
+      (qs : Quantifier.t list)
       (instantiation_maps : instantiation_maps)
-    : (Types.quantifier list * instantiation_maps) =
+    : (Quantifier.t list * instantiation_maps) =
   let open CommonTypes.PrimaryKind in
   List.fold_right
     (fun q (new_qs, imaps) ->
@@ -49,9 +51,9 @@ let freshen_quantifiers
 
 (* Unused untill we integrate some syncing of tyvars and quantifiers *)
 let _replace_quantifiers
-  (qs_old : Types.quantifier list)
+  (qs_old : Quantifier.t list)
   (instantiation_maps : instantiation_maps)
-  (qs_new : Types.quantifier list) : instantiation_maps =
+  (qs_new : Quantifier.t list) : instantiation_maps =
   List.fold_right2
     (fun q_old q_new imaps ->
       let (var_old, (pk_old, sk_old)) = q_old in
@@ -196,15 +198,14 @@ let refresher initial_maps refresh_quantifiers =
      o,function_definition'
 
 
-     method! recursive_function : recursive_function -> 'self * recursive_function
+     method! recursive_functionnode : recursive_functionnode -> 'self * recursive_functionnode
          = fun { rec_binder;
               rec_linearity;
               rec_definition = ((tyvars, ty), lit);
               rec_location;
               rec_signature;
               rec_unsafe_signature;
-              rec_frozen;
-              rec_pos } ->
+              rec_frozen } ->
        let (pats, body) = lit in
        let o, (pats', tyvars', typ', signature', phrase') =
          o#handle_function pats tyvars (Binder.to_type rec_binder) rec_signature body in
@@ -215,8 +216,7 @@ let refresher initial_maps refresh_quantifiers =
            rec_location;
            rec_signature = signature';
            rec_unsafe_signature;
-           rec_frozen;
-           rec_pos }
+           rec_frozen }
        in
        o, recursive_definition'
 

--- a/core/renameTypeVariables.ml
+++ b/core/renameTypeVariables.ml
@@ -2,7 +2,7 @@
 open Utility
 
 let internal_error message =
-  Errors.internal_error ~filename:"refreshTypeVariables.ml" ~message
+  Errors.internal_error ~filename:"renameTypeVariables.ml" ~message
 
 type instantiation_maps =
   (Types.meta_type_var IntMap.t *

--- a/core/sugarTraversals.ml
+++ b/core/sugarTraversals.ml
@@ -2335,7 +2335,7 @@ class fold_map =
       | `Type t -> let o,t = o#typ t in o, `Type t
       | `Row r -> let o, r = o#type_row r in o, `Row r
       | `Presence p -> let o, p =o#type_field_spec p in o, `Presence p
-    method tyvar : Types.quantifier -> ('self_type * Types.quantifier) =
+    method tyvar : Quantifier.t -> ('self_type * Quantifier.t) =
       o#unknown
     method type_field_spec : Types.field_spec -> ('self_type * Types.field_spec) =
       o#unknown

--- a/core/sugarTraversals.ml
+++ b/core/sugarTraversals.ml
@@ -1506,6 +1506,9 @@ class fold_map =
     method bool : bool -> ('self_type * bool) =
       function | false -> (o, false) | true -> (o, true)
 
+
+
+
     method unary_op : UnaryOp.t -> ('self_type * UnaryOp.t) =
       let open UnaryOp in function
       | Minus -> (o, Minus)
@@ -1514,6 +1517,7 @@ class fold_map =
 
     method tyunary_op : tyarg list * UnaryOp.t -> 'self_type * (tyarg list * UnaryOp.t) =
       fun (_x, _x_i1) ->
+        let (o, _x) = o#list (fun o -> o#tyarg) _x in
         let (o, _x_i1) = o#unary_op _x_i1 in (o, (_x, _x_i1))
 
     method sentence : sentence -> ('self_type * sentence) =
@@ -1628,10 +1632,17 @@ class fold_map =
           (o, (QualifiedVar _xs))
       | FunLit (_x, _x1, _x_i1, _x_i2) ->
         let (o, _x_i1) = o#funlit _x_i1 in
+        let handle_funtype o (t, r) =
+          let (o, t) = o#typ t in
+          let (o,r) = o#type_row r in
+          (o, (t,r))
+        in
+        let (o, _x) = o#option (fun o -> o#list handle_funtype) _x in
         let (o, _x_i2) = o#location _x_i2 in (o, (FunLit (_x, _x1, _x_i1, _x_i2)))
       | Spawn (_spawn_kind, _given_spawn_location, _block_phr, _dt) ->
           let (o, _given_spawn_location) = o#given_spawn_location _given_spawn_location in
           let (o, _block_phr) = o#phrase _block_phr in
+          let (o, _dt) = o#option (fun o -> o#type_row) _dt in
           (o, (Spawn (_spawn_kind, _given_spawn_location, _block_phr, _dt)))
       | Query (_x, _policy, _x_i1, _x_i2) ->
           let (o, _x) =
@@ -1642,7 +1653,9 @@ class fold_map =
               _x in
           let (o, _x_i1) = o#phrase _x_i1 in (o, (Query (_x, _policy, _x_i1, _x_i2)))
       | ListLit (_x, _x_i1) ->
-          let (o, _x) = o#list (fun o -> o#phrase) _x in (o, (ListLit (_x, _x_i1)))
+          let (o, _x) = o#list (fun o -> o#phrase) _x in
+          let (o, _x_i1) = o#option (fun o -> o#typ) _x_i1 in
+          (o, (ListLit (_x, _x_i1)))
       | RangeLit ((_x_i1, _x_i2)) ->
           let (o, _x_i1) = o#phrase _x_i1 in
           let (o, _x_i2) = o#phrase _x_i2
@@ -1680,7 +1693,9 @@ class fold_map =
           let (o, _x_i1) = o#list (fun o -> o#phrase) _x_i1
           in (o, (FnAppl ((_x, _x_i1))))
       | TAbstr ((_x, _x_i1)) ->
-          let (o, _x_i1) = o#phrase _x_i1 in (o, (TAbstr ((_x, _x_i1))))
+          let o, _x = o#list (fun o -> o#tyvar) _x in
+          let (o, _x_i1) = o#phrase _x_i1 in
+          (o, (TAbstr ((_x, _x_i1))))
       | TAppl ((_x, _x_i1)) ->
           let (o, _x) = o#phrase _x in
           let (o, _x_i1) = o#list (fun o -> o#type_arg') _x_i1 in
@@ -1725,12 +1740,13 @@ class fold_map =
           (o, Generalise _x)
       | ConstructorLit ((_x, _x_i1, _x_i2)) ->
           let (o, _x) = o#name _x in
-          let (o, _x_i1) = o#option (fun o -> o#phrase) _x_i1
-          in (o, (ConstructorLit ((_x, _x_i1, _x_i2))))
+          let (o, _x_i1) = o#option (fun o -> o#phrase) _x_i1 in
+          let o, _x_i2 = o#option (fun o -> o#typ) _x_i2 in
+          (o, (ConstructorLit ((_x, _x_i1, _x_i2))))
       | DoOperation (name, ps, t) ->
-     let (o, t) = o#option (fun o -> o#unknown) t in
-     let (o, ps) = o#list (fun o -> o#phrase) ps in
-     (o, DoOperation (name, ps, t))
+          let (o, t) = o#option (fun o -> o#typ) t in
+          let (o, ps) = o#list (fun o -> o#phrase) ps in
+          (o, DoOperation (name, ps, t))
       | Handle { sh_expr; sh_effect_cases; sh_value_cases; sh_descr } ->
           let (o, m) = o#phrase sh_expr in
           let (o, params) =
@@ -1761,7 +1777,7 @@ class fold_map =
                  let (o, _x) = o#pattern _x in
                  let (o, _x_i1) = o#phrase _x_i1 in (o, (_x, _x_i1)))
               _x_i1 in
-          let (o, _x_i2) = o#option (fun o -> o#unknown) _x_i2
+          let (o, _x_i2) = o#option (fun o -> o#typ) _x_i2
           in (o, (Switch ((_x, _x_i1, _x_i2))))
       | Receive ((_x, _x_i1)) ->
           let (o, _x) =
@@ -1770,7 +1786,7 @@ class fold_map =
                  let (o, _x) = o#pattern _x in
                  let (o, _x_i1) = o#phrase _x_i1 in (o, (_x, _x_i1)))
               _x in
-          let (o, _x_i1) = o#option (fun o -> o#unknown) _x_i1
+          let (o, _x_i1) = o#option (fun o -> o#typ) _x_i1
           in (o, (Receive ((_x, _x_i1))))
       (* | Link ((_x, _x_i1)) -> *)
       (*     let (o, _x) = o#phrase _x in *)
@@ -1808,9 +1824,11 @@ class fold_map =
                let (o, _x) = o#datatype _x in
                let (o, _x_i1) =
                  o#option
-                   (fun o _x ->
-                      let (o, _x) = o#unknown _x in (o, _x))
-                   _x_i1
+                   (fun o (a, b, c) ->
+                     let o, a = o#typ a in
+                     let o, b = o#typ b in
+                     let o, c = o#typ c in
+                     o, (a, b, c)) _x_i1
                in (o, (_x, _x_i1)))
               _x_i1 in
           let (o, _x_i2) =
@@ -1861,12 +1879,12 @@ class fold_map =
             (o, (LensCheckLit ((_x, _x_i1))))
       | LensGetLit ((_x, _x_i1)) ->
           let (o, _x) = o#phrase _x in
-          let (o, _x_i1) = o#option (fun o -> o#unknown) _x_i1 in
+          let (o, _x_i1) = o#option (fun o -> o#typ) _x_i1 in
             (o, (LensGetLit ((_x, _x_i1))))
       | LensPutLit ((_x, _x_i1, _x_i2)) ->
           let (o, _x) = o#phrase _x in
           let (o, _x_i1) = o#phrase _x_i1 in
-          let (o, _x_i2) = o#option (fun o -> o#unknown) _x_i2 in
+          let (o, _x_i2) = o#option (fun o -> o#typ) _x_i2 in
             (o, (LensPutLit ((_x, _x_i1, _x_i2))))
       | DBDelete ((_x, _x_i1, _x_i2)) ->
           let (o, _x) = o#pattern _x in
@@ -1923,6 +1941,7 @@ class fold_map =
           let (o, _pat) = o#pattern _pat in
           let (o, _p2) = o#phrase _p2 in
           let (o, _p3) = o#phrase _p3 in
+          let o, _ty = o#option (fun o -> o#typ) _ty in
           (o, (TryInOtherwise (_p1, _pat, _p2, _p3, _ty)))
       | Raise -> (o, Raise)
 
@@ -1933,18 +1952,28 @@ class fold_map =
         ~f_node:(fun o v -> o#phrasenode v)
 
     method cp_phrasenode : cp_phrasenode -> ('self_type * cp_phrasenode) =
+      let arg_pair (o : 'self_type) =
+        o#option (fun o (dt, args) ->
+            let o, dt = o#typ dt in
+            let o, args = o#list (fun o -> o#tyarg) args in
+            let o, dt = o#typ dt in
+            o, (dt, args))
+      in
+
       function
       | CPUnquote (bs, e) ->
          let o, bs = o#list (fun o -> o#binding) bs in
          let o, e = o#phrase e in
          o, CPUnquote (bs, e)
-      | CPGrab (c, x, p) ->
+      | CPGrab ((c, a), x, p) ->
+         let o, a = arg_pair o a in
          let o, p = o#cp_phrase p in
-         o, CPGrab (c, x, p)
-      | CPGive (c, e, p) ->
+         o, CPGrab ((c, a), x, p)
+      | CPGive ((c, a), e, p) ->
+         let o, a = arg_pair o a in
          let o, e = o#option (fun o -> o#phrase) e in
          let o, p = o#cp_phrase p in
-         o, CPGive (c, e, p)
+         o, CPGive ((c, a), e, p)
       | CPGiveNothing c ->
          let o, c = o#binder c in
          o, CPGiveNothing c
@@ -2035,16 +2064,17 @@ class fold_map =
         let (o, _x_i1) = o#phrase _x_i1 in (o, (_x, _x_i1))
 
     method handle_params : handler_parameterisation -> ('self_type * handler_parameterisation) =
-      fun params ->
-        let (o, bindings) =
+      fun { shp_bindings; shp_types } ->
+        let (o, shp_bindings) =
           o#list
             (fun o (pat, expr) ->
               let (o, expr) = o#phrase expr in
               let (o, pat) = o#pattern pat in
               (o, (pat, expr)))
-            params.shp_bindings
+            shp_bindings
         in
-        (o, { params with shp_bindings = bindings })
+        let o, shp_types = o#list (fun o -> o#typ) shp_types in
+        (o, { shp_bindings; shp_types })
 
     method fieldspec : Datatype.fieldspec -> ('self_type * Datatype.fieldspec) =
       let open Datatype in function
@@ -2063,7 +2093,7 @@ class fold_map =
     method datatype' : datatype' -> ('self_type * datatype') =
       fun (_x, _x_i1) ->
         let (o, _x) = o#datatype _x in
-        let (o, _x_i1) = o#option (fun o -> o#unknown) _x_i1
+        let (o, _x_i1) = o#option (fun o -> o#typ) _x_i1
         in (o, (_x, _x_i1))
 
     method datatypenode : Datatype.t -> ('self_type * Datatype.t) =
@@ -2139,6 +2169,7 @@ class fold_map =
     method type_arg' : type_arg' -> ('self_type * type_arg') =
       fun (x, y) ->
         let o, x = o#type_arg x in
+        let o, y = o#option (fun o -> o#tyarg) y in
         (o, (x, y))
 
     method constant : Constant.t -> ('self_type * Constant.t) =
@@ -2168,6 +2199,7 @@ class fold_map =
 
     method tybinop : tyarg list * BinaryOp.t -> 'self_type * (tyarg list * BinaryOp.t) =
       fun (_x, _x_i1) ->
+        let (o, _x) = o#list (fun o -> o#tyarg) _x in
         let (o, _x_i1) = o#binop _x_i1 in (o, (_x, _x_i1))
 
     method bindingnode : bindingnode -> ('self_type * bindingnode) =
@@ -2247,6 +2279,7 @@ class fold_map =
               fun_frozen;
               fun_unsafe_signature; }->
       let o, fun_binder = o#binder fun_binder in
+      let o, tyvar = o#list (fun o -> o#tyvar) tyvar in
       let o, lit = o#funlit lit in
       let o, fun_location = o#location fun_location in
       let o, fun_signature = o#option (fun o -> o#datatype') fun_signature in
@@ -2261,18 +2294,20 @@ class fold_map =
     method recursive_functionnode  : recursive_functionnode -> 'self * recursive_functionnode
       = fun { rec_binder;
               rec_linearity;
-              rec_definition = (ty, lit);
+              rec_definition = ((tyvar, ty), lit);
               rec_location;
               rec_signature;
               rec_unsafe_signature;
               rec_frozen } ->
       let o, rec_binder = o#binder rec_binder in
+      let o, tyvar = o#list (fun o -> o#tyvar) tyvar in
+      let o, ty = o#option (fun o (t, x)-> let o, t = o#typ t in o, (t, x)) ty in
       let o, lit = o#funlit lit in
       let o, rec_location = o#location rec_location in
       let o, rec_signature = o#option (fun o -> o#datatype') rec_signature in
       (o, { rec_binder;
             rec_linearity;
-            rec_definition = (ty, lit);
+            rec_definition = ((tyvar, ty), lit);
             rec_location;
             rec_signature;
             rec_unsafe_signature;
@@ -2289,7 +2324,21 @@ class fold_map =
         ~o
         ~f_pos:(fun o v -> o#position v)
         ~f_name:(fun o v -> o#name v)
-        ~f_ty:(fun o v -> o, v)
+        ~f_ty:(fun o v -> o#typ v)
+
+    method typ : Types.datatype -> ('self_type * Types.datatype) =
+      o#unknown
+    method type_row : Types.row -> ('self_type * Types.row) =
+      o#unknown
+    method tyarg : Types.type_arg -> ('self_type * Types.type_arg) =
+      function
+      | `Type t -> let o,t = o#typ t in o, `Type t
+      | `Row r -> let o, r = o#type_row r in o, `Row r
+      | `Presence p -> let o, p =o#type_field_spec p in o, `Presence p
+    method tyvar : Types.quantifier -> ('self_type * Types.quantifier) =
+      o#unknown
+    method type_field_spec : Types.field_spec -> ('self_type * Types.field_spec) =
+      o#unknown
 
     method unknown : 'a. 'a -> ('self_type * 'a) = fun x -> (o, x)
   end

--- a/core/sugarTraversals.mli
+++ b/core/sugarTraversals.mli
@@ -221,7 +221,7 @@ object ('self)
   method typ             : Types.datatype -> ('self * Types.datatype)
   method type_row        : Types.row -> ('self* Types.row)
   method type_arg        : Datatype.type_arg -> 'self * Datatype.type_arg
-  method tyvar           : Types.quantifier -> ('self * Types.quantifier)
+  method tyvar           : Quantifier.t -> ('self * Quantifier.t)
   method type_field_spec : Types.field_spec -> ('self * Types.field_spec)
   method tyarg           : Types.type_arg -> ('self * Types.type_arg)
   method tyunary_op      : tyarg list * UnaryOp.t -> 'self * (tyarg list * UnaryOp.t)

--- a/core/sugarTraversals.mli
+++ b/core/sugarTraversals.mli
@@ -218,7 +218,12 @@ object ('self)
   method freedom         : Freedom.t -> 'self * Freedom.t
   method type_variable   : type_variable -> 'self * type_variable
   method known_type_variable : known_type_variable -> 'self * known_type_variable
+  method typ             : Types.datatype -> ('self * Types.datatype)
+  method type_row        : Types.row -> ('self* Types.row)
   method type_arg        : Datatype.type_arg -> 'self * Datatype.type_arg
+  method tyvar           : Types.quantifier -> ('self * Types.quantifier)
+  method type_field_spec : Types.field_spec -> ('self * Types.field_spec)
+  method tyarg           : Types.type_arg -> ('self * Types.type_arg)
   method tyunary_op      : tyarg list * UnaryOp.t -> 'self * (tyarg list * UnaryOp.t)
   method unary_op        : UnaryOp.t -> 'self * UnaryOp.t
   method function_definition : function_definition -> 'self * function_definition

--- a/core/types.mli
+++ b/core/types.mli
@@ -226,6 +226,7 @@ val make_type_variable : int -> Subkind.t -> datatype
 val make_rigid_type_variable : int -> Subkind.t -> datatype
 val make_row_variable : int -> Subkind.t -> row_var
 val make_rigid_row_variable : int -> Subkind.t -> row_var
+val make_rigid_presence_variable : int -> Subkind.t -> field_spec
 
 (** fresh type variable generation *)
 val fresh_type_variable : Subkind.t -> datatype


### PR DESCRIPTION
This PR implements two things:

1. Extend the `fold_map` visitor in `core/sugartraversals.ml` to visit semantics datatypes (i.e., those from `Types`) properly. The `map` visitor already did this, but `fold_map` didn't. This step is a prerequisite for the next step.

2. Implements `RenameTypeVariables` which substitutes type variables in sugar ASTs (namely, in all types found anywhere in an AST). Based on a flag, it can also refresh all quantifiers it comes across in the process.

This is a step towards @jstolarek and my efforts to improve `TypeSugar`, but the functionality of this PR is not used, yet.