### PR TITLE
Foreign Function Interface clean up.

### DIFF
--- a/core/buildTables.ml
+++ b/core/buildTables.ml
@@ -232,9 +232,10 @@ struct
                 defs in
 
             o#close_cont (IntSet.union fvs fvs') bs
-        | Alien (f, _, _language)::bs ->
-            let fvs = IntSet.remove (Var.var_of_binder f) fvs in
-              o#close_cont fvs bs
+        | Alien { binder; _ } :: bs ->
+           let f = Var.var_of_binder binder in
+           let fvs = IntSet.remove f fvs in
+           o#close_cont fvs bs
         | Module _::_ ->
             assert false
 

--- a/core/closures.ml
+++ b/core/closures.ml
@@ -379,7 +379,8 @@ struct
     | Let (x, body) -> Let (binder x, body)
     | Fun def -> Fun (fun_def def)
     | Rec defs -> Rec (List.map fun_def defs)
-    | Alien (x, n, language) -> Alien (binder x, n, language)
+    | Alien { binder = x; object_name; language } ->
+       Alien { binder = binder x; object_name; language }
     | Module _ ->
         raise (Errors.internal_error ~filename:"closures.ml"
           ~message:"Globalisation of modules unimplemented")

--- a/core/commonTypes.ml
+++ b/core/commonTypes.ml
@@ -199,6 +199,19 @@ module Name = struct
     [@@deriving show]
 end
 
+module ForeignLanguage = struct
+  type t =
+    | JavaScript
+    [@@deriving show]
+
+  let of_string = function
+    | "javascript" -> JavaScript
+    | _ -> raise (Invalid_argument "of_string")
+
+  let to_string = function
+    | JavaScript -> "javascript"
+end
+
 module Primitive = struct
   type t = Bool | Int | Char | Float | XmlItem | DB | String
     [@@deriving show]

--- a/core/desugarAlienBlocks.ml
+++ b/core/desugarAlienBlocks.ml
@@ -38,10 +38,17 @@ object(self)
   method get_bindings = List.rev bindings
 
   method! binding = function
