### PR TITLE
Disable ocamlformat check

### DIFF
--- a/tools/rule-check
+++ b/tools/rule-check
@@ -5,6 +5,19 @@
 #
 
 RULEDIR="tools/rules"
+BLACKLIST=("ocamlformat_check")
+
+function is_blacklisted () {
+    local target="$1"
+    local script=
+    for script in ${BLACKLIST[@]}; do
+        echo "$script == $target\n" >> debug
+        if [[ "$script" == "$target" ]]; then
+            return 1
+        fi
+    done
+    return 0
+}
 
 ERRORS=0
 
@@ -12,12 +25,21 @@ for script in $(find $RULEDIR -maxdepth 1 -perm -111 -type f -not -name "*~"); d
     # Only run the script if it is under revision control.
     git ls-files --error-unmatch "$script" > /dev/null 2>&1 # Returns 1 when the file is untracked.
     if [[ $? -eq 0 ]]; then
-        echo "Running '$script'..."
-        /usr/bin/env bash $script | sed 's/^/  - /' ; test ${PIPESTATUS[0]} -eq 0
-        ret_code=$?
-        if [[ $ret_code -ne 0 ]]; then
-            ERRORS=$(($ERRORS+$ret_code))
+        # Check whether the script is blacklisted.
+        is_blacklisted $(basename "$script")
+        if [[ $? -eq 1 ]]; then
+            echo "Skipping '$script' as it is blacklisted..."
+            continue
+        else
+            echo "Running '$script'..."
+            /usr/bin/env bash "$script" | sed 's/^/  - /' ; test ${PIPESTATUS[0]} -eq 0
+            ret_code=$?
+            if [[ $ret_code -ne 0 ]]; then
+                ERRORS=$(($ERRORS+$ret_code))
+            fi
         fi
+    else
+        echo "Skipping '$script' as it is not under revision control..."
     fi
 done
 


### PR DESCRIPTION
It seems that the recent upgrade of OCamlformat 0.11 to 0.12 every
file under scrutinty fails.breaks our rule check script.

I can reproduce this problem locally on my machine. This commit is
currently empty to reproduce it on the CI.