### PR TITLE
A 'safer' dummy type.

### DIFF
--- a/core/types.ml
+++ b/core/types.ml
@@ -177,7 +177,7 @@ and type_arg =
 type session_type = (typ, row) session_type_basis
   [@@deriving show]
 
-let dummy_type = `Primitive Primitive.Int
+let dummy_type = `Not_typed
 
 let is_present =
   function


### PR DESCRIPTION
In `types.ml` the following definition `dummy_type = Primitive Int` is
used as an initial placeholder meant to be replaced later by a real
type during type dualisation.

Given that we have a "dummy" type in our type algebra, namely
`Not_typed`, it seems rather silly to use a real type instead as the
type infrastructure is set up to fail if it encounters the
`Not_typed`. Thus this minor patch changes the definition of
`dummy_type = Not_typed` which is potentially a safer placeholder
value.