### PR TITLE
Add the `exp` function to `lib.ml`

### DIFF
--- a/core/lib.ml
+++ b/core/lib.ml
@@ -1127,6 +1127,7 @@ let env : (string * (located_primitive * Types.datatype * pure)) list = [
   "tan",     float_fn tan PURE;
   "log",     float_fn log PURE;
   "log10",   float_fn log10 PURE;
+  "exp",     float_fn exp PURE;
   "sqrt",    float_fn sqrt PURE;
 
   ("environment",

--- a/tests/builtins.tests
+++ b/tests/builtins.tests
@@ -1,0 +1,8 @@
+exp is the inverse of log
+exp(log(2.0))
+stdout : 2.0 : Float
+
+log is the inverse of exp
+log(exp(2.0))
+stdout : 2.0 : Float
+


### PR DESCRIPTION
We have the `log` function in `lib.ml`, but not its inverse `exp`. Now we do.