### PR TITLE
Correctly handle linearity of arguments in lambdas

### DIFF
--- a/core/sugartoir.ml
+++ b/core/sugartoir.ml
@@ -681,7 +681,7 @@ struct
                | `ForAll (_, t')
                | t' ->
                    begin match TypeUtils.concrete_type t' with
-                     | `Function _ | `Lolli _ as ft' ->
+                     | `Function _ as ft' ->
                          let args = TypeUtils.arg_types ft' in
                            List.map (Var.fresh_binder_of_type) args
                      | _ -> assert false

--- a/core/sugartoir.ml
+++ b/core/sugartoir.ml
@@ -681,7 +681,7 @@ struct
                | `ForAll (_, t')
                | t' ->
                    begin match TypeUtils.concrete_type t' with
-                     | `Function _ as ft' ->
+                     | `Function _ | `Lolli _ as ft' ->
                          let args = TypeUtils.arg_types ft' in
                            List.map (Var.fresh_binder_of_type) args
                      | _ -> assert false

--- a/core/typeSugar.ml
+++ b/core/typeSugar.ml
@@ -4212,7 +4212,8 @@ and type_binding : context -> binding -> binding * context * Usage.t =
           let name = Binder.to_name bndr in
           let vs = name :: check_for_duplicate_names pos (List.flatten pats) in
           let (pats_init, pats_tail) = from_option ([], []) (unsnoc_opt pats) in
