### PR TITLE
Remove `native` location.

### DIFF
--- a/bin/repl.ml
+++ b/bin/repl.ml
@@ -301,7 +301,7 @@ let handle previous_context current_context = function
                    `FunctionPtr (var, None)
                 | Location.Client ->
                    `ClientFunction (Js.var_name_binder (var, finfo))
-                | Location.Native -> assert false in
+              in
               let t = Var.info_type finfo in v, t
            | _ -> assert false
          in

--- a/core/commonTypes.ml
+++ b/core/commonTypes.ml
@@ -157,7 +157,7 @@ module Quantifier = struct
 end
 
 module Location = struct
-  type t = Client | Server | Native | Unknown
+  type t = Client | Server | Unknown
     [@@deriving show]
 
   let is_client = function
@@ -168,10 +168,6 @@ module Location = struct
     | Server -> true
     | _      -> false
 
-  let is_native = function
-    | Native -> true
-    | _      -> false
-
   let is_unknown = function
     | Unknown -> true
     | _      -> false
@@ -179,14 +175,12 @@ module Location = struct
   let to_string = function
     | Client -> "client"
     | Server -> "server"
-    | Native -> "native"
     | Unknown -> "unknown"
 end
 
 (* Convenient aliases for constructing values *)
 let loc_client  = Location.Client
 let loc_server  = Location.Server
-let loc_native  = Location.Native
 let loc_unknown = Location.Unknown
 
 module Freedom = struct

--- a/core/evalir.ml
+++ b/core/evalir.ml
@@ -86,7 +86,6 @@ struct
           Some (`FunctionPtr (f, None))
         | Location.Client ->
           Some (`ClientFunction (Js.var_name_binder (f, finfo)))
-        | Location.Native -> assert false
       end
     | _ -> assert false
 

--- a/core/irtojs.ml
+++ b/core/irtojs.ml
@@ -742,7 +742,7 @@ end = functor (K : CONTINUATION) -> struct
          advantage of dynamic scoping *)
 
         match location with
-        | Location.Client | Location.Native | Location.Unknown ->
+        | Location.Client | Location.Unknown ->
            let xs_names'' = xs_names'@[__kappa] in
            LetFun ((Js.var_name_binder fb,
                     xs_names'',
@@ -1175,8 +1175,6 @@ end = functor (K : CONTINUATION) -> struct
         | Location.Client | Location.Unknown ->
            snd (generate_computation body_env body (K.reflect (Var __kappa)))
         | Location.Server -> generate_remote_call f xs_names (Dict [])
-        | Location.Native ->
-            raise (Errors.runtime_error ("Not implemented native calls yet"))
       in
       (f_name,
        xs_names @ [__kappa],

--- a/core/json.ml
+++ b/core/json.ml
@@ -48,12 +48,7 @@ let json_of_table ((db, params), name, keys, row) : Yojson.Basic.t =
         ("row", `String (Types.string_of_datatype (`Record row)));
         ("keys", json_of_keylist keys)])]
 
-let jsonize_location loc = `String (
-  match loc with
-    | Location.Client  -> "client"
-    | Location.Server  -> "server"
-    | Location.Native  -> "native"
-    | Location.Unknown -> "unknown")
+let jsonize_location loc = `String (Location.to_string loc)
 
 let rec cons_listify : Yojson.Basic.t list -> Yojson.Basic.t = function
   | [] -> `Null

--- a/core/lens_ir_conv.ml
+++ b/core/lens_ir_conv.ml
@@ -63,12 +63,6 @@ module Env = struct
                    ( Js.var_name_binder (f, finfo)
                    |> Format.asprintf
                         "Attempt to use client function: %s in query" ))
-          | Location.Native ->
-              raise
-                (Errors.runtime_error
-                   ( Var.show_binder (f, finfo)
-                   |> Format.asprintf
-                        "Attempt to use native function: %s in query" ))
         in
         Some fn
     | None -> None
@@ -255,7 +249,7 @@ let lens_sugar_phrase_of_ir p env =
           Result.bind
             ~f:(fun v -> computation (Env.bind env (x, v)) (bs, tailcomp))
             v
-      | I.Fun (_, _, _, (Location.Client | Location.Native)) ->
+      | I.Fun (_, _, _, Location.Client) ->
           Result.error Of_ir_error.Client_function
       | I.Fun _ ->
           Result.error @@ Of_ir_error.Internal_error "Unexpected function."

--- a/core/lexer.mll
+++ b/core/lexer.mll
@@ -197,7 +197,6 @@ let keywords = [
  "module"   , MODULE;
  "mu"       , MU;
  "mutual"   , MUTUAL;
- "native"   , NATIVE;
  "nu"       , NU;
  "offer"    , OFFER;
  "on"       , ON;

--- a/core/parser.mly
+++ b/core/parser.mly
@@ -260,7 +260,7 @@ end
 %token LENSPUT LENSGET LENSCHECK
 %token READONLY DEFAULT
 %token ESCAPE
-%token CLIENT SERVER NATIVE
+%token CLIENT SERVER
 %token SEMICOLON
 %token TRUE FALSE
 %token BARBAR AMPAMP
@@ -467,7 +467,6 @@ fixity:
 perhaps_location:
 | SERVER                                                       { loc_server  }
 | CLIENT                                                       { loc_client  }
-| NATIVE                                                       { loc_native  }
 | /* empty */                                                  { loc_unknown }
 
 constant:

--- a/core/query/query.ml
+++ b/core/query/query.ml
@@ -366,9 +366,6 @@ struct
             | Location.Client ->
               raise (Errors.runtime_error ("Attempt to use client function: " ^
                 Js.var_name_binder (f, finfo) ^ " in query"))
-            | Location.Native ->
-              raise (Errors.runtime_error ("Attempt to use native function: " ^
-                Var.show_binder (f, finfo) ^ " in query"))
           end
       end
     | None -> None
@@ -691,7 +688,7 @@ struct
               | Let (xb, (_, tc)) ->
                   let x = Var.var_of_binder xb in
                     computation (bind env (x, tail_computation env tc)) (bs, tailcomp)
-              | Fun (_, _, _, (Location.Client | Location.Native)) ->
+              | Fun (_, _, _, Location.Client) ->
                   eval_error "Client function"
               | Fun ((f, _), _, _, _) ->
                 (* This should never happen now that we have closure conversion*)


### PR DESCRIPTION
This patch removes the `native` location which, judging from the
source code, never seems to have been implemented. I seem to recall
that values marked native were intended to be FFI-like, i.e. their
implementations were to be given outside of Links. We already support FFI calls
to JavaScript via `alien` declarations. I think further development of
FFI should happen on `alien`.

This patch garbage collects the keyword `native`, that is, it can now
be used as an identifier.