### PR TITLE
Distinction between nominal and structural 'names'.

### DIFF
--- a/core/commonTypes.ml
+++ b/core/commonTypes.ml
@@ -199,6 +199,11 @@ module Name = struct
     [@@deriving show]
 end
 
+module Typename = struct
+  type t = string
+    [@@deriving show]
+end
+
 module Label = struct
   type t = string
     [@@deriving show]

--- a/core/commonTypes.ml
+++ b/core/commonTypes.ml
@@ -199,6 +199,11 @@ module Name = struct
     [@@deriving show]
 end
 
+module Label = struct
+  type t = string
+    [@@deriving show]
+end
+
 module Primitive = struct
   type t = Bool | Int | Char | Float | XmlItem | DB | String
     [@@deriving show]

--- a/core/commonTypes.ml
+++ b/core/commonTypes.ml
@@ -204,6 +204,11 @@ module Typename = struct
     [@@deriving show]
 end
 
+module Typevar = struct
+  type t = string
+    [@@deriving show]
+end
+
 module Label = struct
   type t = string
     [@@deriving show]

--- a/core/operators.ml
+++ b/core/operators.ml
@@ -57,6 +57,6 @@ end
 
 (* Operator section *)
 module Section = struct
-  type t = Minus | FloatMinus | Project of Name.t | Name of Name.t
+  type t = Minus | FloatMinus | Project of Label.t | Name of Name.t
     [@@deriving show]
 end

--- a/core/sugarConstructorsIntf.ml
+++ b/core/sugarConstructorsIntf.ml
@@ -56,7 +56,7 @@ module type SugarConstructorsSig = sig
   val block_node  :            block_body -> phrasenode
   val datatype    : Datatype.with_pos -> Datatype.with_pos * 'a option
   val cp_unit     : t -> cp_phrase
-  val record      : ?ppos:t -> ?exp:phrase -> (Name.t * phrase) list -> phrase
+  val record      : ?ppos:t -> ?exp:phrase -> (Label.t * phrase) list -> phrase
   val tuple       : ?ppos:t -> phrase list -> phrase
   val orderby_tuple : ?ppos:t -> phrase list -> phrase
   val list        :
@@ -73,7 +73,7 @@ module type SugarConstructorsSig = sig
   val binder   : ?ppos:t -> ?ty:Types.datatype -> Name.t -> Binder.with_pos
 
   (* Imports *)
-  val import : ?ppos:t -> ?pollute:bool -> Name.t list -> binding
+  val import : ?ppos:t -> ?pollute:bool -> string list -> binding
 
   (* Patterns *)
   val variable_pat : ?ppos:t -> ?ty:Types.datatype -> Name.t -> Pattern.with_pos
@@ -127,9 +127,9 @@ module type SugarConstructorsSig = sig
 
   (* Database queries *)
   val db_exps
-      : ?ppos:t -> (Name.t * phrase) list -> phrase
+      : ?ppos:t -> (Label.t * phrase) list -> phrase
   val db_insert
-      : ?ppos:t -> phrase -> Name.t list -> phrase -> string option
+      : ?ppos:t -> phrase -> Label.t list -> phrase -> string option
      -> phrase
   val query
       : ?ppos:t -> (phrase * phrase) option -> QueryPolicy.t -> phrase -> phrase
@@ -143,8 +143,8 @@ module type SugarConstructorsSig = sig
   val validate_xml
       : ?tags:(string * string) -> phrase -> unit
   val xml
-      : ?ppos:t -> ?tags:(string * string) -> Name.t
-     -> (Name.t * (phrase list)) list -> phrase option -> phrase list
+      : ?ppos:t -> ?tags:(string * string) -> Label.t
+     -> (Label.t * (phrase list)) list -> phrase option -> phrase list
      -> phrase
 
   (* Handlers *)

--- a/core/sugartypes.ml
+++ b/core/sugartypes.ml
@@ -73,11 +73,11 @@ let default_effect_subkind : Subkind.t = (lin_unl, res_any)
 type kind = PrimaryKind.t option * Subkind.t option
     [@@deriving show]
 
-type type_variable = Name.t * kind * Freedom.t
+type type_variable = Typename.t * kind * Freedom.t
     [@@deriving show]
 
 (* type variable of primary kind Type? *)
-type known_type_variable = Name.t * Subkind.t option * Freedom.t
+type known_type_variable = Typename.t * Subkind.t option * Freedom.t
     [@@deriving show]
 
 type quantifier = type_variable
@@ -98,10 +98,10 @@ type fieldconstraint = Readonly | Default
 module Datatype = struct
   type t =
     | TypeVar         of known_type_variable
-    | QualifiedTypeApplication of Name.t list * type_arg list
+    | QualifiedTypeApplication of Typename.t list * type_arg list
     | Function        of with_pos list * row * with_pos
     | Lolli           of with_pos list * row * with_pos
-    | Mu              of Name.t * with_pos
+    | Mu              of Typename.t * with_pos
     | Forall          of quantifier list * with_pos
     | Unit
     | Tuple           of with_pos list
@@ -124,7 +124,7 @@ module Datatype = struct
   and row_var =
     | Closed
     | Open of known_type_variable
-    | Recursive of Name.t * row
+    | Recursive of Typename.t * row
   and fieldspec =
     | Present of with_pos
     | Absent