-          let pats = List.append (List.map (List.map tpcu) pats_init)
+          let tpc' = if DeclaredLinearity.is_linear lin then tpc else tpcu in
+          let pats = List.append (List.map (List.map tpc') pats_init)
                        [List.map tpc pats_tail] in
           let effects = Types.make_empty_open_row default_effect_subkind in
           let return_type = Types.fresh_type_variable (lin_any, res_any) in
@@ -4379,7 +4380,8 @@ and type_binding : context -> binding -> binding * context * Usage.t =
                  let name = Binder.to_name bndr in
                  let _ = check_for_duplicate_names pos (List.flatten pats) in
                  let (pats_init, pats_tail) = from_option ([], []) (unsnoc_opt pats) in
-                 let pats = List.append (List.map (List.map tpcu) pats_init)
+                 let tpc' = if DeclaredLinearity.is_linear lin then tpc else tpcu in
+                 let pats = List.append (List.map (List.map tpc') pats_init)
                               [List.map tpc pats_tail] in
                  let t_ann = match def with
                    | Some (ty, _) -> Some ty

--- a/core/typeSugar.ml
+++ b/core/typeSugar.ml
@@ -2179,11 +2179,17 @@ let check_unsafe_signature context unify inner = function
      unsafe
   | Some (_, None) -> raise (internal_error "Sugartypes.datatype' without a Types.typ instance")
 
-let type_pattern closed : Pattern.with_pos -> Pattern.with_pos * Types.environment * Types.datatype =
+let type_pattern ?(linear_vars=true) closed
+    : Pattern.with_pos -> Pattern.with_pos * Types.environment * Types.datatype =
   let make_singleton_row =
     match closed with
       | `Closed -> Types.make_singleton_closed_row
       | `Open -> (fun var -> Types.make_singleton_open_row var (lin_any, res_any)) in
+
+  let fresh_var () =
+    if linear_vars
+    then Types.fresh_type_variable (lin_any, res_any)
+    else Types.fresh_type_variable (lin_unl, res_any) in
 
   (* type_pattern p types the pattern p returning a typed pattern, a
      type environment for the variables bound by the pattern and two
@@ -2210,7 +2216,7 @@ let type_pattern closed : Pattern.with_pos -> Pattern.with_pos * Types.environme
       let open Pattern in
       match pattern with
       | Nil ->
-        let t = Types.make_list_type (Types.fresh_type_variable (lin_any, res_any)) in
+        let t = Types.make_list_type (fresh_var ()) in
         Nil, Env.empty, (t, t)
       | Any ->
         let t = Types.fresh_type_variable (lin_unl, res_any) in
@@ -2219,7 +2225,7 @@ let type_pattern closed : Pattern.with_pos -> Pattern.with_pos * Types.environme
         let t = `Primitive (Constant.type_of c) in
         c', Env.empty, (t, t)
       | Variable bndr ->
-        let xtype = Types.fresh_type_variable (lin_any, res_any) in
+        let xtype = fresh_var () in
         (Variable (Binder.set_type bndr xtype),
          Env.singleton (Binder.to_name bndr) xtype,
          (xtype, xtype))
@@ -2240,7 +2246,7 @@ let type_pattern closed : Pattern.with_pos -> Pattern.with_pos * Types.environme
           Types.make_list_type (typ p) in
         let ts =
           match ps' with
-          | [] -> let t = Types.fresh_type_variable (lin_any, res_any) in t, t
+          | [] -> let t = fresh_var () in t, t
           | p::ps ->
             list_type p ps ot, list_type p ps it
         in
@@ -2256,8 +2262,8 @@ let type_pattern closed : Pattern.with_pos -> Pattern.with_pos * Types.environme
          (* Auxiliary machinery for typing effect patterns *)
          let rec type_resumption_pat (kpat : Pattern.with_pos) : Pattern.with_pos * Types.environment * (Types.datatype * Types.datatype) =
            let fresh_resumption_type () =
-             let domain   = Types.fresh_type_variable (lin_any, res_any) in
-             let codomain = Types.fresh_type_variable (lin_any, res_any) in
+             let domain   = fresh_var () in
+             let codomain = fresh_var () in
              let effrow   = Types.make_empty_open_row default_effect_subkind in
              Types.make_function_type [domain] effrow codomain
            in
@@ -2316,7 +2322,7 @@ let type_pattern closed : Pattern.with_pos -> Pattern.with_pos * Types.environme
         let positive, negative =
           List.fold_right
             (fun name (positive, negative) ->
-               let a = Types.fresh_type_variable (lin_any, res_any) in
+               let a = fresh_var () in
                (StringMap.add name (`Present a) positive,
                 StringMap.add name `Absent negative))
             names (StringMap.empty, StringMap.empty) in
@@ -2503,8 +2509,9 @@ let rec type_check : context -> phrase -> phrase * Types.datatype * Usage.t =
       Position.Resolved.source_expression in
     let exp_pos (p,_,_) = uexp_pos p in
     let pos_and_typ e = (exp_pos e, typ e) in
-    let tpc p = type_pattern `Closed p
-    and tpo p = type_pattern `Open p
+    let tpc p = type_pattern `Closed p in
+    let tpcu p = type_pattern ~linear_vars:false `Closed p in
+    let tpo p = type_pattern `Open p
     and tc : phrase -> phrase * Types.datatype * Usage.t = type_check context
     and expr_string (p : Sugartypes.phrase) : string =
       let pos = WithPos.pos p in
@@ -2676,7 +2683,10 @@ let rec type_check : context -> phrase -> phrase * Types.datatype * Usage.t =
             end
         | FunLit (argss_prev, lin, (pats, body), location) ->
             let vs = check_for_duplicate_names pos (List.flatten pats) in
-            let pats = List.map (List.map tpc) pats in
+            let (pats_init, pats_tail) = from_option ([], []) (unsnoc_opt pats) in
+            let tpc' = if DeclaredLinearity.is_linear lin then tpc else tpcu in
+            let pats = List.append (List.map (List.map tpc') pats_init)
+                                   [List.map tpc pats_tail] in
             let pat_env = List.fold_left (List.fold_left (fun env pat' -> Env.extend env (pattern_env pat'))) Env.empty pats in
             let env' = Env.extend context.var_env pat_env in
 
@@ -4145,6 +4155,7 @@ and type_binding : context -> binding -> binding * context * Usage.t =
     and pattern_typ (_, _, t) = t
     and tc = type_check context
     and tpc = type_pattern `Closed
+    and tpcu p = type_pattern ~linear_vars:false `Closed p
     and pattern_env (_, e, _) = e
     and (++) ctxt env' = {ctxt with var_env = Env.extend ctxt.var_env env'} in
     let pattern_pos ({pos=p;_},_,_) = Position.resolve_expression p in
@@ -4200,8 +4211,9 @@ and type_binding : context -> binding -> binding * context * Usage.t =
 
           let name = Binder.to_name bndr in
           let vs = name :: check_for_duplicate_names pos (List.flatten pats) in
-          let pats = List.map (List.map tpc) pats in
-
+          let (pats_init, pats_tail) = from_option ([], []) (unsnoc_opt pats) in
+          let pats = List.append (List.map (List.map tpcu) pats_init)
+                       [List.map tpc pats_tail] in
           let effects = Types.make_empty_open_row default_effect_subkind in
           let return_type = Types.fresh_type_variable (lin_any, res_any) in
 
@@ -4366,7 +4378,9 @@ and type_binding : context -> binding -> binding * context * Usage.t =
                             _ }; _ } ->
                  let name = Binder.to_name bndr in
                  let _ = check_for_duplicate_names pos (List.flatten pats) in
-                 let pats = List.map (List.map tpc) pats in
+                 let (pats_init, pats_tail) = from_option ([], []) (unsnoc_opt pats) in
+                 let pats = List.append (List.map (List.map tpcu) pats_init)
+                              [List.map tpc pats_tail] in
                  let t_ann = match def with
                    | Some (ty, _) -> Some ty
                    | None -> resolve_type_annotation bndr t_ann'

--- a/tests/functions.tests
+++ b/tests/functions.tests
@@ -121,7 +121,6 @@ stdout : fun : (a) -> (c::Any) -> (a, c::Any)
 Linearity (3) (#795)
 fun (x)(y) {(x, y)}
 stdout : fun : (a) -> (c::Any) -> (a, c::Any)
-ignore : Failing test case
 
 Linearity (4)
 linfun (x){ linfun (y) {(x, y)}}
@@ -130,3 +129,11 @@ stdout : fun : (a::Any) -@ (c::Any) -@ (a::Any, c::Any)
 Linearity (5)
 linfun (x)(y) {(x, y)}
 stdout : fun : (a::Any) -@ (c::Any) -@ (a::Any, c::Any)
+
+Linearity (6) (#797)
+fun f(x)(y) {(x, y)} f
+stdout : fun : (a) -> (c::Any) -> (a, c::Any)
+
+Linearity (7) (#797)
+fun f(x)(y) {f(x)(y)} f
+stdout : fun : (_) -> (_::Any) ~> _::Any

--- a/tests/functions.tests
+++ b/tests/functions.tests
@@ -144,4 +144,5 @@ stdout : fun : (a::Any) -@ (c::Any) -@ (a::Any, c::Any)
 
 Linearity (9) - linear recursive functions should be disallowed
 linfun f(x) {f(x)} f
-stderr : @.*
+stderr : @.*cannot be linear.*
+exit : 1

--- a/tests/functions.tests
+++ b/tests/functions.tests
@@ -142,6 +142,6 @@ Linearity (8) (#797)
 linfun f(x)(y) {(x, y)} f
 stdout : fun : (a::Any) -@ (c::Any) -@ (a::Any, c::Any)
 
-Linearity (9) (#797)
-linfun f(x)(y) {f(x)(y)} f
-stdout : fun : (_::Any) -@ (_::Any) ~@ _::Any
+Linearity (9) - linear recursive functions should be disallowed
+linfun f(x) {f(x)} f
+stderr : @.*

--- a/tests/functions.tests
+++ b/tests/functions.tests
@@ -137,3 +137,11 @@ stdout : fun : (a) -> (c::Any) -> (a, c::Any)
 Linearity (7) (#797)
 fun f(x)(y) {f(x)(y)} f
 stdout : fun : (_) -> (_::Any) ~> _::Any
+
+Linearity (8) (#797)
+linfun f(x)(y) {(x, y)} f
+stdout : fun : (a::Any) -@ (c::Any) -@ (a::Any, c::Any)
+
+Linearity (9) (#797)
+linfun f(x)(y) {f(x)(y)} f
+stdout : fun : (_::Any) -@ (_::Any) ~@ _::Any


### PR DESCRIPTION
In an anonymous function only the last argument can be linear. This patch is based on #796.

Fixes #795