-    | {node=AlienBlock (lang, lib, decls); _} ->
-        self#list (fun o ((bnd, dt)) ->
-          let name = Binder.to_name bnd in
-          o#add_binding (with_dummy_pos (Foreign (bnd, name, lang, lib, dt)))) decls
+    | {node=AlienBlock alien; _} ->
+       self#list
+         (fun o ((bnd, dt)) ->
+           let alien =
+             Foreign (Alien.single
+                        (Alien.language alien)
+                        (Alien.object_file alien)
+                        bnd dt)
+           in
+           o#add_binding (with_dummy_pos alien))
+      (Alien.declarations alien)
     | {node=Module ({ members; _ } as module') ; _} ->
         let flattened_bindings =
           List.concat (

--- a/core/desugarDatatypes.ml
+++ b/core/desugarDatatypes.ml
@@ -1022,10 +1022,11 @@ object (self)
         ) alias_env desugared_mutuals in
 
         ({< alias_env = alias_env >}, Typenames desugared_mutuals)
-    | Foreign (bind, raw_name, lang, file, dt) ->
-        let _, bind = self#binder bind in
-        let dt' = Desugar.foreign alias_env dt in
-        self, Foreign (bind, raw_name, lang, file, dt')
+    | Foreign alien ->
+       let binder, datatype = Alien.declaration alien in
+       let _, binder = self#binder binder in
+       let datatype = Desugar.foreign alias_env datatype in
+       self, Foreign (Alien.modify ~declarations:[(binder, datatype)] alien)
     | b -> super#bindingnode b
 
   method! sentence =

--- a/core/errors.ml
+++ b/core/errors.ml
@@ -48,6 +48,7 @@ exception DynlinkError of string
 exception ModuleError of string * Position.t option
 exception DisabledExtension of Position.t option * (string * bool) option * string option * string
 exception PrimeAlien of Position.t
+exception ClientCallOutsideWebMode of string
 
 exception LocateFailure of string
 let driver_locate_failure driver = LocateFailure driver
@@ -180,6 +181,8 @@ let format_exception =
      pos_prefix (Printf.sprintf "Error: Cannot load plugin dependency '%s' (link error: %s)\n" file (Dynlink.error_message err))
   | LoadFailure (file, err) ->
      pos_prefix (Printf.sprintf "Error: Cannot load plugin '%s' (link error: %s)\n" file (Dynlink.error_message err))
+  | ClientCallOutsideWebMode fn ->
+     pos_prefix (Printf.sprintf "Error: Cannot call client side function '%s' outside of web mode\n" fn)
   | Sys.Break -> "Caught interrupt"
   | exn -> pos_prefix ("Error: " ^ Printexc.to_string exn)
 
@@ -209,3 +212,4 @@ let module_error ?pos message = (ModuleError (message, pos))
 let disabled_extension ?pos ?setting ?flag name =
   DisabledExtension (pos, setting, flag, name)
 let prime_alien pos = PrimeAlien pos
+let client_call_outside_webmode fn = ClientCallOutsideWebMode fn

--- a/core/errors.mli
+++ b/core/errors.mli
@@ -54,3 +54,4 @@ val driver_locate_failure : string -> exn
 val illformed_plugin_description : string -> exn
 val dependency_load_failure : string -> Dynlink.error -> exn
 val load_failure : string -> Dynlink.error -> exn
+val client_call_outside_webmode : string -> exn

--- a/core/evalir.ml
+++ b/core/evalir.ml
@@ -131,7 +131,7 @@ struct
 
        fun req_data name cont args ->
          if not(Settings.get Basicsettings.web_mode) then
-           raise (internal_error "Can't make client call outside web mode.");
+           raise (Errors.client_call_outside_webmode name);
          (*if not(Proc.singlethreaded()) then
            raise (internal_error "Remaining procs on server at client call!"); *)
          Debug.print("Making client call to " ^ name);
@@ -537,7 +537,7 @@ struct
        eval_error "Continuation applied to multiple (or zero) arguments"
     | `Resumption r, vs ->
        resume env cont r vs
-    | `Alien, _ -> eval_error "Can't make alien call on the server.";
+    | `Alien, _ -> eval_error "Cannot make alien call on the server.";
     | v, _ -> type_error ~action:"apply" "function" v
   and resume env (cont : continuation) (r : resumption) vs =
     Proc.yield (fun () -> K.Eval.resume ~env cont r vs)
@@ -548,22 +548,25 @@ struct
   and computation env (cont : continuation) (bindings, tailcomp) : result =
     match bindings with
       | [] -> tail_computation env cont tailcomp
-      | b::bs -> match b with
-        | Let ((var, _) as b, (_, tc)) ->
-           let locals = Value.Env.localise env var in
-           let cont' =
-             K.(let frame = Frame.make (Var.scope_of_binder b) var locals (bs, tailcomp) in
-                frame &> cont)
-           in
-           tail_computation env cont' tc
-        (* function definitions are stored in the global fun map *)
-        | Fun _ ->
-          computation env cont (bs, tailcomp)
-        | Rec _ ->
-          computation env cont (bs, tailcomp)
-        | Alien ((var, _) as b, _, _) ->
-          computation (Value.Env.bind var (`Alien, Var.scope_of_binder b) env) cont (bs, tailcomp)
-        | Module _ -> raise (internal_error "Not implemented interpretation of modules yet")
+      | b::bs ->
+         match b with
+         | Let ((var, _) as b, (_, tc)) ->
+            let locals = Value.Env.localise env var in
+            let cont' =
+              K.(let frame = Frame.make (Var.scope_of_binder b) var locals (bs, tailcomp) in
+                 frame &> cont)
+            in
+            tail_computation env cont' tc
+         (* function definitions are stored in the global fun map *)
+         | Fun _ ->
+            computation env cont (bs, tailcomp)
+         | Rec _ ->
+            computation env cont (bs, tailcomp)
+         | Alien { binder; _ } ->
+            let var = Var.var_of_binder binder in
+            let scope = Var.scope_of_binder binder in
+            computation (Value.Env.bind var (`Alien, scope) env) cont (bs, tailcomp)
+         | Module _ -> raise (internal_error "Not implemented interpretation of modules yet")
   and tail_computation env (cont : continuation) : Ir.tail_computation -> result = function
     | Ir.Return v   -> apply_cont cont env (value env v)
     | Apply (f, ps) -> apply cont env (value env f, List.map (value env) ps)

--- a/core/ir.ml
+++ b/core/ir.ml
@@ -63,7 +63,7 @@ and binding =
   | Let        of binder * (tyvar list * tail_computation)
   | Fun        of fun_def
   | Rec        of fun_def list
-  | Alien      of binder * Name.t * language
+  | Alien      of binder * string * ForeignLanguage.t
   | Module     of string * binding list option
 and special =
   | Wrong      of Types.datatype

--- a/core/ir.ml
+++ b/core/ir.ml
@@ -63,7 +63,9 @@ and binding =
   | Let        of binder * (tyvar list * tail_computation)
   | Fun        of fun_def
   | Rec        of fun_def list
-  | Alien      of binder * string * ForeignLanguage.t
+  | Alien      of { binder: binder;
+                    language: ForeignLanguage.t;
+                    object_name: string }
   | Module     of string * binding list option
 and special =
   | Wrong      of Types.datatype
@@ -103,7 +105,7 @@ let binding_scope : binding -> scope =
   | Let (b, _)
   | Fun (b, _, _, _)
   | Rec ((b, _, _, _)::_)
-  | Alien (b, _, _) -> Var.scope_of_binder b
+  | Alien { binder = b; _ } -> Var.scope_of_binder b
   | Rec []
   | Module _ -> assert false
 

--- a/core/ir.mli
+++ b/core/ir.mli
@@ -64,7 +64,9 @@ and binding =
   | Let        of binder * (tyvar list * tail_computation)
   | Fun        of fun_def
   | Rec        of fun_def list
-  | Alien      of binder * string * ForeignLanguage.t
+  | Alien      of { binder: binder;
+                    language: ForeignLanguage.t;
+                    object_name: string }
   | Module     of string * binding list option
 and special =
   | Wrong      of Types.datatype

--- a/core/ir.mli
+++ b/core/ir.mli
@@ -64,7 +64,7 @@ and binding =
   | Let        of binder * (tyvar list * tail_computation)
   | Fun        of fun_def
   | Rec        of fun_def list
-  | Alien      of binder * Name.t * language
+  | Alien      of binder * string * ForeignLanguage.t
   | Module     of string * binding list option
 and special =
   | Wrong      of Types.datatype

--- a/core/irCheck.ml
+++ b/core/irCheck.ml
@@ -1231,9 +1231,9 @@ struct
             Rec defs, o
 
 
-        | Alien (x, name, language) ->
-            let x, o = o#binder x in
-              Alien (x, name, language), o
+        | Alien { binder; object_name; language } ->
+           let x, o = o#binder binder in
+           Alien { binder = x; object_name; language }, o
 
         | Module (name, defs) ->
             let defs, o =
@@ -1273,7 +1273,7 @@ struct
                   o#remove_function_closure_binder f)
                 o
                 fundefs
-      | Alien (binder, _, _) -> o#remove_binder binder
+      | Alien { binder; _ } -> o#remove_binder binder
       | Module _ -> o
 
     method remove_bindings : binding list -> 'self_type =

--- a/core/irTraversals.ml
+++ b/core/irTraversals.ml
@@ -481,9 +481,9 @@ struct
                 defs in
             let defs = List.rev defs in
               Rec defs, o
-        | Alien (x, name, language) ->
-            let x, o = o#binder x in
-              Alien (x, name, language), o
+        | Alien ({ binder; _ } as payload) ->
+            let binder, o = o#binder binder in
+            Alien { payload with binder}, o
         | Module (name, defs) ->
             let defs, o =
               match defs with

--- a/core/irtojs.ml
+++ b/core/irtojs.ml
@@ -1243,10 +1243,17 @@ end = functor (K : CONTINUATION) -> struct
              varenv fs
          in
          (state, varenv, None, fun code -> LetRec (List.map (generate_function varenv fs) defs, code))
-      | Alien (bnd, raw_name, _lang) ->
-        let (a, _a_name) = name_binder bnd in
-        let varenv = VEnv.bind a raw_name varenv in
-        state, varenv, None, (fun code -> code)
+      | Alien { binder; object_name; language } ->
+         begin
+           let open ForeignLanguage in
+           (* TODO(dhil): If the foreign language isn't JavaScript,
+              then I think a server-call should be generated. *)
+           match language with
+           | JavaScript ->
+              let (a, _a_name) = name_binder binder in
+              let varenv = VEnv.bind a object_name varenv in
+              state, varenv, None, (fun code -> code)
+         end
       | Module _ -> state, varenv, None, (fun code -> code)
 
   let rec generate_toplevel_bindings : Value.env -> Json.json_state -> venv -> Ir.binding list -> Json.json_state * venv * string list * (code -> code) =

--- a/core/moduleUtils.ml
+++ b/core/moduleUtils.ml
@@ -150,7 +150,8 @@ let get_ffi_files_obj =
     method get_filenames = List.rev filenames
 
     method! bindingnode = function
-      | Foreign (_, _, _, filename, _) -> self#add_external_file filename
+      | Foreign alien ->
+         self#add_external_file (Alien.object_file alien)
       | x -> super#bindingnode x
   end
 

--- a/core/parser.mly
+++ b/core/parser.mly
@@ -31,6 +31,10 @@ open SourceCode
 open Sugartypes
 open SugarConstructors
 
+(* Workaround path bug in OCaml 4.07 when using menhir and dune
+(c.f. https://github.com/ocaml/dune/issues/1504). *)
+module Links_core = struct end
+
 (* Construction of nodes using positions produced by Menhir parser *)
 module ParserPosition
        : Pos with type t = (SourceCode.Lexpos.t * SourceCode.Lexpos.t) = struct
@@ -232,6 +236,12 @@ module MutualBindings = struct
     type_binding mut_types @ fun_binding mut_funs
 end
 
+let parse_foreign_language pos lang =
+  try ForeignLanguage.of_string lang
+  with Invalid_argument _ ->
+    raise (ConcreteSyntaxError
+             (pos, Printf.sprintf "Unrecognised foreign language '%s'." lang))
+
 %}
 
 %token END
@@ -375,9 +385,13 @@ declaration:
 
 nofun_declaration:
 | alien_block                                                  { $1 }
-| ALIEN VARIABLE STRING VARIABLE COLON datatype SEMICOLON      { with_pos $loc
-                                                                          (Foreign (binder ~ppos:$loc($4) $4,
-                                                                                     $4, $2, $3, datatype $6)) }
+| ALIEN VARIABLE STRING VARIABLE COLON datatype SEMICOLON      { let alien =
+                                                                   let binder = binder ~ppos:$loc($4) $4 in
+                                                                   let datatype = datatype $6 in
+                                                                   let language = parse_foreign_language (pos $loc($1)) $2 in
+                                                                   Alien.single language $3 binder datatype
+                                                                 in
+                                                                 with_pos $loc (Foreign alien) }
 | fixity perhaps_uinteger op SEMICOLON                         { let assoc, set = $1 in
                                                                  set assoc (from_option default_fixity $2) (WithPos.node $3);
                                                                  with_pos $loc Infix }
@@ -395,7 +409,8 @@ links_module:
 | MODULE name = CONSTRUCTOR members = moduleblock              { module_binding ~ppos:$loc($1) (binder ~ppos:$loc(name) name) members }
 
 alien_block:
-| ALIEN VARIABLE STRING LBRACE alien_datatypes RBRACE          { with_pos $loc (AlienBlock ($2, $3, $5)) }
+| ALIEN VARIABLE STRING LBRACE alien_datatypes RBRACE          { let lang = parse_foreign_language (pos $loc($1)) $2 in
+                                                                 with_pos $loc (AlienBlock (Alien.multi lang $3 $5)) }
 
 fun_declarations:
 | fun_declaration+                                             { $1 }

--- a/core/sugarTraversals.mli
+++ b/core/sugarTraversals.mli
@@ -48,6 +48,7 @@ class map :
     method cp_phrase       : cp_phrase -> cp_phrase
     method patternnode     : Pattern.t -> Pattern.t
     method pattern         : Pattern.with_pos -> Pattern.with_pos
+    method foreign_language : ForeignLanguage.t -> ForeignLanguage.t
     method name            : Name.t -> Name.t
     method location        : Location.t -> Location.t
     method iterpatt        : iterpatt -> iterpatt
@@ -127,6 +128,7 @@ class fold :
     method cp_phrase       : cp_phrase -> 'self
     method patternnode     : Pattern.t -> 'self
     method pattern         : Pattern.with_pos -> 'self
+    method foreign_language : ForeignLanguage.t -> 'self
     method name            : Name.t -> 'self
     method location        : Location.t -> 'self
     method iterpatt        : iterpatt -> 'self
@@ -193,6 +195,7 @@ object ('self)
   method iterpatt        : iterpatt -> 'self * iterpatt
   method list            : 'a . ('self -> 'a -> 'self * 'a) -> 'a list -> 'self * 'a list
   method location        : Location.t -> 'self * Location.t
+  method foreign_language : ForeignLanguage.t -> 'self * ForeignLanguage.t
   method name            : Name.t -> 'self * Name.t
   method option          : 'a . ('self -> 'a -> 'self * 'a) -> 'a option -> 'self * 'a option
   method patternnode     : Pattern.t -> 'self * Pattern.t

--- a/core/sugartoir.ml
+++ b/core/sugartoir.ml
@@ -193,7 +193,7 @@ sig
     (var list -> tail_computation sem) ->
     tail_computation sem
 
-  val alien : var_info * Name.t * language * (var -> tail_computation sem) -> tail_computation sem
+  val alien : var_info * string * ForeignLanguage.t * (var -> tail_computation sem) -> tail_computation sem
 
   val select : Name.t * value sem -> tail_computation sem
 
@@ -283,7 +283,7 @@ struct
        * location) list ->
       (Var.var list) M.sem
 
-    val alien_binding : var_info * Name.t * language -> var M.sem
+    val alien_binding : var_info * string * ForeignLanguage.t -> var M.sem
 
     val value_of_untyped_var : var M.sem * datatype -> value sem
   end =
@@ -331,9 +331,9 @@ struct
                 defs))
           fs
 
-    let alien_binding (x_info, raw_name, language) =
+    let alien_binding (x_info, object_name, language) =
       let xb, x = Var.fresh_var x_info in
-        lift_binding (Alien (xb, raw_name, language)) x
+        lift_binding (Alien (xb, object_name, language)) x
 
     let value_of_untyped_var (s, t) =
       M.bind s (fun x -> lift (Variable x, t))
@@ -537,8 +537,8 @@ struct
 
   let wrong t = lift (Special (Wrong t), t)
 
-  let alien (x_info, raw_name, language, rest) =
-    M.bind (alien_binding (x_info, raw_name, language)) rest
+  let alien (x_info, object_name, language, rest) =
+    M.bind (alien_binding (x_info, object_name, language)) rest
 
   let select (l, e) =
     let t = TypeUtils.select_type l (sem_type e) in
@@ -1177,17 +1177,21 @@ struct
                         (nodes_of_list defs)
                     in
                       I.letrec env defs (fun vs -> eval_bindings scope (extend fs (List.combine vs outer_fts) env) bs e)
-                | Foreign (bndr, raw_name, language, _file, _)
-                     when Binder.has_type bndr ->
-                    let x  = Binder.to_name bndr in
-                    let xt = Binder.to_type bndr in
-                    I.alien ((xt, x, scope), raw_name, language, fun v -> eval_bindings scope (extend [x] [(v, xt)] env) bs e)
+                | Foreign alien ->
+                   let binder =
+                     fst (Alien.declaration alien)
+                   in
+                   assert (Binder.has_type binder);
+                   let x  = Binder.to_name binder in
+                   let xt = Binder.to_type binder in
+                   I.alien ((xt, x, scope), Alien.object_name alien, Alien.language alien,
+                            fun v -> eval_bindings scope (extend [x] [(v, xt)] env) bs e)
                 | Typenames _
                 | Infix ->
                     (* Ignore type alias and infix declarations - they
                        shouldn't be needed in the IR *)
                     eval_bindings scope env bs e
-                | Import _ | Open _ | Fun _ | Foreign _
+                | Import _ | Open _ | Fun _
                 | AlienBlock _ | Module _  -> assert false
             end
 

--- a/core/sugartoir.ml
+++ b/core/sugartoir.ml
@@ -333,7 +333,7 @@ struct
 
     let alien_binding (x_info, object_name, language) =
       let xb, x = Var.fresh_var x_info in
-        lift_binding (Alien (xb, object_name, language)) x
+      lift_binding (Alien { binder = xb; object_name; language }) x
 
     let value_of_untyped_var (s, t) =
       M.bind s (fun x -> lift (Variable x, t))
@@ -1241,7 +1241,10 @@ struct
                           | Scope.Local ->
                               partition (globals, b::locals, nenv) bs
                       end
-                | Alien ((f, (_ft, f_name, Scope.Global)), _, _) ->
+                | Alien { binder; _ }
+                     when Var.Scope.isGlobal (Var.scope_of_binder binder) ->
+                   let f = Var.var_of_binder binder in
+                   let f_name = Var.name_of_binder binder in
                     partition (b::locals @ globals, [], Env.String.bind f_name f nenv) bs
                 | _ -> partition (globals, b::locals, nenv) bs
             end in

--- a/core/transformSugar.ml
+++ b/core/transformSugar.ml
@@ -803,9 +803,17 @@ class transform (env : Types.typing_environment) =
          (* put the outer bindings in the environment *)
          let o, defs = o#rec_activate_outer_bindings defs in
          (o, (Funs defs))
-      | Foreign (f, raw_name, language, file, t) ->
-         let (o, f) = o#binder f in
-         (o, Foreign (f, raw_name, language, file, t))
+      | Foreign alien ->
+         let (o, declarations) =
+           listu o
+             (fun o (b, dt) ->
+               let o, b = o#binder b in
+               let o, dt = o#datatype' dt in
+               (o, (b, dt)))
+             (Alien.declarations alien)
+         in
+         let o, language = o#foreign_language (Alien.language alien) in
+         (o, Foreign (Alien.modify ~language ~declarations alien))
       | Typenames ts ->
           let (o, _) = listu o (fun o {node=(name, vars, (x, dt')); pos} ->
               match dt' with
@@ -901,4 +909,7 @@ class transform (env : Types.typing_environment) =
          let (o, right, t) = {< var_env = TyEnv.bind c (whiny_dual_type s) (o#get_var_env ()) >}#cp_phrase right in
          let o = o#restore_envs envs in
          o, CPComp (bndr, left, right), t
+
+    method foreign_language : ForeignLanguage.t -> ('self_type * ForeignLanguage.t)
+      = fun lang -> (o, lang)
   end

--- a/core/transformSugar.mli
+++ b/core/transformSugar.mli
@@ -90,6 +90,7 @@ object ('self)
   method directive       : directive -> 'self * directive
 *)
   method unary_op        : UnaryOp.t -> 'self * UnaryOp.t * Types.datatype
+  method foreign_language : ForeignLanguage.t -> 'self * ForeignLanguage.t
 end
 
 val fun_effects : Types.datatype -> Sugartypes.Pattern.with_pos list list -> Types.row

--- a/core/value.ml
+++ b/core/value.ml
@@ -774,7 +774,7 @@ let rec p_value (ppf : formatter) : t -> 'a = function
   | `List l -> fprintf ppf "[@[<hov 0>";
                p_list_elements ppf l
   | `ClientDomRef i -> fprintf ppf "%i" i
-  | `ClientFunction n -> fprintf ppf "%s" n
+  | `ClientFunction _n -> fprintf ppf "fun"
   | `PrimitiveFunction (name, _op) -> fprintf ppf "%s" name
   | `Variant (label, `Record []) -> fprintf ppf "@{<constructor>%s@}" label
   (* avoid duplicate parenthesis for Foo(a = 5, b = 3) *)

--- a/tests/alien.tests
+++ b/tests/alien.tests
@@ -19,7 +19,7 @@ stdout : alien : ()
 Alien functions may not be applied in the interpreter
 alien javascript "fun.js" f : () ~> (); f()
 exit : 1
-stderr : @.*Can't make alien call on the server\..*
+stderr : @.*Cannot make alien call on the server\..*
 
 Alien binders cannot contain primes
 alien javascript "" f' : () -> ();


### PR DESCRIPTION
This patch refactors the frontend implementation of FFI. The changes
are only cosmetic.

This is backported from my work on name hygiene/compilation
units. Ultimately, I would like to use the FFI to bootstrap (in the
frontend) the Links builtins library (aka `lib.ml`). By doing this
`lib.ml` need not be treated specially by the frontend, which makes it
significantly easier to implement a uniform infrastructure for
compilation units.