### PR TITLE
Implement character operations in Links.

### DIFF
--- a/core/lib.ml
+++ b/core/lib.ml
@@ -72,22 +72,6 @@ let string_to_xml : Value.t -> Value.t = function
   | _ -> raise (runtime_type_error "non-string value passed to xml conversion routine")
 
 (* The following functions expect 1 argument. Assert false otherwise. *)
-let char_test_op fn pure =
-  (`PFun (fun _ args ->
-      match args with
-        | [c] -> (`Bool (fn (Value.unbox_char c)))
-        | _ -> assert false),
-   datatype "(Char) ~> Bool",
-   pure)
-
-let char_conversion fn pure =
-  (`PFun (fun _ args ->
-      match args with
-        | [c] -> (Value.box_char (fn (Value.unbox_char c)))
-        | _ -> assert false),
-   datatype "(Char) -> Char",
-   pure)
-
 let float_fn fn pure =
   (`PFun (fun _ args ->
       match args with
@@ -1124,19 +1108,6 @@ let env : (string * (located_primitive * Types.datatype * pure)) list = [
                 "args", Value.box_string args])),
    datatype "() ~> (driver:String, args:String)",
   IMPURE);
-
-  (* some char functions *)
-  "isAlpha",  char_test_op Char.isAlpha PURE;
-  "isAlnum",  char_test_op Char.isAlnum PURE;
-  "isLower",  char_test_op Char.isLower PURE;
-  "isUpper",  char_test_op Char.isUpper PURE;
-  "isDigit",  char_test_op Char.isDigit PURE;
-  "isXDigit", char_test_op Char.isXDigit PURE;
-  "isBlank",  char_test_op Char.isBlank PURE;
-  (* isCntrl, isGraph, isPrint, isPunct, isSpace *)
-
-  "toUpper", char_conversion Char.uppercase_ascii PURE;
-  "toLower", char_conversion Char.lowercase_ascii PURE;
 
   "ord",
   (p1 (fun c -> Value.box_int (Char.code (Value.unbox_char c))),

--- a/lib/js/jslib.js
+++ b/lib/js/jslib.js
@@ -3646,45 +3646,10 @@ function _include(script_filename) {
 //_include("extras.js")
 
 
-function _chartest(r) {
-  return function (c) {return r.test(c._c);};
-}
-
-var _isAlpha = _chartest(/[a-zA-Z]/);
-var _isAlnum = _chartest(/[a-zA-Z0-9]/);
-var _isLower = _chartest(/[a-z]/);
-var _isUpper = _chartest(/[A-Z]/);
-var _isDigit = _chartest(/[0-9]/);
-var _isXDigit= _chartest(/[0-9a-fA-F]/);
-var _isBlank = _chartest(/[ \t]/);
-
-var isAlpha = LINKS.kify(_isAlpha);
-var isAlnum = LINKS.kify(_isAlnum);
-var isLower = LINKS.kify(_isLower);
-var isUpper = LINKS.kify(_isUpper);
-var isDigit = LINKS.kify(_isDigit);
-var isXDigit= LINKS.kify(_isXDigit);
-var isBlank = LINKS.kify(_isBlank);
-
 function _chr(c) { return { _c: String.fromCharCode(c) } };
 var chr = LINKS.kify(_chr);
 function _ord(c) { return c._c.charCodeAt(0); }
 var ord = LINKS.kify(_ord);
-
-function _toUpper(c) {
-  var c = c._c;
-  DEBUG.assert(c.length == 1, "_toUpper only operates on single characters");
-  return {_c:c.toUpperCase()};
-}
-
-function _toLower(c) {
-  var c = c._c;
-  DEBUG.assert(c.length == 1, "_toLower only operates on single characters");
-  return {_c:c.toLowerCase()};
-}
-
-var toUpper = LINKS.kify(_toUpper);
-var toLower = LINKS.kify(_toLower);
 
 var _sqrt = Math.sqrt; var sqrt = LINKS.kify(_sqrt);
 var _floor = Math.floor; var floor = LINKS.kify(_floor);

--- a/prelude.links
+++ b/prelude.links
@@ -1420,3 +1420,62 @@ fun serveThese(routes) {
   var _ = map(fun ((s,p)) {addRoute(s,fun (_) {p()})}, routes);
   servePages()
 }
+
+# Operations on (ASCII) characters
+sig isLower : (Char) -> Bool
+fun isLower(ch) {
+  var c = ord(ch);
+  (97 <= c && c <= 122) # ord('a') = 97, ord('z') = 122
+}
+
+sig isUpper : (Char) -> Bool
+fun isUpper(ch) {
+  var c = ord(ch);
+  (65 <= c && c <= 90) # ord('A') = 65, ord('Z') = 90
+}
+
+sig isAlpha : (Char) -> Bool
+fun isAlpha(ch) {
+  isLower(ch) || isUpper(ch)
+}
+
+sig isDigit : (Char) -> Bool
+fun isDigit(ch) {
+  var c = ord(ch);
+  (48 <= c && c <= 57)
+}
+
+sig isAlnum : (Char) -> Bool
+fun isAlnum(ch) {
+ isAlpha(ch) || isDigit(ch)
+}
+
+sig isXDigit : (Char) -> Bool
+fun isXDigit(ch) {
+  isDigit(ch)
+  || ({ var c = ord(ch);
+        (65 <= c && c <= 70)        # ord('F') = 70
+        || (97 <= c && c <= 102) }) # ord('f') = 102
+}
+
+sig isBlank : (Char) -> Bool
+fun isBlank(ch) {
+  var c = ord(ch);
+  c == 32 || c == 9 # ord(' ') = 32, ord('\t') = 9
+}
+
+# Implements the behaviour of Char.uppercase_ascii in OCaml.
+sig toUpper : (Char) -> Char
+fun toUpper(ch) {
+  if (isLower(ch)) {
+    chr(ord(ch) - 32)
+  } else ch
+}
+
+# Implements the behaviour of Char.lowercase_ascii in OCaml.
+sig toLower : (Char) -> Char
+fun toLower(ch) {
+  if (isUpper(ch)) {
+    chr(ord(ch) + 32)
+  } else ch
+}

--- a/tests/char_operations.tests
+++ b/tests/char_operations.tests
@@ -1,0 +1,131 @@
+isBlank [1]
+isBlank(' ')
+stdout : true : Bool
+
+isBlank [2]
+isBlank('\t')
+stdout : true : Bool
+
+isBlank [3]
+isBlank('\n')
+stdout : false : Bool
+
+isBlank [4]
+isBlank('$')
+stdout : false : Bool
+
+isBlank [5]
+isBlank('M')
+stdout : false : Bool
+
+isLower [1]
+isLower('a')
+stdout : true : Bool
+
+isLower [2]
+isLower('z')
+stdout : true : Bool
+
+isLower [3]
+isLower('j')
+stdout : true : Bool
+
+isLower [4]
+isLower('A')
+stdout : false : Bool
+
+isLower [5]
+isLower('{')
+stdout : false : Bool
+
+isLower [7]
+isLower('`')
+stdout : false : Bool
+
+isUpper [1]
+isUpper('A')
+stdout : true : Bool
+
+isUpper [2]
+isUpper('Z')
+stdout : true : Bool
+
+isUpper [3]
+isUpper('J')
+stdout : true : Bool
+
+isUpper [4]
+isUpper('a')
+stdout : false : Bool
+
+isUpper [5]
+isUpper('[')
+stdout : false : Bool
+
+isUpper [6]
+isUpper('@')
+stdout : false : Bool
+
+isAlnum [1]
+isAlnum('a') && isAlnum('z') && isAlnum('A') && isAlnum('Z') && isAlnum('0') && isAlnum('1') && isAlnum('2') && isAlnum('3') && isAlnum('4') && isAlnum('5') && isAlnum('6') && isAlnum('7') && isAlnum('8') && isAlnum('9')
+stdout : true : Bool
+
+isAlnum [2]
+isAlnum('/') || isAlnum('$') || isAlnum('*') || isAlnum('{')
+stdout : false : Bool
+
+isXDigit [1]
+isXDigit('A') && isXDigit('B') && isXDigit('C') && isXDigit('D') && isXDigit('E') && isXDigit('F') && isXDigit('a') && isXDigit('b') && isXDigit('c') && isXDigit('d') && isXDigit('e') && isXDigit('f') && isXDigit('0') && isXDigit('1') && isXDigit('2') && isXDigit('3') && isXDigit('4') && isXDigit('5') && isXDigit('6') && isXDigit('7') && isXDigit('8') && isXDigit('9')
+stdout : true : Bool
+
+isXDigit [2]
+isXDigit('/') || isXDigit('[')
+stdout : false : Bool
+
+toUpper [1]
+toUpper('a')
+stdout : 'A' : Char
+
+toUpper [2]
+toUpper('z')
+stdout : 'Z' : Char
+
+toUpper [3]
+toUpper('k')
+stdout : 'K' : Char
+
+toUpper [4]
+toUpper('$')
+stdout : '$' : Char
+
+toUpper [5]
+toUpper('[')
+stdout : '[' : Char
+
+toUpper [6]
+toUpper('7')
+stdout : '7' : Char
+
+toLower [1]
+toLower('A')
+stdout : 'a' : Char
+
+toLower [2]
+toLower('Z')
+stdout : 'z' : Char
+
+toLower [3]
+toLower('O')
+stdout : 'o' : Char
+
+toLower [4]
+toLower('$')
+stdout : '$' : Char
+
+toLower [5]
+toLower('{')
+stdout : '{' : Char
+
+toLower [6]
+toLower('5')
+stdout : '5' : Char


### PR DESCRIPTION
This patch removes the following character operations from `lib.ml`
and implements them in Links itself (they are now defined in
`prelude.links`):

* `toUpper : (Char) -> Char`
* `toLower : (Char) -> Char`
* `isUpper : (Char) -> Bool`
* `isLower : (Char) -> Bool`
* `isDigit : (Char) -> Bool`
* `isAlnum : (Char) -> Bool`
* `isXDigit : (Char) -> Bool`
* `isBlank : (Char) -> Bool`