### PR TITLE
Accept the empty program as a valid Links program.

### DIFF
--- a/core/parser.mly
+++ b/core/parser.mly
@@ -346,6 +346,7 @@ interactive:
 | END                                                          { Directive ("quit", []) (* rather hackish *) }
 
 file:
+| END                                                          { ([], None) }
 | declarations exp? END                                        { ($1, $2     ) }
 | exp END                                                      { ([], Some $1) }
 


### PR DESCRIPTION
This patch extends the grammar of Links such that the empty program is
accepted by the parser as a syntactically valid program.

It is useful to be able to start Links with an empty prelude, e.g. for
debugging. We already accept the empty expression as valid input in
interactive mode.