### PR TITLE
Fix installation of `python3` on Azure Pipelines macOS image (again).

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -36,8 +36,7 @@ steps:
   - bash: |
       case $AGENT_OS in
         "Linux") sudo apt-get install ocaml python3-setuptools python3-pip;;
-        "Darwin") brew install ocaml &&
-                  brew upgrade python3;;
+        "Darwin") brew install ocaml;;
         *) exit 1 ;;
       esac
     displayName: 'System dependencies'


### PR DESCRIPTION
It seems there have been two changes to either `brew` or the macOS
version on Azure Pipelines lately. It seems that the macOS image now
ships with `python` version `3.7.5` which also appears to be the
latest version maintained by the `brew` repository that we are
using. Apparently the command `brew upgrade python` fails whenever the
installed `python` package is up-to-date.

Thus this patch simply removes the `brew upgrade python` step.