--- a/core/sugartypes.ml
+++ b/core/sugartypes.ml
@@ -73,11 +73,11 @@ let default_effect_subkind : Subkind.t = (lin_unl, res_any)
 type kind = PrimaryKind.t option * Subkind.t option
     [@@deriving show]
 
-type type_variable = Typename.t * kind * Freedom.t
+type type_variable = Typevar.t * kind * Freedom.t
     [@@deriving show]
 
 (* type variable of primary kind Type? *)
-type known_type_variable = Typename.t * Subkind.t option * Freedom.t
+type known_type_variable = Typevar.t * Subkind.t option * Freedom.t
     [@@deriving show]
 
 type quantifier = type_variable
@@ -101,7 +101,7 @@ module Datatype = struct
     | QualifiedTypeApplication of Typename.t list * type_arg list
     | Function        of with_pos list * row * with_pos
     | Lolli           of with_pos list * row * with_pos
-    | Mu              of Typename.t * with_pos
+    | Mu              of Typevar.t * with_pos
     | Forall          of quantifier list * with_pos
     | Unit
     | Tuple           of with_pos list
@@ -124,7 +124,7 @@ module Datatype = struct
   and row_var =
     | Closed
     | Open of known_type_variable
-    | Recursive of Typename.t * row
+    | Recursive of Typevar.t * row
   and fieldspec =
     | Present of with_pos
     | Absent

--- a/core/sugartypes.ml
+++ b/core/sugartypes.ml
@@ -150,10 +150,10 @@ module Pattern = struct
     | Nil
     | Cons     of with_pos * with_pos
     | List     of with_pos list
-    | Variant  of Name.t * with_pos option
-    | Effect   of Name.t * with_pos list * with_pos
-    | Negative of Name.t list
-    | Record   of (Name.t * with_pos) list * with_pos option
+    | Variant  of Label.t * with_pos option
+    | Effect   of Label.t * with_pos list * with_pos
+    | Negative of Label.t list
+    | Record   of (Label.t * with_pos) list * with_pos option
     | Tuple    of with_pos list
     | Constant of Constant.t
     | Variable of Binder.with_pos
@@ -243,15 +243,15 @@ and phrasenode =
   | TAbstr           of tyvar list * phrase
   | TAppl            of phrase * type_arg' list
   | TupleLit         of phrase list
-  | RecordLit        of (Name.t * phrase) list * phrase option
-  | Projection       of phrase * Name.t
-  | With             of phrase * (Name.t * phrase) list
+  | RecordLit        of (Label.t * phrase) list * phrase option
+  | Projection       of phrase * Label.t
+  | With             of phrase * (Label.t * phrase) list
   | TypeAnnotation   of phrase * datatype'
   | Upcast           of phrase * datatype' * datatype'
   | Instantiate      of phrase
   | Generalise       of phrase
-  | ConstructorLit   of Name.t * phrase option * Types.datatype option
-  | DoOperation      of Name.t * phrase list * Types.datatype option
+  | ConstructorLit   of Label.t * phrase option * Types.datatype option
+  | DoOperation      of Label.t * phrase list * Types.datatype option
   | Handle           of handler
   | Switch           of phrase * (Pattern.with_pos * phrase) list *
                           Types.datatype option
@@ -259,11 +259,11 @@ and phrasenode =
   | DatabaseLit      of phrase * (phrase option * phrase option)
   | TableLit         of phrase * (Datatype.with_pos * (Types.datatype *
                            Types.datatype * Types.datatype) option) *
-                          (Name.t * fieldconstraint list) list * phrase * phrase
+                          (Label.t * fieldconstraint list) list * phrase * phrase
   | DBDelete         of Pattern.with_pos * phrase * phrase option
-  | DBInsert         of phrase * Name.t list * phrase * phrase option
+  | DBInsert         of phrase * Label.t list * phrase * phrase option
   | DBUpdate         of Pattern.with_pos * phrase * phrase option *
-                          (Name.t * phrase) list
+                          (Label.t * phrase) list
   | LensLit          of phrase * Lens.Type.t option
   (* the lens keys lit is a literal that takes an expression and is converted
      into a LensLit with the corresponding table keys marked in the lens_sort *)
@@ -278,7 +278,7 @@ and phrasenode =
   | LensGetLit       of phrase * Types.datatype option
   | LensCheckLit     of phrase * Lens.Type.t option
   | LensPutLit       of phrase * phrase * Types.datatype option
-  | Xml              of Name.t * (Name.t * (phrase list)) list * phrase option *
+  | Xml              of Label.t * (Label.t * (phrase list)) list * phrase option *
                           phrase list
   | TextNode         of string
   | Formlet          of phrase * phrase
@@ -287,7 +287,7 @@ and phrasenode =
   | PagePlacement    of phrase
   | FormBinding      of phrase * Pattern.with_pos
   (* choose *)
-  | Select           of Name.t * phrase
+  | Select           of Label.t * phrase
   (* choice *)
   | Offer            of phrase * (Pattern.with_pos * phrase) list *
                           Types.datatype option


### PR DESCRIPTION
The module `Name` in `commonTypes.ml` is used to name both nominal and
structural things. It is conceptually wrong to mix the two. This patch
introduces a new module `Label` in `commonTypes.ml` which is used to
name structural things, reserving `Name` to be used for nominal
things. Although this change is only cosmetic, it becomes important as
we move towards hygienic (nominal) name handling in the frontend.

Addendum: I have added `Typename` in `commonTypes.ml` for type-level names and `Typevar` for type variable names.

**Merge strategy**: Please use rebase when merging this PR.