### PR TITLE
An efficient interface for `Env`.

### DIFF
--- a/bin/driver.ml
+++ b/bin/driver.ml
@@ -130,7 +130,7 @@ module Phases = struct
       (fun name var ->
         let (datatype : string) =
           Types.string_of_datatype
-            (Env.String.lookup Lib.typing_env.Types.var_env name)
+            (Env.String.find name Lib.typing_env.Types.var_env)
         in
         Printf.fprintf oc " %d -> %s : %s\n%!" var name datatype)
       Lib.nenv

--- a/bin/repl.ml
+++ b/bin/repl.ml
@@ -125,7 +125,7 @@ let rec directives : (string * ((Context.t -> string list -> Context.t) * string
                    (Types.string_of_tycon_spec s))
                (Lib.typing_env.Types.tycon_env) ();
              StringSet.iter (fun n ->
-                 let t = Env.String.lookup Lib.type_env n in
+                 let t = Env.String.find n Lib.type_env in
                  Printf.fprintf stderr " %-16s : %s\n"
                    n (Types.string_of_datatype t))
                (Env.String.domain Lib.type_env)),
@@ -143,7 +143,7 @@ let rec directives : (string * ((Context.t -> string list -> Context.t) * string
           in
           StringSet.iter
             (fun k ->
-              let t = Env.String.lookup typeenv k in
+              let t = Env.String.find k typeenv in
               Printf.fprintf stderr " %-16s : %s\n" k
                 (Types.string_of_datatype t))
             (StringSet.diff (Env.String.domain typeenv)
@@ -158,7 +158,7 @@ let rec directives : (string * ((Context.t -> string list -> Context.t) * string
             tenv.Types.tycon_env
           in
           StringSet.iter (fun k ->
-              let s = Env.String.lookup tycon_env k in
+              let s = Env.String.find k tycon_env in
               Printf.fprintf stderr " %s = %s\n"
                 (Module_hacks.Name.prettify k)
                 (Types.string_of_tycon_spec s))
@@ -178,7 +178,7 @@ let rec directives : (string * ((Context.t -> string list -> Context.t) * string
             (fun name var () ->
               if not (Lib.is_primitive name) then
                 let ty = (Types.string_of_datatype ~policy:Types.Print.default_policy ~refresh_tyvar_names:true
-                          -<- Env.String.lookup tyenv.Types.var_env) name in
+                          -<- (fun name -> Env.String.find name tyenv.Types.var_env)) name in
                 let name =
                   if Settings.get Debug.enabled
                   then Printf.sprintf "%s(%d)" name var
@@ -226,7 +226,7 @@ let rec directives : (string * ((Context.t -> string list -> Context.t) * string
                  StringSet.iter
                    (fun id ->
                      try begin
-                         let t' = Env.String.lookup tenv id in
+                         let t' = Env.String.find id tenv in
                          let ttype = Types.string_of_datatype t' in
                          let fresh_envs = Types.make_fresh_envs t' in
                          let t' = Instantiate.datatype fresh_envs t' in
@@ -292,7 +292,7 @@ let handle previous_context current_context = function
            match Tables.lookup Tables.fun_defs var with
            | None ->
               let v = Value.Env.find var valenv in
-              let t = Env.String.lookup var_env' name in
+              let t = Env.String.find name var_env' in
               v, t
            | Some (finfo, _, None, location) ->
               let v =

--- a/core/compilePatterns.ml
+++ b/core/compilePatterns.ml
@@ -77,25 +77,25 @@ type env = nenv * tenv * Types.row * penv
 type raw_env = nenv * tenv * Types.row
 
 let bind_context var context (nenv, tenv, eff, penv) =
-  (nenv, tenv, eff, PEnv.bind penv (var, context))
+  (nenv, tenv, eff, PEnv.bind var context penv)
 
 let bind_type var t (nenv, tenv, eff, penv) =
-  (nenv, TEnv.bind tenv (var, t), eff, penv)
+  (nenv, TEnv.bind var t tenv, eff, penv)
 
 let mem_context var (_nenv, _tenv, _eff, penv) =
-  PEnv.has penv var
+  PEnv.has var penv
 
 let mem_type var (_nenv, tenv, _eff, _penv) =
-  TEnv.has tenv var
+  TEnv.has var tenv
 
 let lookup_context var (_nenv, _tenv, _eff, penv) =
-  PEnv.lookup penv var
+  PEnv.find var penv
 
 let lookup_type var (_nenv, tenv, _eff, _penv) =
-  TEnv.lookup tenv var
+  TEnv.find var tenv
 
 let lookup_name name (nenv, _tenv, _eff, _penv) =
-  NEnv.lookup nenv name
+  NEnv.find name nenv
 
 let lookup_effects (_nenv, _tenv, eff, _penv) = eff
 
@@ -109,7 +109,7 @@ let rec desugar_pattern : Types.row -> Sugartypes.Pattern.with_pos -> Pattern.t 
       let name = Sugartypes.Binder.to_name bndr in
       let t = Sugartypes.Binder.to_type bndr in
       let xb, x = Var.fresh_var (t, name, Scope.Local) in
-      xb, (NEnv.bind nenv (name, x), TEnv.bind tenv (x, t), eff)
+      xb, (NEnv.bind name x nenv, TEnv.bind x t tenv, eff)
     in
       let open Sugartypes.Pattern in
       match p with
@@ -187,7 +187,7 @@ struct
   (*   TEnv.lookup tenv var *)
 
   let lookup_name name (nenv, _tenv, _eff) =
-    NEnv.lookup nenv name
+    NEnv.find name nenv
 
   let lookup_effects (_nenv, _tenv, eff) = eff
 
@@ -223,7 +223,7 @@ struct
   (*   TEnv.lookup tenv var *)
 
   let lookup_name name (nenv, _tenv, _eff) =
-    NEnv.lookup nenv name
+    NEnv.find name nenv
 
   let lookup_effects (_nenv, _tenv, eff) = eff
 
@@ -1009,7 +1009,7 @@ let compile_handle_cases
         in
         let compiled_transformed_effect_cases =
           let dummy_var = Var.(make_local_info ->- fresh_binder ->- var_of_binder) (variant_type, "_m") in
-          let tenv = TEnv.bind tenv (dummy_var, variant_type) in
+          let tenv = TEnv.bind dummy_var variant_type tenv in
           let initial_env = (nenv, tenv, eff, PEnv.empty) in (* Need to bind raw continuation binders in tenv and nenv? *)
           match snd @@ match_cases [dummy_var] transformed_effect_clauses (fun _ -> ([], Special (Wrong comp_ty))) initial_env with
           | Case (_, clauses, _) -> clauses (* No default effect pattern *)
@@ -1069,7 +1069,7 @@ let compile_handle_cases
   let return : binder * computation =
     let (_, comp_ty, _, _) = Sugartypes.(desc.shd_types) in
     let scrutinee = Var.(make_local_info ->- fresh_binder) (comp_ty, "_return_value") in
-    let tenv = TEnv.bind tenv (Var.var_of_binder scrutinee, comp_ty) in
+    let tenv = TEnv.bind (Var.var_of_binder scrutinee) comp_ty tenv in
     let initial_env = (nenv, tenv, eff, PEnv.empty) in
     let clauses = List.map reduce_clause raw_value_clauses in
     let body = match_cases [Var.var_of_binder scrutinee] clauses (fun _ -> ([], Special (Wrong comp_ty))) initial_env in

--- a/core/defaultAliases.ml
+++ b/core/defaultAliases.ml
@@ -5,10 +5,10 @@ module AliasEnv = Env.String
 
 let alias_env : Types.tycon_environment =
   List.fold_left
-    AliasEnv.bind
+    (fun env (name, t) ->
+      AliasEnv.bind name t env)
     AliasEnv.empty
-    [
-      (* "String"  , `Alias ([], `Application (Types.list, [`Type (`Primitive Primitive.Char)])); *)
+    [ (* "String"  , `Alias ([], `Application (Types.list, [`Type (`Primitive Primitive.Char)])); *)
       "Xml"     , `Alias ([], `Application (Types.list, [`Type (`Primitive Primitive.XmlItem)]));
       "Event"   , `Abstract Types.event;
       "List"    , `Abstract Types.list;
@@ -17,5 +17,4 @@ let alias_env : Types.tycon_environment =
       "AP"      , `Abstract Types.access_point;
       "EndBang" , `Alias ([], Types.make_endbang_type);
       "Socket"  , `Abstract Types.socket;
-      "Location", `Abstract Types.spawn_location
-    ]
+      "Location", `Abstract Types.spawn_location ]

--- a/core/desugarCP.ml
+++ b/core/desugarCP.ml
@@ -38,8 +38,10 @@ object (o : 'self_type)
             let x = Binder.to_name bndr in
             let u = Binder.to_type bndr in
             let envs = o#backup_envs in
-            let venv = TyEnv.bind (TyEnv.bind (o#get_var_env ()) (x, u))
-                                  (c, s) in
+            let venv =
+              TyEnv.bind x u (o#get_var_env ())
+              |> TyEnv.bind c s
+            in
             let o = {< var_env = venv >} in
             let (o, e, t) = desugar_cp o p in
             let o = o#restore_envs envs in
@@ -56,7 +58,7 @@ object (o : 'self_type)
                  with_dummy_pos e), t
          | CPGive ((c, Some (`Output (_t, s), give_tyargs)), Some e, p) ->
             let envs = o#backup_envs in
-            let o = {< var_env = TyEnv.bind (o#get_var_env ()) (c, s) >} in
+            let o = {< var_env = TyEnv.bind c s (o#get_var_env ()) >} in
             let (o, e, _typ) = o#phrase e in
             let (o, p, t) = desugar_cp o p in
             let o = o#restore_envs envs in
@@ -72,7 +74,7 @@ object (o : 'self_type)
             let c = Binder.to_name bndr in
             let s = Binder.to_type bndr in
             let envs = o#backup_envs in
-            let o = {< var_env = TyEnv.bind (o#get_var_env ()) (c, TypeUtils.select_type label s) >} in
+            let o = {< var_env = TyEnv.bind c (TypeUtils.select_type label s) (o#get_var_env ()) >} in
             let (o, p, t) = desugar_cp o p in
             let o = o#restore_envs envs in
             o, block_node
@@ -84,7 +86,7 @@ object (o : 'self_type)
             let s = Binder.to_type bndr in
             let desugar_branch (label, p) (o, cases) =
               let envs = o#backup_envs in
-              let o = {< var_env = TyEnv.bind (o#get_var_env ()) (c, TypeUtils.choice_at label s) >} in
+              let o = {< var_env = TyEnv.bind c (TypeUtils.choice_at label s) (o#get_var_env ()) >} in
               let (o, p, t) = desugar_cp o p in
               let pat : Pattern.with_pos = with_dummy_pos (Pattern.Variant (label,
                       Some (variable_pat ~ty:(TypeUtils.choice_at label s) c))) in
@@ -105,8 +107,8 @@ object (o : 'self_type)
             let c = Binder.to_name bndr in
             let s = Binder.to_type bndr in
             let envs = o#backup_envs in
-            let (o, left, _typ) = desugar_cp {< var_env = TyEnv.bind (o#get_var_env ()) (c, s) >} left in
-            let (o, right, t) = desugar_cp {< var_env = TyEnv.bind (o#get_var_env ()) (c, Types.dual_type s) >} right in
+            let (o, left, _typ) = desugar_cp {< var_env = TyEnv.bind c s (o#get_var_env ()) >} left in
+            let (o, right, t) = desugar_cp {< var_env = TyEnv.bind c (Types.dual_type s) (o#get_var_env ()) >} right in
             let o = o#restore_envs envs in
 
             let eff_fields, eff_row, eff_closed = Types.flatten_row o#lookup_effects in

--- a/core/env.ml
+++ b/core/env.ml
@@ -1,10 +1,10 @@
-module type S =
-sig
+module type S = sig
   type name
   type 'a t
   val pp : (Format.formatter -> 'a -> unit) -> Format.formatter -> 'a t -> unit
   val show : (Format.formatter -> 'a -> unit) -> 'a t -> string
   val empty : 'a t
+  val singleton : name -> 'a -> 'a t
   val bind : name -> 'a -> 'a t -> 'a t
   val unbind : name -> 'a t -> 'a t
   val extend : 'a t -> 'a t -> 'a t
@@ -37,6 +37,7 @@ struct
   let empty = M.empty
   let bind n v env = M.add n v env
   let unbind n env = M.remove n env
+  let singleton n v = bind n v empty
   let extend = M.superimpose
   let has name env = M.mem name env
   let find name env = M.find name env

--- a/core/env.ml
+++ b/core/env.ml
@@ -5,12 +5,12 @@ sig
   val pp : (Format.formatter -> 'a -> unit) -> Format.formatter -> 'a t -> unit
   val show : (Format.formatter -> 'a -> unit) -> 'a t -> string
   val empty : 'a t
-  val bind : 'a t -> name * 'a -> 'a t
-  val unbind : 'a t -> name -> 'a t
+  val bind : name -> 'a -> 'a t -> 'a t
+  val unbind : name -> 'a t -> 'a t
   val extend : 'a t -> 'a t -> 'a t
-  val has : 'a t -> name -> bool
-  val lookup : 'a t -> name -> 'a
-  val find : 'a t -> name -> 'a option
+  val has : name -> 'a t -> bool
+  val find : name -> 'a t -> 'a
+  val find_opt : name -> 'a t -> 'a option
   module Dom : Utility.Set.S
   val domain : 'a t -> Dom.t
   val range : 'a t -> 'a list
@@ -35,12 +35,12 @@ struct
   type 'a t = 'a M.t
 
   let empty = M.empty
-  let bind env (n,v) = M.add n v env
-  let unbind env n = M.remove n env
+  let bind n v env = M.add n v env
+  let unbind n env = M.remove n env
   let extend = M.superimpose
-  let has env name = M.mem name env
-  let lookup env name = M.find name env
-  let find env name = M.lookup name env
+  let has name env = M.mem name env
+  let find name env = M.find name env
+  let find_opt name env = M.find_opt name env
   module Dom = Utility.Set.Make(Ord)
   let domain map = M.fold (fun k _ -> Dom.add k) map Dom.empty
   let range map = M.fold (fun _ v l -> v::l) map []
@@ -55,9 +55,9 @@ struct
   let complement env env' =
     fold
       (fun key value env'' ->
-        if has env key
+        if has key env
         then env''
-        else bind env'' (key, value))
+        else bind key value env'')
     env' empty
 end
 

--- a/core/env.mli
+++ b/core/env.mli
@@ -11,6 +11,9 @@ module type S = sig
   val empty : 'a t
   (** The empty environment. *)
 
+  val singleton : name -> 'a -> 'a t
+  (** Create an environment with a single entry. *)
+
   val bind : name -> 'a -> 'a t -> 'a t
   (** Extend an environment with a new entry. *)
 

--- a/core/env.mli
+++ b/core/env.mli
@@ -1,7 +1,6 @@
 (** Environments. *)
 
-module type S =
-sig
+module type S = sig
   type name
   (** The type of names. *)
 
@@ -12,24 +11,24 @@ sig
   val empty : 'a t
   (** The empty environment. *)
 
-  val bind : 'a t -> name * 'a -> 'a t
+  val bind : name -> 'a -> 'a t -> 'a t
   (** Extend an environment with a new entry. *)
 
-  val unbind : 'a t -> name -> 'a t
+  val unbind : name -> 'a t -> 'a t
   (** Remove an entry from an environment. *)
 
   val extend : 'a t -> 'a t -> 'a t
   (** Extend an environment with another.  Bindings from the right
       shadow bindings from the left. *)
 
-  val has : 'a t -> name -> bool
+  val has : name -> 'a t -> bool
   (** Whether a particular name is in an environment *)
 
-  val lookup : 'a t -> name -> 'a
+  val find : name -> 'a t -> 'a
   (** Look up a name in an environment.  Raise [NotFound name] if the
      name is not present. *)
 
-  val find : 'a t -> name -> 'a option
+  val find_opt : name -> 'a t -> 'a option
   (** Look up a name in an environment.  Return [None] if the name
       is not present. *)
 
@@ -55,6 +54,7 @@ sig
   val filter_map : (name -> 'a -> 'b option) -> 'a t -> 'b t
 
   val complement : 'a t -> 'a t -> 'a t
+  (** Computes the relative complement B \ A *)
 end
 (** Output signature of the functor {!Env.Make}. *)
 

--- a/core/instantiate.ml
+++ b/core/instantiate.ml
@@ -305,7 +305,7 @@ let instantiate : environment -> string -> type_arg list * datatype =
   fun env var ->
     let t =
       try
-        Env.String.lookup env var
+        Env.String.find var env
       with NotFound _ ->
         raise (Errors.UndefinedVariable ("Variable '"^ var ^ "' does not refer to a declaration"))
     in
@@ -318,7 +318,7 @@ let rigid : environment -> string -> type_arg list * datatype =
   fun env var ->
     let t =
       try
-        Env.String.lookup env var
+        Env.String.find var env
       with NotFound _ ->
         raise (Errors.UndefinedVariable ("Variable '"^ var ^ "' does not refer to a declaration"))
     in
@@ -448,7 +448,7 @@ let alias name tyargs env : Types.typ =
 
      (\Lambda x1 ... xn . t) (t1 ... tn) ~> t[ti/xi]
   *)
-  match (SEnv.find env name : Types.tycon_spec option) with
+  match (SEnv.find_opt name env : Types.tycon_spec option) with
     | None ->
         raise (internal_error (Printf.sprintf "Unrecognised type constructor: %s" name))
     | Some (`Abstract _)

--- a/core/irTraversals.ml
+++ b/core/irTraversals.ml
@@ -79,7 +79,7 @@ struct
     (* val cenv = Env.empty *)
 
     method lookup_type : var -> datatype = fun var ->
-      Env.lookup tyenv var
+      Env.find var tyenv
 
     (* method private lookup_closure_type : var -> datatype = fun var -> *)
     (*   Env.lookup cenv var *)
@@ -497,7 +497,7 @@ struct
 
     method binder : binder -> (binder * 'self_type) =
       fun (var, info) ->
-        let tyenv = Env.bind tyenv (var, info_type info) in
+        let tyenv = Env.bind var (info_type info) tyenv in
           (var, info), {< tyenv=tyenv >}
 
     method program : program -> (program * datatype * 'self_type) = o#computation

--- a/core/irtojs.ml
+++ b/core/irtojs.ml
@@ -627,7 +627,7 @@ end = functor (K : CONTINUATION) -> struct
        end
     | Variable var ->
           (* HACK *)
-       let name = VEnv.lookup env var in
+       let name = VEnv.find var env in
        if Arithmetic.is name then
          Fn (["x"; "y"; __kappa],
              K.apply (K.reflect (Var __kappa))
@@ -675,7 +675,7 @@ end = functor (K : CONTINUATION) -> struct
        begin
          match f with
          | Variable f ->
-            let f_name = VEnv.lookup env f in
+            let f_name = VEnv.find f env in
             begin
               match vs with
               | [l; r] when Arithmetic.is f_name ->
@@ -828,7 +828,7 @@ end = functor (K : CONTINUATION) -> struct
          begin
            match f with
            | Variable f ->
-              let f_name = VEnv.lookup env f in
+              let f_name = VEnv.find f env in
               begin
                 match vs with
                 | [l; r] when Arithmetic.is f_name ->
@@ -873,7 +873,7 @@ end = functor (K : CONTINUATION) -> struct
            (fun kappa ->
              let gen_cont (xb, c) =
                let (x, x_name) = name_binder xb in
-               x_name, (snd (generate_computation (VEnv.bind env (x, x_name)) c kappa)) in
+               x_name, (snd (generate_computation (VEnv.bind x x_name env) c kappa)) in
              let cases = StringMap.map gen_cont cases in
              let default = opt_map gen_cont default in
              k (Case (x, cases, default)))
@@ -925,7 +925,7 @@ end = functor (K : CONTINUATION) -> struct
              let channel = Call (Var "LINKS.project", [Var result; strlit "2"]) in
              let generate_branch (cb, b) =
                let (c, cname) = name_binder cb in
-               cname, Bind (cname, channel, snd (generate_computation (VEnv.bind env (c, cname)) b K.(skappa <> kappa))) in
+               cname, Bind (cname, channel, snd (generate_computation (VEnv.bind c cname env) b K.(skappa <> kappa))) in
              let branches = StringMap.map generate_branch bs in
              Fn ([result], (Bind (received, scrutinee, (Case (received, branches, None)))))) in
 
@@ -995,8 +995,8 @@ end = functor (K : CONTINUATION) -> struct
          let vmap r y =
            Call (Var "_vmapOp", [r; y])
          in
-         let generate_body env binder body kappas =
-           let env' = VEnv.bind env binder in
+         let generate_body env (x, n) body kappas =
+           let env' = VEnv.bind x n env in
            snd (generate_computation env' body kappas)
          in
          begin match depth with
@@ -1005,9 +1005,13 @@ end = functor (K : CONTINUATION) -> struct
             let translate_parameters params =
               let is_parameterised = List.length params > 0 in
               let param_ptr_binder =
-                Var.fresh_binder (Var.make_local_info (`Not_typed, "_param_ptr"))
+                Var.fresh_binder
+                  (Var.make_local_info (`Not_typed, "_param_ptr"))
               in
-              let env = VEnv.bind env (name_binder param_ptr_binder) in
+              let env =
+                let (x, n) = name_binder param_ptr_binder in
+                VEnv.bind x n env
+              in
               let params =
                 List.mapi (fun i (binder,initial_value) -> (i, binder, initial_value)) params
               in
@@ -1057,7 +1061,10 @@ end = functor (K : CONTINUATION) -> struct
                   let s = project (Var (snd xb)) (strlit "s") in
                   make_resumption s
                 in
-                let env' = VEnv.bind env resume in
+                let env' =
+                  let (x, n) = resume in
+                  VEnv.bind x n env
+                in
                 let body = generate_body env' xb (parameterise body) kappas in
                 snd xb, Bind (snd resume, r,
                               Bind (snd xb, p, body))
@@ -1115,7 +1122,7 @@ end = functor (K : CONTINUATION) -> struct
           function
           | Ir.Let (b, (_, Ir.Return v)) :: bs ->
              let (x, x_name) = name_binder b in
-             let env', rest = gbs (VEnv.bind env (x, x_name)) kappa bs in
+             let env', rest = gbs (VEnv.bind x x_name env) kappa bs in
              (env', Bind (x_name, generate_value env v, rest))
           | Let (b, (_, tc)) :: bs ->
              let (x, x_name) = name_binder b in
@@ -1123,18 +1130,18 @@ end = functor (K : CONTINUATION) -> struct
              let env',skappa' =
                K.contify_with_env
                  (fun kappas ->
-                   let env', body = gbs (VEnv.bind env (x, x_name)) K.(skappa <> kappas) bs in
+                   let env', body = gbs (VEnv.bind x x_name env) K.(skappa <> kappas) bs in
                    env', Fn ([x_name], body))
              in
              env', bind (generate_tail_computation env tc K.(skappa' <> skappas))
           | Fun ((fb, _, _zs, _location) as def) :: bs ->
              let (f, f_name) = name_binder fb in
              let def_header = generate_function env [] def in
-             let env', rest = gbs (VEnv.bind env (f, f_name)) kappa bs in
+             let env', rest = gbs (VEnv.bind f f_name env) kappa bs in
              (env', LetFun (def_header, rest))
           | Rec defs :: bs ->
              let fs = List.map (fun (fb, _, _, _) -> name_binder fb) defs in
-             let env', rest = gbs (List.fold_left VEnv.bind env fs) kappa bs in
+             let env', rest = gbs (List.fold_left (fun env (x, n) -> VEnv.bind x n env) env fs) kappa bs in
              (env', LetRec (List.map (generate_function env fs) defs, rest))
           | Module _ :: bs
           | Alien _ :: bs -> gbs env kappa bs
@@ -1157,7 +1164,12 @@ end = functor (K : CONTINUATION) -> struct
       in
       let bs = List.map name_binder xsb in
       let _xs, xs_names = List.split bs in
-      let body_env = List.fold_left VEnv.bind env (fs @ bs) in
+      let body_env =
+        List.fold_left
+          (fun env (n, x) -> VEnv.bind n x env)
+          env
+          (fs @ bs)
+      in
       let body =
         match location with
         | Location.Client | Location.Unknown ->
@@ -1180,7 +1192,7 @@ end = functor (K : CONTINUATION) -> struct
     let affected_variables =
        VariableInspection.get_affected_variables (K.reify kappa) in
     (* Bind affected variables array to a fresh variable *)
-    let env = VEnv.bind env (fresh_var, affected_vars_name) in
+    let env = VEnv.bind fresh_var affected_vars_name env in
     (* Compile raise operation WRT reflected, bound continuation *)
     let raiseOp =
       generate_special env (DoOperation (
@@ -1207,7 +1219,7 @@ end = functor (K : CONTINUATION) -> struct
       | Let (b, _) ->
          let (x, x_name) = name_binder b in
       (* Debug.print ("let_binding: " ^ x_name); *)
-         let varenv = VEnv.bind varenv (x, x_name) in
+         let varenv = VEnv.bind x x_name varenv in
          let value = Value.Env.find x valenv in
          let jsonized_val = Json.jsonize_value value |> Json.json_to_string in
          let state = ResolveJsonState.add_value_information value state in
@@ -1217,7 +1229,7 @@ end = functor (K : CONTINUATION) -> struct
           fun code -> Bind (x_name, Lit jsonized_val, code))
       | Fun ((fb, _, _zs, _location) as def) ->
          let (f, f_name) = name_binder fb in
-         let varenv = VEnv.bind varenv (f, f_name) in
+         let varenv = VEnv.bind f f_name varenv in
          let def_header = generate_function varenv [] def in
          (state,
           varenv,
@@ -1225,11 +1237,15 @@ end = functor (K : CONTINUATION) -> struct
           fun code -> LetFun (def_header, code))
       | Rec defs ->
          let fs = List.map (fun (fb, _, _, _) -> name_binder fb) defs in
-         let varenv = List.fold_left VEnv.bind varenv fs in
+         let varenv =
+           List.fold_left
+             (fun env (n, x) -> VEnv.bind n x env)
+             varenv fs
+         in
          (state, varenv, None, fun code -> LetRec (List.map (generate_function varenv fs) defs, code))
       | Alien (bnd, raw_name, _lang) ->
         let (a, _a_name) = name_binder bnd in
-        let varenv = VEnv.bind varenv (a, raw_name) in
+        let varenv = VEnv.bind a raw_name varenv in
         state, varenv, None, (fun code -> code)
       | Module _ -> state, varenv, None, (fun code -> code)
 

--- a/core/lens_ir_conv.ml
+++ b/core/lens_ir_conv.ml
@@ -99,7 +99,7 @@ module Env = struct
     match lookup_fun (var, None) with
     | Some v -> v
     | None -> (
-      match (Value.Env.lookup var val_env, LEnv.Int.find exp_env var) with
+      match (Value.Env.lookup var val_env, LEnv.Int.find_opt var exp_env) with
       | None, Some v -> v
       | Some v, None -> expression_of_value v
       | Some _, Some v -> v (*eval_error "Variable %d bound twice" var*)
@@ -109,7 +109,7 @@ module Env = struct
           raise (internal_error (Format.sprintf "Variable %d not found" var)) )
       )
 
-  let bind (val_env, exp_env) (x, v) = (val_env, Env.Int.bind exp_env (x, v))
+  let bind (val_env, exp_env) (x, v) = (val_env, Env.Int.bind x v exp_env)
 end
 
 module Of_ir_error = struct

--- a/core/page.ml
+++ b/core/page.ml
@@ -30,25 +30,24 @@ module Make_RealPage (C : JS_PAGE_COMPILER) (G : JS_CODEGEN) = struct
      *)
     let tyenv =
       {Types.var_env =
-          Env.String.bind
-            (Env.String.bind tyenv.Types.var_env
-               ("ConcatMap", dt "((a) -> [b], [a]) -> [b]"))
-            ("stringifyB64", dt "(a) -> String");
+         (Env.String.bind "stringifyB64" (dt "(a) -> String") tyenv.Types.var_env
+          |> Env.String.bind "ConcatMap" (dt "((a) -> [b], [a]) -> [b]"));
        Types.rec_vars = StringSet.empty;
        Types.tycon_env = tyenv.Types.tycon_env;
        Types.effect_row = tyenv.Types.effect_row;
        Types.desugared = tyenv.Types.desugared } in
     let nenv =
-      Env.String.bind
-        (Env.String.bind nenv
-           ("ConcatMap", Var.fresh_raw_var ()))
-        ("stringifyB64", Var.fresh_raw_var ()) in
+      Env.String.bind "ConcatMap" (Var.fresh_raw_var ()) nenv
+      |>  Env.String.bind "stringifyB64" (Var.fresh_raw_var ())
+
+    in
 
     let venv =
       Env.String.fold
-        (fun name v venv -> VEnv.bind venv (v, name))
+        (fun name v venv -> VEnv.bind v name venv)
         nenv
-        VEnv.empty in
+        VEnv.empty
+    in
     let tenv = Var.varify_env (nenv, tyenv.Types.var_env) in
     (nenv, venv, tenv)
 

--- a/core/transformSugar.ml
+++ b/core/transformSugar.ml
@@ -15,8 +15,8 @@ let internal_error message =
 
 let type_section env =
   let open Section in function
-  | Minus -> TyEnv.lookup env "-"
-  | FloatMinus -> TyEnv.lookup env "-."
+  | Minus -> TyEnv.find "-" env
+  | FloatMinus -> TyEnv.find "-."env
   | Project label ->
       let ab, a = Types.fresh_type_quantifier (lin_any, res_any) in
       let rhob, (fields, rho, _) = Types.fresh_row_quantifier (lin_any, res_any) in
@@ -25,19 +25,19 @@ let type_section env =
       let r = `Record (StringMap.add label (`Present a) fields, rho, false) in
         `ForAll ([ab; rhob; eb],
                  `Function (Types.make_tuple_type [r], e, a))
-  | Name var -> TyEnv.lookup env var
+  | Name var -> TyEnv.find var env
 
 let type_unary_op env tycon_env =
   let datatype = DesugarDatatypes.read ~aliases:tycon_env in function
     | UnaryOp.Minus      -> datatype "(Int) -> Int"
     | UnaryOp.FloatMinus -> datatype "(Float) -> Float"
-    | UnaryOp.Name n     -> TyEnv.lookup env n
+    | UnaryOp.Name n     -> TyEnv.find n env
 
 let type_binary_op env tycon_env =
   let open BinaryOp in
   let datatype = DesugarDatatypes.read ~aliases:tycon_env in function
-  | Minus        -> TyEnv.lookup env "-"
-  | FloatMinus   -> TyEnv.lookup env "-."
+  | Minus        -> TyEnv.find "-" env
+  | FloatMinus   -> TyEnv.find "-." env
   | RegexMatch flags ->
       let nativep  = List.exists ((=) RegexNative)  flags
       and listp    = List.exists ((=) RegexList)    flags
@@ -50,8 +50,8 @@ let type_binary_op env tycon_env =
 
   | And
   | Or           -> datatype "(Bool,Bool) -> Bool"
-  | Cons         -> TyEnv.lookup env "Cons"
-  | Name "++"    -> TyEnv.lookup env "Concat"
+  | Cons         -> TyEnv.find "Cons" env
+  | Name "++"    -> TyEnv.find "Concat" env
   | Name ">"
   | Name ">="
   | Name "=="
@@ -63,8 +63,8 @@ let type_binary_op env tycon_env =
         `ForAll ([ab; eb],
                  `Function (Types.make_tuple_type [a; a], e,
                             `Primitive Primitive.Bool))
-  | Name "!"     -> TyEnv.lookup env "Send"
-  | Name n       -> TyEnv.lookup env n
+  | Name "!"     -> TyEnv.find "Send" env
+  | Name n       -> TyEnv.find n env
 
 let fun_effects t pss =
   let rec get_eff =
@@ -162,10 +162,10 @@ class transform (env : Types.typing_environment) =
       {< formlet_env = formlet_env >}
 
     method bind_tycon name tycon =
-      {< tycon_env = TyEnv.bind tycon_env (name, tycon) >}
+      {< tycon_env = TyEnv.bind name tycon tycon_env >}
 
     method lookup_type : Name.t -> Types.datatype = fun var ->
-      TyEnv.lookup var_env var
+      TyEnv.find var var_env
 
     method lookup_effects : Types.row = effect_row
 
@@ -832,7 +832,7 @@ class transform (env : Types.typing_environment) =
     method binder : Binder.with_pos -> ('self_type * Binder.with_pos) =
       fun bndr ->
       assert (Binder.has_type bndr);
-      let var_env = TyEnv.bind var_env (Binder.to_name bndr, Binder.to_type bndr) in
+      let var_env = TyEnv.bind (Binder.to_name bndr) (Binder.to_type bndr) var_env in
       ({< var_env=var_env >}, bndr)
 
     method cp_phrase : cp_phrase -> ('self_type * cp_phrase * Types.datatype) =
@@ -854,14 +854,14 @@ class transform (env : Types.typing_environment) =
       | CPGrab ((c, Some (`Input (_a, s), _grab_tyargs) as cbind), Some b, p) -> (* FYI: a = u *)
          let envs = o#backup_envs in
          let (o, b) = o#binder b in
-         let venv = TyEnv.bind (o#get_var_env ()) (c, s) in
+         let venv = TyEnv.bind c s (o#get_var_env ()) in
          let o = {< var_env = venv >} in
          let (o, p, t) = o#cp_phrase p in
          let o = o#restore_envs envs in
          o, CPGrab (cbind, Some b, p), t
       | CPGive ((c, Some (`Output (_t, s), _tyargs) as cbind), e, p) ->
          let envs = o#backup_envs in
-         let o = {< var_env = TyEnv.bind (o#get_var_env ()) (c, s) >} in
+         let o = {< var_env = TyEnv.bind c s (o#get_var_env ()) >} in
          let (o, e, _typ) = option o (fun o -> o#phrase) e in
          let (o, p, t) = o#cp_phrase p in
          let o = o#restore_envs envs in
@@ -896,9 +896,9 @@ class transform (env : Types.typing_environment) =
          let c = Binder.to_name bndr in
          let s = Binder.to_type bndr in
          let envs = o#backup_envs in
-         let (o, left, _typ) = {< var_env = TyEnv.bind (o#get_var_env ()) (c, s) >}#cp_phrase left in
+         let (o, left, _typ) = {< var_env = TyEnv.bind c s (o#get_var_env ()) >}#cp_phrase left in
          let whiny_dual_type s = try Types.dual_type s with Invalid_argument _ -> raise (Invalid_argument ("Attempted to dualize non-session type " ^ Types.string_of_datatype s)) in
-         let (o, right, t) = {< var_env = TyEnv.bind (o#get_var_env ()) (c, whiny_dual_type s) >}#cp_phrase right in
+         let (o, right, t) = {< var_env = TyEnv.bind c (whiny_dual_type s) (o#get_var_env ()) >}#cp_phrase right in
          let o = o#restore_envs envs in
          o, CPComp (bndr, left, right), t
   end

--- a/core/typeSugar.ml
+++ b/core/typeSugar.ml
@@ -2074,7 +2074,7 @@ let type_pattern closed : Pattern.with_pos -> Pattern.with_pos * Types.environme
       | Variable bndr ->
         let xtype = Types.fresh_type_variable (lin_any, res_any) in
         (Variable (Binder.set_type bndr xtype),
-         Env.bind (Binder.to_name bndr) xtype Env.empty,
+         Env.singleton (Binder.to_name bndr) xtype,
          (xtype, xtype))
       | Cons (p1, p2) ->
         let p1 = tp p1
@@ -2123,7 +2123,7 @@ let type_pattern closed : Pattern.with_pos -> Pattern.with_pos * Types.environme
            | Variable bndr ->
               let xtype = fresh_resumption_type () in
               ( with_pos pos' (Variable (Binder.set_type bndr xtype))
-              , Env.bind (Binder.to_name bndr) xtype Env.empty, (xtype, xtype))
+              , Env.singleton (Binder.to_name bndr) xtype, (xtype, xtype))
            | As (bndr, pat') ->
               let p = type_resumption_pat pat' in
               let env' = Env.bind (Binder.to_name bndr) (it p) (env p) in
@@ -2251,7 +2251,7 @@ let rec pattern_env : Pattern.with_pos -> Types.datatype Env.t =
     | List ps
     | Tuple ps -> List.fold_right (pattern_env ->- Env.extend) ps Env.empty
     | Variable bndr ->
-       Env.bind (Binder.to_name bndr) (Binder.to_type bndr) Env.empty
+       Env.singleton (Binder.to_name bndr) (Binder.to_type bndr)
     | As (bndr, p) ->
        Env.bind (Binder.to_name bndr) (Binder.to_type bndr) (pattern_env p)
 
@@ -3740,7 +3740,7 @@ let rec type_check : context -> phrase -> phrase * Types.datatype * usagemap =
                              Types.make_function_type domain effs codomain
                            in
                            let env = Env.bind kname kt env in
-                           let env' = Env.bind kname kt Env.empty in
+                           let env' = Env.singleton kname kt in
                            (pat, env, effrow), (kpat, env', kt)
                         | _ -> assert false
                         end
@@ -3755,7 +3755,7 @@ let rec type_check : context -> phrase -> phrase * Types.datatype * usagemap =
                              | Some t -> t
                              | None -> assert false
                            in
-                           let env' = Env.bind kname kt Env.empty in
+                           let env' = Env.singleton kname kt in
                            (pat, env, effrow), (kpat, env', kt)
                         | Any ->
                            let kt =
@@ -4200,7 +4200,7 @@ and type_binding : context -> binding -> binding * context * usagemap =
                  fun_frozen = true;
                  fun_location; fun_signature = t_ann'; fun_unsafe_signature = unsafe },
              {empty_context with
-                var_env = Env.bind name ft Env.empty},
+                var_env = Env.singleton name ft},
              StringMap.filter (fun v _ -> not (List.mem v vs)) (usages body))
       | Funs defs ->
           (*

--- a/core/var.ml
+++ b/core/var.ml
@@ -74,6 +74,6 @@ let scope_of_binder (_, (_, _, scope) : binder) = scope
 let varify_env (nenv, tenv) : Types.datatype Env.Int.t =
   Env.String.fold
     (fun name t tenv ->
-       Env.Int.bind tenv (Env.String.lookup nenv name, t))
+       Env.Int.bind (Env.String.find name nenv) t tenv)
     tenv
     Env.Int.empty

--- a/core/webserver.ml
+++ b/core/webserver.ml
@@ -335,7 +335,7 @@ struct
       let render_cont () =
         let (_, nenv, {Types.tycon_env = tycon_env; _ }) = !env in
         let _, x = Var.fresh_global_var_of_type (Instantiate.alias "Page" [] tycon_env) in
-        let render_page = Env.String.lookup nenv "renderPage" in
+        let render_page = Env.String.find "renderPage" nenv in
         let tail = Ir.Apply (Ir.Variable render_page, [Ir.Variable x]) in
         Hashtbl.add Tables.scopes x Scope.Global;
         Hashtbl.add Tables.cont_defs x ([], tail);


### PR DESCRIPTION
This patch changes the signature of `Env.S` to allow for a more
efficient implementation of environments. For performance reasons it
changes the signature of `bind` from

```ocaml
bind : 'a t -> (name * 'a) -> 'a t
```

to

```ocaml
bind : name -> 'a -> 'a t -> 'a t
```

That is the `bind` now takes all its arguments in curried form. This
reduces the amount of necessary memory allocations by one per
invocation of `bind` (which is called a lot). For aesthetics and
coherence the data container (i.e. the environment of type `'a t`) is
now the last parameter. This aligns with the "standard" functional
APIs (e.g. `Map`) rather than the "standard" imperative APIs which
take the data container as their first argument (e.g. `Hashtbl`).
Moreover, this change also aligns the interface with `Map`, `Set`,
and `Value.Env` in our codebase.