### PR TITLE
Fix "Unbound type variable" IR errors

### DIFF
--- a/core/desugarFuns.ml
+++ b/core/desugarFuns.ml
@@ -102,9 +102,9 @@ object (o : 'self_type)
     let f = gensym ~prefix:"_fun_" () in
     let (bndr, lin, (_, def), loc) =
       unwrap_def (binder ~ty:ft f, lin, ([], lam), location) in
-    let (tvs, tyargs), ft =
+    let (tvs, tyargs), gen_ft =
       Generalise.generalise (o#get_var_env ()) (Binder.to_type bndr) in
-    let bndr = Binder.set_type bndr ft in
+    let bndr = Binder.set_type bndr gen_ft in
     let o = o#bind_binder bndr in
     let e = block_node ([with_dummy_pos
                            (Fun { fun_binder           = bndr

--- a/core/instantiate.mli
+++ b/core/instantiate.mli
@@ -20,6 +20,7 @@ val recursive_application : string -> Quantifier.t list -> Types.type_arg list -
 (* Given a quantified type and a list of type arguments, create the corresponding instantiation maps *)
 val instantiation_maps_of_type_arguments : bool -> Types.datatype -> Types.type_arg list -> (Types.datatype * instantiation_maps)
 
+val build_fresh_quantifiers : Quantifier.t list -> Quantifier.t list * Types.type_arg list
 val apply_type : Types.datatype -> Types.type_arg list -> Types.datatype
 val freshen_quantifiers : Types.datatype -> Types.datatype
 val replace_quantifiers : Types.datatype -> Quantifier.t list -> Types.datatype

--- a/core/renamer.ml
+++ b/core/renamer.ml
@@ -1,0 +1,298 @@
+(* Rename for type variables in terms *)
+
+open Utility
+open CommonTypes
+open Sugartypes
+
+let internal_error message =
+  Errors.internal_error ~filename:"renamer.ml" ~message
+
+type instantiation_maps =
+  (Types.meta_type_var     IntMap.t *
+   Types.meta_row_var      IntMap.t *
+   Types.meta_presence_var IntMap.t)
+
+let fresh_instantiation_maps : instantiation_maps =
+  (IntMap.empty, IntMap.empty, IntMap.empty)
+
+let add_type_var var t (ty_map, r_map, p_map) =
+  (IntMap.add var t ty_map), r_map, p_map
+
+let add_row_var var r (ty_map, r_map, p_map) =
+  ty_map, (IntMap.add var r r_map), p_map
+
+let add_presence_var var p (ty_map, r_map, p_map) =
+  ty_map, r_map, (IntMap.add var p p_map)
+
+
+let remove_type_var var (ty_map, r_map, p_map) =
+  (IntMap.remove var ty_map), r_map, p_map
+
+let remove_row_var var (ty_map, r_map, p_map) =
+  ty_map, (IntMap.remove var r_map), p_map
+
+let remove_presence_var var (ty_map, r_map, p_map) =
+  ty_map, r_map, (IntMap.remove var p_map)
+
+
+let unwrap_type_point = function
+    | `MetaTypeVar point -> point
+    | _ -> assert false
+
+let unwrap_presence_point = function
+    | `Var point -> point
+    | _ -> assert false
+
+
+(** Build instantiation maps between two lists of quantifiers *)
+let build_instantiation_maps
+     ?(instantiation_maps=fresh_instantiation_maps)
+      (qs_old : Quantifier.t list)
+      (qs_new : Quantifier.t list) : instantiation_maps =
+  assert (List.length qs_old == List.length qs_new);
+  List.fold_right2
+    (fun q_old q_new imaps ->
+      let (var_old, (pk_old, sk_old)) = q_old in
+      let (var_new, (pk_new, sk_new)) = q_new in
+      (if pk_old <> pk_new || sk_old <> sk_new then
+        raise (internal_error "build_instantiation_maps: Kind missmatch"));
+      let open CommonTypes.PrimaryKind in
+      match pk_old with
+      | Type ->
+         let t = Types.make_rigid_type_variable var_new sk_new in
+         add_type_var var_old (unwrap_type_point t) imaps
+      | Row ->
+         let r = Types.make_rigid_row_variable var_new sk_new in
+         add_row_var var_old r imaps
+      | Presence ->
+         let f = Types.make_rigid_presence_variable var_new sk_new in
+         add_presence_var var_old (unwrap_presence_point f) imaps)
+    qs_old qs_new instantiation_maps
+
+(** Remove quantifiers from instantiation_maps.  Required to handle variable
+    shadowing. *)
+let shadow_vars
+      (maps : instantiation_maps)
+      (qs : Quantifier.t list) : instantiation_maps =
+  List.fold_right
+    (fun (var, (pk, _)) imaps ->
+      let open CommonTypes.PrimaryKind in
+      match pk with
+      | Type     -> remove_type_var     var imaps
+      | Row      -> remove_row_var      var imaps
+      | Presence -> remove_presence_var var imaps)
+    qs maps
+
+let renaming_type_visitor instantiation_map =
+  let open Types in
+  object ((o : 'self_type))
+    inherit Transform.visitor as super
+
+    val inst_maps : instantiation_maps = instantiation_map
+
+    method set_maps new_inst_maps =
+      {< inst_maps = new_inst_maps >}
+
+    method! typ : datatype -> (datatype * 'self_type) = function
+      | `ForAll (qs, t) ->
+         let inst_maps = shadow_vars inst_maps qs in
+         let t', _ = {< inst_maps >}#typ t in
+         `ForAll (qs, t'), o
+      | t -> super#typ t
+
+    method! meta_type_var : meta_type_var -> (meta_type_var * 'self_type) =
+      fun point ->
+      match Unionfind.find point with
+        | `Var (var, _, _) ->
+           begin match IntMap.lookup var (fst3 inst_maps) with
+             | Some subst_p -> subst_p, o
+             | None -> point, o
+           end
+        | _ -> super#meta_type_var point
+
+    method! meta_row_var : meta_row_var -> (meta_row_var * 'self_type) =
+      fun point ->
+      match Unionfind.find point with
+        | `Var (var, _, _) ->
+           begin match IntMap.lookup var (snd3 inst_maps) with
+             | Some subst_p -> subst_p, o
+             | None -> point, o
+           end
+        | _ -> super#meta_row_var point
+
+    method! meta_presence_var :
+            meta_presence_var -> (meta_presence_var * 'self_type) =
+      fun point ->
+      match Unionfind.find point with
+      | `Var (id, _, _) ->
+         begin match IntMap.lookup id (thd3 inst_maps) with
+         | Some subst_p -> subst_p, o
+         | None -> point, o
+         end
+      | _ -> super#meta_presence_var point
+
+  end
+
+
+let renamer qs_from qs_to =
+  object(o : 'self_type)
+    inherit SugarTraversals.fold_map as super
+
+    val maps : instantiation_maps =
+      build_instantiation_maps qs_from qs_to
+
+    method set_maps new_inst_maps =
+      {< maps = new_inst_maps >}
+
+    method with_maps new_inst_maps =
+      {< maps = new_inst_maps >}, maps
+
+    method! typ = fun t ->
+      o, fst ((renaming_type_visitor maps)#typ t)
+
+    method! type_row = fun r ->
+      o, fst ((renaming_type_visitor maps)#row r)
+
+    method! type_field_spec = fun fs ->
+      o, fst ((renaming_type_visitor maps)#field_spec fs)
+
+    method! tyvar = fun q -> (o,q)
+
+    method! bindingnode : bindingnode -> ('self_type * bindingnode) =
+      function
+      | Val (pat, (tyvars, phrase), loc, signature) ->
+         (* Invariant: both signature and pat use quantifiers identical to
+            tyvars.  If this invariant is ever to be changed then type variable
+            shadowing needs to be done separately for pat and signature. *)
+          let maps = shadow_vars maps tyvars in
+
+          let o, old_maps   = o#with_maps maps in
+          let o, pat'       = o#pattern pat in
+          let o, phrase'    = o#phrase phrase in
+          let o, loc'       = o#location loc in
+          let o, signature' = o#option (fun o -> o#datatype') signature in
+          let o             = o#set_maps old_maps in
+          o, (Val ((pat', (tyvars, phrase'), loc', signature')))
+      | other -> super#bindingnode other
+
+
+   method! function_definition :
+           function_definition -> 'self * function_definition
+     = fun { fun_binder
+           ; fun_linearity
+           ; fun_definition = (tyvars, (pats, body))
+           ; fun_location
+           ; fun_signature
+           ; fun_frozen
+           ; fun_unsafe_signature } ->
+     let o, (pats', tyvars', typ', _, signature', body') =
+       o#handle_function pats tyvars (Binder.to_type fun_binder) None
+                         fun_signature body in
+     let function_definition' =
+       { fun_binder = Binder.set_type fun_binder typ'
+       ; fun_linearity
+       ; fun_definition = (tyvars', (pats', body'))
+       ; fun_location
+       ; fun_signature = signature'
+       ; fun_frozen
+       ; fun_unsafe_signature } in
+     o, function_definition'
+
+
+     method! recursive_functionnode :
+             recursive_functionnode -> 'self * recursive_functionnode
+       = fun { rec_binder
+             ; rec_linearity
+             ; rec_definition = ((tyvars, ty), (pats, body))
+             ; rec_location
+             ; rec_signature
+             ; rec_unsafe_signature
+             ; rec_frozen } ->
+       let o, (pats', tyvars', typ', ty', signature', body') =
+         o#handle_function pats tyvars (Binder.to_type rec_binder) ty
+                           rec_signature body in
+       let recursive_definition' =
+         { rec_binder = Binder.set_type rec_binder typ'
+         ; rec_linearity
+         ; rec_definition = ((tyvars', ty'), (pats', body'))
+         ; rec_location
+         ; rec_signature = signature'
+         ; rec_unsafe_signature
+         ; rec_frozen } in
+       o, recursive_definition'
+
+
+     method pattern_list (obj : 'self_type) (pats : Pattern.with_pos list)
+            : 'self_type * Pattern.with_pos list =
+       obj#list (fun obj' pat -> obj'#pattern pat) pats
+
+
+     method handle_function = fun param_pats tyvars typ ty signature phrase ->
+      (* Invariant: both signature, typ and param_pats use quantifiers identical
+         to tyvars.  If this invariant is ever to be changed then type variable
+         shadowing needs to be done separately for pat and signature. *)
+      let maps = shadow_vars maps tyvars in
+      let o, old_maps    = o#with_maps maps in
+      let _, param_pats' = o#list o#pattern_list param_pats in
+      let typ', _        = (renaming_type_visitor maps)#typ typ in
+      let o, ty'         = o#option (fun o (ty, x) -> o, (snd (o#typ ty), x)) ty in
+      let o, phrase'     = o#phrase phrase in
+      let o, signature'  = o#option (fun o -> o#datatype') signature in
+      let o              = o#set_maps old_maps in
+      o, (param_pats', tyvars, typ', ty', signature', phrase')
+
+     method forall = function
+       | `ForAll (qs_from', t) ->
+          assert (List.length qs_from' = List.length qs_to);
+          let _, t' = o#typ t in
+          `ForAll (qs_to, t')
+       | t -> snd (o#typ t)
+
+    end
+
+let rename_function_definition : function_definition -> function_definition =
+  fun { fun_binder
+      ; fun_linearity
+      ; fun_definition = (qs_from, (pats, body))
+      ; fun_location
+      ; fun_signature
+      ; fun_frozen
+      ; fun_unsafe_signature } ->
+  let qs_to, _      = Instantiate.build_fresh_quantifiers qs_from in
+  let o             = renamer qs_from qs_to in
+  let typ'          = o#forall (Binder.to_type fun_binder) in
+  let _, pats'      = List.split (List.map (o#pattern_list o) pats) in
+  let _, body'      = o#phrase body in
+  let _, signature' = o#option (fun o -> o#datatype') fun_signature in
+  { fun_binder =  Binder.set_type fun_binder typ'
+  ; fun_linearity
+  ; fun_definition = (qs_to, (pats', body'))
+  ; fun_location
+  ; fun_signature = signature'
+  ; fun_frozen
+  ; fun_unsafe_signature }
+
+
+let rename_recursive_functionnode :
+      recursive_functionnode -> recursive_functionnode =
+  fun { rec_binder
+      ; rec_linearity
+      ; rec_definition = ((qs_from, ty), (pats, body))
+      ; rec_location
+      ; rec_signature
+      ; rec_frozen
+      ; rec_unsafe_signature } ->
+  let qs_to, _      = Instantiate.build_fresh_quantifiers qs_from in
+  let o             = renamer qs_from qs_to in
+  let typ'          = o#forall (Binder.to_type rec_binder) in
+  let _, pats'      = List.split (List.map (o#pattern_list o) pats) in
+  let _, ty'        = o#option (fun o (ty, x) -> o, (o#forall ty, x)) ty in
+  let _, body'      = o#phrase body in
+  let _, signature' = o#option (fun o -> o#datatype') rec_signature in
+  { rec_binder =  Binder.set_type rec_binder typ'
+  ; rec_linearity
+  ; rec_definition = ((qs_to, ty'), (pats', body'))
+  ; rec_location
+  ; rec_signature = signature'
+  ; rec_frozen
+  ; rec_unsafe_signature }

--- a/core/renamer.mli
+++ b/core/renamer.mli
@@ -1,0 +1,4 @@
+open Sugartypes
+
+val rename_function_definition    : function_definition    -> function_definition
+val rename_recursive_functionnode : recursive_functionnode -> recursive_functionnode

--- a/core/sugarTraversals.mli
+++ b/core/sugarTraversals.mli
@@ -221,7 +221,12 @@ object ('self)
   method freedom         : Freedom.t -> 'self * Freedom.t
   method type_variable   : type_variable -> 'self * type_variable
   method known_type_variable : known_type_variable -> 'self * known_type_variable
+  method typ             : Types.datatype -> ('self * Types.datatype)
+  method type_row        : Types.row -> ('self* Types.row)
   method type_arg        : Datatype.type_arg -> 'self * Datatype.type_arg
+  method tyvar           : Quantifier.t -> ('self * Quantifier.t)
+  method type_field_spec : Types.field_spec -> ('self * Types.field_spec)
+  method tyarg           : Types.type_arg -> ('self * Types.type_arg)
   method tyunary_op      : tyarg list * UnaryOp.t -> 'self * (tyarg list * UnaryOp.t)
   method unary_op        : UnaryOp.t -> 'self * UnaryOp.t
   method function_definition : function_definition -> 'self * function_definition

--- a/core/sugartoir.ml
+++ b/core/sugartoir.ml
@@ -795,8 +795,8 @@ struct
         let open Sugartypes in
         match e with
           | Constant c -> cofv (I.constant c)
-          | Var x -> cofv (I.var (lookup_name_and_type x env))
-          | FreezeVar x -> cofv (I.var (lookup_name_and_type x env))
+          | Var x -> cofv (lookup_var x)
+          | FreezeVar x -> cofv (lookup_var x)
           | RangeLit (low, high) ->
               I.apply (instantiate_mb "intRange", [ev low; ev high])
           | ListLit ([], Some t) ->

--- a/core/transformSugar.ml
+++ b/core/transformSugar.ml
@@ -164,6 +164,9 @@ class transform (env : Types.typing_environment) =
     method bind_tycon name tycon =
       {< tycon_env = TyEnv.bind name tycon tycon_env >}
 
+    method bind_binder bndr =
+      {< var_env = TyEnv.bind (Binder.to_name bndr)  (Binder.to_type bndr) var_env >}
+
     method lookup_type : Name.t -> Types.datatype = fun var ->
       TyEnv.find var var_env
 

--- a/core/transformSugar.mli
+++ b/core/transformSugar.mli
@@ -45,6 +45,7 @@ object ('self)
   method with_formlet_env : Types.environment -> 'self
 
   method bind_tycon      : string -> Types.tycon_spec -> 'self
+  method bind_binder     : Binder.with_pos -> 'self
 
   method lookup_type     : Name.t -> Types.datatype
   method lookup_effects  : Types.row

--- a/core/typeSugar.ml
+++ b/core/typeSugar.ml
@@ -4188,12 +4188,16 @@ and type_binding : context -> binding -> binding * context * Usage.t =
             {empty_context with
               var_env = penv},
             usage
-      | Fun { fun_binder = bndr; fun_linearity = lin;
-              fun_definition = (_, (pats, body));
-              fun_location;
-              fun_signature = t_ann';
-              fun_frozen;
-              fun_unsafe_signature = unsafe } ->
+      | Fun def ->
+         let { fun_binder = bndr;
+               fun_linearity = lin;
+               fun_definition = (_, (pats, body));
+               fun_location;
+               fun_signature = t_ann';
+               fun_frozen;
+               fun_unsafe_signature = unsafe } =
+           Renamer.rename_function_definition def in
+
           let name = Binder.to_name bndr in
           let vs = name :: check_for_duplicate_names pos (List.flatten pats) in
           let pats = List.map (List.map tpc) pats in
@@ -4345,6 +4349,9 @@ and type_binding : context -> binding -> binding * context * Usage.t =
             manifests on encountering a recursive reference to a
             recursive function (which we track using the rec_vars
             component of context) *)
+          let defs =
+            List.map (WithPos.map ~f:Renamer.rename_recursive_functionnode) defs in
+
           let fresh_tame () = Types.make_empty_open_row default_effect_subkind in
           (* let fresh_wild () = Types.make_singleton_open_row ("wild", (`Present Types.unit_type)) (lin_any, res_any) in *)
 

--- a/core/types.ml
+++ b/core/types.ml
@@ -2349,7 +2349,7 @@ let extend_typing_environment
   ; effect_row = er
   ; desugared  = dr }
 
-let string_of_environment = show_environment
+let string_of_environment env = show_environment (Env.map DecycleTypes.datatype env)
 
 let string_of_typing_environment { var_env = env; _ }
   = string_of_environment env

--- a/core/types.mli
+++ b/core/types.mli
@@ -226,6 +226,7 @@ val make_type_variable : int -> Subkind.t -> datatype
 val make_rigid_type_variable : int -> Subkind.t -> datatype
 val make_row_variable : int -> Subkind.t -> row_var
 val make_rigid_row_variable : int -> Subkind.t -> row_var
+val make_rigid_presence_variable : int -> Subkind.t -> field_spec
 
 (** fresh type variable generation *)
 val fresh_type_variable : Subkind.t -> datatype

--- a/tests/typed_ir.tests
+++ b/tests/typed_ir.tests
@@ -2,21 +2,25 @@
 config: tests/typed_ir.tests.config
 ---
 
-Anonymous constant function
+Anonymous constant function (#693)
 fun (x) {1}
-stdout : fun : (_::(Unl,Mono)) -> Int
+stdout : fun : forall a,b::Row.(a) -b-> Int
 
-Anonymous identity function
+Anonymous identity function (#693)
 fun (x) {x}
-stdout : fun : (a::(Any,Mono)) -> a::(Any,Mono)
+stdout : fun : forall a::(Any,Any),b::Row.(a::Any) -b-> a::Any
 
-Anonymous composition function
+Anonymous composition function (#693)
 fun (f,g) {fun (x){f (g(x))}}
-stdout : fun : ((a::(Any,Mono)) -b-> c::(Any,Mono), (d::(Any,Mono)) -b-> a::(Any,Mono)) -> (d::(Any,Mono)) -b-> c::(Any,Mono)
+stdout : fun : forall a::(Any,Any),b::Row,c::(Any,Any),d::(Any,Any),e::Row.((a::Any) -b-> c::Any, (d::Any) -b-> a::Any) -e-> (d::Any) -b-> c::Any
 
-XML typing
+Anonymous application function (#693)
+fun (f) {fun (x){f (x)}}
+stdout : fun : forall a::(Any,Any),b::Row,c::(Any,Any),d::Row.((a::Any) -b-> c::Any) -d-> (a::Any) -b-> c::Any
+
+XML typing (#693)
 fun (x) {<a>{x}</a>}
-stdout : fun : (Xml) -> Xml
+stdout : fun : forall a::Row.(Xml) -a-> Xml
 
 ConcatMap (#368)
 tests/typed_ir/T368.links
@@ -27,3 +31,13 @@ Quantifiers on let-bound values (#620)
 tests/typed_ir/T620.links
 filemode : true
 stdout : () : ()
+
+Bound quantifiers in `and` and `all` (#692)
+tests/typed_ir/T692.links
+filemode : true
+stdout : () : ()
+
+Bound quantifiers in a query (#694)
+tests/typed_ir/T694.links
+filemode : true
+stdout : fun : forall a::Row,b::Row(Any,Base).() -a-> [(|b::(Any,Base))]

--- a/tests/typed_ir.tests.config
+++ b/tests/typed_ir.tests.config
@@ -1,4 +1,6 @@
 typecheck_ir=true
 fail_on_ir_type_error=true
 prelude=tests/empty_prelude.links
-generalise_toplevel=false
+generalise_toplevel=true
+show_quantifiers=true
+recheck_frontend_transformations=true

--- a/tests/typed_ir/T692.links
+++ b/tests/typed_ir/T692.links
@@ -1,0 +1,10 @@
+fun all(p, l) {
+   switch (l) {
+     case []    -> true
+     case x::xs -> p(x) && all(p, xs)
+   }
+}
+
+fun and(l) {
+  all(fun(x) { x }, l)
+}

--- a/tests/typed_ir/T694.links
+++ b/tests/typed_ir/T694.links
@@ -1,0 +1,8 @@
+fun concatMap(f, l) {
+  switch (l) {
+    case [] -> []
+    case hd::tl -> f(hd) ++ concatMap(f, tl)
+  }
+}
+
+fun () {query {[]}}

--- a/tests/variants.tests
+++ b/tests/variants.tests
@@ -98,7 +98,7 @@ stdout : 2 : Int
 
 Closure at top-level (issue #422) [2]
 switch(Foo(fun(x) { x })) { case Foo(id) -> fun(x) { id(x) } }
-stdout : fun : (a::(Any,Mono)) -> a::(Any,Mono)
+stdout : fun : (a::Any) -> a::Any
 
 Constructor names with primes (1)
 Foo'


### PR DESCRIPTION
Primary goal of this patch is to fix "Unbound type variable" errors in the IR and also restore fix for #534, which for some reason got reverted during FreezeML implementation. This PR is marked as draft - see below for details.

In addition, this patch includes a renamer for type variables in terms (+ fallout changes in `SugarTraversals`) implemented by @frank-emirch (originally as #771). This renamer allows to fix type variable escapes check (#678), which didn't work as expected in some settings.

@frank-emrich: I made various modifications to the interfaces of the renamer but the core renaming code remains unchanged. In particular:
 
  * the renamer is now in `renamer.ml`

  * `replace_quantifiers` is now `build_instantiation_maps` and uses an optional argument for an initial map

  * `freshen_quantifiers` is now `freshen_and_build_instantiation_maps` and relies on `build_instantiation_maps` as well as `initialize.ml` (the latter was slightly refactored)

  * **Question**: previously `unknown` method in refresher would raise an exception instead of being a no-op (default implementation in `super`). Why? This exception really gets raised when using the renamer but using the default `super` implementation behaves as expected.

  * **Question**: instead of `rename_phrase` there is now `rename_phrase`, which is essentially the same except that it calls `funlit` method instead of `phrase` method.  Is there a way to write a polymorphic function that would invoke a method from the `renamer` depending on the type of the argument? Otheriwse we might be forced to write a dozen of entry points, each for a different type of node.

@slindley, during our discussion this week you insisted that renaming of quantifiers and corresponding type variables happens during typechecking. I couldn't figure out how to do that and consequently this patch implements renaming during `DesugarFuns` transformations. The problem that I ran into was that although I can easily rename variables in the definitions I can't rename the use sites and this leads to mismatching effect variables. I'm not sure why that happens, I would expect that these effect variables are instantiated in a normal way and thus their names at call sites don't matter. I need to investigate this further, but if you can offer any insight here I would appreciate it.
  
Fixes #692,#693,#694.