### PR TITLE
Operator associativity and precedence

### DIFF
--- a/core/context.ml
+++ b/core/context.ml
@@ -6,7 +6,8 @@ type t =
     value_environment: Value.env;
     variable_environment: Types.datatype Env.Int.t; (* TODO remove. *)
     source_code: SourceCode.source_code;          (* TODO remove. *)
-    ffi_files: string list }                      (* TODO remove. *)
+    ffi_files: string list;                      (* TODO remove. *)
+    operator_table: (int * Operators.Associativity.t) Utility.StringMap.t option } (* TODO remove. *)
 
 let empty_code = new SourceCode.source_code
 
@@ -16,7 +17,8 @@ let empty =
     name_environment = Env.String.empty;
     value_environment = Value.Env.empty;
     source_code = empty_code;
-    ffi_files = [] }
+    ffi_files = [];
+    operator_table = None }
 
 let typing_environment { typing_environment; _ } = typing_environment
 let name_environment { name_environment; _ } = name_environment
@@ -24,3 +26,4 @@ let value_environment { value_environment; _ } = value_environment
 let source_code { source_code; _ } = source_code
 let variable_environment { variable_environment; _ } = variable_environment
 let ffi_files { ffi_files; _ } = ffi_files
+let operator_table { operator_table; _ } = operator_table

--- a/core/desugarModules.ml
+++ b/core/desugarModules.ml
@@ -280,6 +280,12 @@ and desugar ?(toplevel=false) (renamer' : Epithet.t) (scope' : Scope.t) =
       self#bind_term name name';
       Binder.set_name bndr name'
 
+    method fixity : string -> string
+      = fun name ->
+      let name' = if toplevel then Epithet.expand renamer name else name in
+      self#bind_term name name';
+      name'
+
     method bind_term name name' =
       scope <- Scope.Extend.var name name' scope
 
@@ -483,6 +489,8 @@ and desugar ?(toplevel=false) (renamer' : Epithet.t) (scope' : Scope.t) =
              Alien.(declarations aliendecls)
          in
          AlienBlock (Alien.modify ~declarations:decls' aliendecls)
+      | Infix { name; assoc; precedence } ->
+         Infix { name = self#fixity name; assoc; precedence }
       | Module _ | Import _ | Open _ -> assert false (* Should have been processed by this point. *)
       | b -> super#bindingnode b
 

--- a/core/frontend.ml
+++ b/core/frontend.ml
@@ -126,6 +126,7 @@ module Untyped = struct
     = [| (module ResolvePositions)
        ; (module CheckXmlQuasiquotes)
        ; (module DesugarModules)
+       ; (module Shunting)
        ; (module Collect_FFI_Files)
        ; only_if Basicsettings.Sessions.exceptions_enabled (module DesugarSessionExceptions)
        ; (module DesugarLAttributes)

--- a/core/operators.ml
+++ b/core/operators.ml
@@ -17,7 +17,7 @@ type regexflag = RegexList | RegexNative | RegexGlobal | RegexReplace
     [@@deriving show]
 
 module Associativity = struct
-  type t = Left | Right | None | Pre | Post
+  type t = Left | Right | None
     [@@deriving show]
 end
 

--- a/core/parser.mly
+++ b/core/parser.mly
@@ -424,7 +424,7 @@ tlfunbinding:
 | fun_kind VARIABLE arg_lists perhaps_location block           { ($1, $2, $3, $4, $5)                }
 | OP pattern sigop pattern perhaps_location block              { ((dl_unl, false), WithPos.node $3, [[$2; $4]], $5, $6) }
 | OP OPERATOR pattern perhaps_location block                   { ((dl_unl, false), $2, [[$3]], $4, $5)          }
-| OP pattern OPERATOR perhaps_location block                  { ((dl_unl, false), $3, [[$2]], $4, $5)          }
+| OP pattern OPERATOR perhaps_location block                   { ((dl_unl, false), $3, [[$2]], $4, $5)          }
 
 tlvarbinding:
 | VAR VARIABLE perhaps_location EQ exp                         { (PatName $2, $5, $3) }

--- a/core/shunting.ml
+++ b/core/shunting.ml
@@ -1,0 +1,296 @@
+(* An implementation of Dijkstra's Shunting Yard algorithm. *)
+open Sugartypes
+open SourceCode.WithPos
+open Operators
+
+let name_of_binop = function
+  | BinaryOp.Minus -> "-"
+  | BinaryOp.FloatMinus -> "-."
+  | BinaryOp.RegexMatch _ -> "=~"
+  | BinaryOp.And -> "&&"
+  | BinaryOp.Or -> "||"
+  | BinaryOp.Cons -> "::"
+  | BinaryOp.Name name -> name
+
+let name_of_unop = function
+  | UnaryOp.Minus -> "-"
+  | UnaryOp.FloatMinus -> "-."
+  | UnaryOp.Name name -> name
+
+type 'a partial_op =
+  { partial_node: (tyarg list * 'a);
+    assoc: Associativity.t;
+    precedence: int;
+    position: SourceCode.Position.t }
+
+type op =
+  | Unary  of UnaryOp.t partial_op
+  | Binary of BinaryOp.t partial_op
+
+type exp =
+  | Op of op
+  | Operand of phrase
+
+let assoc : 'a partial_op -> Associativity.t
+  = fun { assoc; _ } -> assoc
+
+let precedence : 'a partial_op -> int
+  = fun { precedence; _ } -> precedence
+
+let op_precedence : op -> int = function
+  | Unary pnode -> precedence pnode
+  | Binary pnode -> precedence pnode
+
+let op_assoc : op -> Associativity.t = function
+  | Unary pnode -> assoc pnode
+  | Binary pnode -> assoc pnode
+
+let partial_op : (tyarg list * 'a) -> Associativity.t -> int -> SourceCode.Position.t -> 'a partial_op
+  = fun partial_node assoc precedence position ->
+  { partial_node; assoc; precedence; position }
+
+let binary : phrase -> BinaryOp.t partial_op -> phrase -> phrase
+  = fun lhs op rhs ->
+  make ~pos:op.position (InfixAppl (op.partial_node, lhs, rhs))
+
+let unary : phrase -> UnaryOp.t partial_op -> phrase
+  = fun exp op ->
+  make ~pos:op.position (UnaryAppl (op.partial_node, exp))
+
+
+module Optable = struct
+  type t = (int * Associativity.t) Utility.StringMap.t
+  let defaults : t =
+    let open Associativity in
+    let xs =
+      [ "::" , (9, Right)
+
+      ; "^"  , (8, Right)
+      ; "^^" , (8, Right)
+      ; "**" , (8, Right)
+
+      ; "*"  , (7, Left)
+      ; "/"  , (7, Left)
+      ; "+"  , (6, Left)
+      ; "*." , (7, Left)
+      ; "/." , (7, Left)
+      ; "+." , (6, Left)
+
+      ; "-"  , (6, Left)
+      ; ".-" , (6, Left)
+
+      ; "!"  , (6, Left)
+
+      ; "++" , (5, Right)
+
+      ; "=~" , (5, Right)
+
+      ; "==" , (4, None)
+      ; "<>" , (4, None)
+      ; "<"  , (4, None)
+      ; "<=" , (4, None)
+      ; ">=" , (4, None)
+      ; ">"  , (4, None)
+
+      ; "&&" , (3, Right)
+
+      ; "||" , (2, Right)
+
+      ;  ">>" , (1, Left)
+      ;  "$"  , (1, Right) ]
+    in
+    Utility.StringMap.from_alist xs
+
+  let lookup : string -> t -> (int * Associativity.t)
+    = fun name optable ->
+    try Utility.StringMap.find name optable with
+    | Notfound.NotFound _ -> (9, Associativity.Left)
+
+  let add : string -> (int * Associativity.t) -> t -> t
+    = fun name data optable ->
+    Utility.StringMap.add name data optable
+end
+
+
+(* Pops an operator from a given operator stack and adds it to a given
+   RPN expression. *)
+let shift : op Stack.t -> exp Queue.t -> unit
+  = fun opstack exps ->
+  assert (not (Stack.is_empty opstack));
+  let op = Stack.pop opstack in
+  Queue.push (Op op) exps
+
+(* Pops all operators from a given operator stack and adds them to a
+   given RPN expression. *)
+let rec shift_all : op Stack.t -> exp Queue.t -> unit
+  = fun opstack exps ->
+  if not (Stack.is_empty opstack)
+  then (shift opstack exps; shift_all opstack exps)
+
+(* Pushes an operator onto a given operator stack. As a side-effect
+   the given RPN expression may be augmented. *)
+let rec push_operator : op Stack.t -> exp Queue.t -> op -> unit
+  = fun opstack exps tok ->
+  (* Let 'tok' denote most recently scanned operator and 'op' be the
+     top-most operator on the operator stack.
+
+     The operator 'tok' is said to follow the operator 'op' if either
+     condition is met:
+
+     1) The precedence of 'op' is greater than the precedence of
+     'tok',
+     2) or 'op' and 'tok' have the same precedence and 'tok' is left
+     associative. *)
+  let follows : op -> op -> bool
+    = fun tok op ->
+    let tok_prec, tok_assoc, op_prec =
+      op_precedence tok, op_assoc tok, op_precedence op
+    in
+    (op_prec > tok_prec)
+    || (tok_prec = op_prec && tok_assoc = Associativity.Left)
+  in
+  if Stack.is_empty opstack
+  then Stack.push tok opstack
+  else if follows tok (Stack.top opstack)
+  then (shift opstack exps;
+        push_operator opstack exps tok)
+  else Stack.push tok opstack
+
+(* Builds an infix expression from a given RPN expression. *)
+let reduce : exp Queue.t -> phrase
+  = fun exps ->
+  assert (Queue.length exps > 0);
+  let rec loop operands exps =
+    if not (Queue.is_empty exps)
+    then begin (match Queue.pop exps with
+                | Operand p ->
+                   Stack.push p operands
+                | Op (Unary pnode) ->
+                   assert (Stack.length operands > 0);
+                   let p = Stack.pop operands in
+                   Stack.push (unary p pnode) operands
+                | Op (Binary pnode) ->
+                   assert (Stack.length operands > 0);
+                   (* Operands are popped in reverse order. *)
+                   let q = Stack.pop operands in
+                   let p = Stack.pop operands in
+                   Stack.push (binary p pnode q) operands);
+               loop operands exps
+         end
+  in
+  let operands = Stack.create () in
+  loop operands exps;
+  assert (Stack.length operands = 1);
+  Stack.pop operands
+
+(* Main idea: use two mutually recursive visitors. One visitor reorders
+   infix expressions, whilst the other maps this visitor over infix
+   expressions. *)
+
+(* This class reorders infix expressions according to the precedence
+   and associativity of the operators within them. *)
+class reorder optable =
+  object (o : 'self)
+    inherit SugarTraversals.fold as _super
+
+    (* Operator stack. *)
+    val opstack :  op Stack.t = Stack.create ()
+    (* The expression in Reverse Polish Notation (RPN). *)
+    val exps    : exp Queue.t = Queue.create ()
+
+    (* Reconstructs an infix expression from the resulting RPN
+       expression. *)
+    method reconstruct : unit -> phrase
+      = fun () ->
+      shift_all opstack exps;
+      reduce exps
+
+    method! phrase p =
+      match node p with
+      | Constant _ | Var _ ->
+         Queue.push (Operand p) exps; o
+      | InfixAppl ((_, op) as def, p', q') ->
+         let o = o#phrase p' in
+         let () =
+           let prec, assoc = Optable.lookup (name_of_binop op) optable in
+           let def' = partial_op def assoc prec (pos p) in
+           push_operator opstack exps (Binary def')
+         in
+         o#phrase q'
+      | UnaryAppl ((_, op) as def, p') ->
+         let o = o#phrase p' in
+         let () =
+           let prec, assoc =
+             match name_of_unop op with
+             | "-" | "-." -> 9, Associativity.Right
+             | _ -> Optable.lookup (name_of_unop op) optable
+           in
+           let def' = partial_op def assoc prec (pos p) in
+           push_operator opstack exps (Unary def')
+         in o
+      | _ ->
+         let p' = (new shunt optable)#phrase p in
+         Queue.push (Operand p') exps; o
+
+    (* This visitor should never visit any other nodes than [phrase]. *)
+    method! binding _ = assert false
+    method! bindingnode _ = assert false
+    method! program _ = assert false
+
+  end
+  (* This visitor traverses the whole AST. On any phrase expression it
+     effectively acts as a pair of enclosing parentheses, ensuring
+     that left-to-right evaluation order is preserved for non-infix
+     expression. *)
+  and shunt optable =
+      object
+        inherit SugarTraversals.map as super
+
+        (* The operator table may be updated as a result of running
+           this visitor. *)
+        val mutable optable = optable
+        method get_optable () = optable
+
+        method! phrase p =
+          match node p with
+          | InfixAppl _ | UnaryAppl _ ->
+             let reorder = (new reorder optable)#phrase p in
+             reorder#reconstruct ()
+          | _ -> super#phrase p
+
+        method! bindingnode = function
+          | (Infix { name; assoc; precedence }) as node ->
+             optable <- Optable.add name (precedence, assoc) optable;
+             node
+          | node -> super#bindingnode node
+      end
+
+module Untyped = struct
+  let name = "shunting"
+
+  let get_operator_table context =
+    match Context.operator_table context with
+    | None -> Optable.defaults
+    | Some table -> table
+
+  open Transform.Untyped
+  let program state program =
+    (* Printf.fprintf stderr "Before shunting:\n%s\n%!" (Sugartypes.show_program program); *)
+    let context = context state in
+    let optable = get_operator_table context in
+    let shunter = new shunt optable in
+    let program' = shunter#program program in
+    (* Printf.fprintf stderr "After shunting:\n%s\n%!" (Sugartypes.show_program program'); *)
+    let optable = shunter#get_optable () in
+    let context' = Context.({ context with operator_table = Some optable }) in
+    return context' program'
+
+  let sentence state sentence =
+    let context = context state in
+    let optable = get_operator_table context in
+    let shunter = new shunt optable in
+    let sentence' = shunter#sentence sentence in
+    let optable = shunter#get_optable () in
+    let context' = Context.({ context with operator_table = Some optable }) in
+    return context' sentence'
+end

--- a/core/sugarTraversals.ml
+++ b/core/sugarTraversals.ml
@@ -700,7 +700,8 @@ class map =
       | Typenames ts ->
           let _x = o#list (fun o -> o#typename) ts in
           Typenames _x
-      | Infix -> Infix
+      | Infix { name; assoc; precedence } ->
+         Infix { name = o#name name; assoc; precedence }
       | Exp _x -> let _x = o#phrase _x in Exp _x
       | Module { binder; members } ->
           let binder = o#binder binder in
@@ -1408,7 +1409,8 @@ class fold =
       | Typenames ts ->
           let o = o#list (fun o -> o#typename) ts in
           o
-      | Infix -> o
+      | Infix { name; _ } ->
+         o#name name
       | Exp _x -> let o = o#phrase _x in o
       | Module { binder; members } ->
           let o = o#binder binder in
@@ -2259,7 +2261,9 @@ class fold_map =
       | Typenames ts ->
           let (o, _x) = o#list (fun o -> o#typename) ts in
           (o, (Typenames _x))
-      | Infix -> (o, Infix)
+      | Infix { name; assoc; precedence } ->
+         let (o, name) = o#name name in
+         (o, Infix { name; assoc; precedence })
       | Exp _x -> let (o, _x) = o#phrase _x in (o, (Exp _x))
       | Module { binder; members } ->
           let (o, binder) = o#binder binder in

--- a/core/sugartoir.ml
+++ b/core/sugartoir.ml
@@ -1199,7 +1199,7 @@ struct
                    I.alien ((xt, x, scope), Alien.object_name alien, Alien.language alien,
                             fun v -> eval_bindings scope (extend [x] [(v, xt)] env) bs e)
                 | Typenames _
-                | Infix ->
+                | Infix _ ->
                     (* Ignore type alias and infix declarations - they
                        shouldn't be needed in the IR *)
                     eval_bindings scope env bs e

--- a/core/sugartypes.ml
+++ b/core/sugartypes.ml
@@ -395,7 +395,9 @@ and bindingnode =
   | Import of { pollute: bool; path : Name.t list }
   | Open of Name.t list
   | Typenames of typename list
-  | Infix
+  | Infix   of { assoc: Associativity.t;
+                 precedence: int;
+                 name: string }
   | Exp     of phrase
   | Module  of { binder: Binder.with_pos; members: binding list }
   | AlienBlock of Alien.multi Alien.t
@@ -643,8 +645,10 @@ struct
           names, union_map (fun rhs -> diff (funlit rhs) names) rhss
     | Import _
     | Open _
-    | Typenames _
-    | Infix -> empty, empty
+    | Typenames _ -> empty, empty
+    (* This is technically a declaration, thus the name should
+       probably be treated as bound rather than free. *)
+    | Infix { name; _ } -> empty, singleton name
     | Exp p -> empty, phrase p
     | Foreign alien ->
        let bound_foreigns =

--- a/core/transformSugar.ml
+++ b/core/transformSugar.ml
@@ -833,7 +833,8 @@ class transform (env : Types.typing_environment) =
                 | None -> raise (internal_error "Unannotated type alias")
             ) ts in
           (o, Typenames ts)
-      | Infix -> (o, Infix)
+      | (Infix _) as node ->
+         (o, node)
       | Exp e -> let (o, e, _) = o#phrase e in (o, Exp e)
       | AlienBlock _ -> assert false
       | Module _ -> assert false

--- a/core/typeSugar.ml
+++ b/core/typeSugar.ml
@@ -152,7 +152,7 @@ struct
     | Module _
     | Fun _
     | Funs _
-    | Infix
+    | Infix _
     | Typenames _
     | Foreign _ -> true
     | Exp p -> is_pure p
@@ -4599,7 +4599,7 @@ and type_binding : context -> binding -> binding * context * Usage.t =
                 | None -> raise (internal_error "typeSugar.ml: unannotated type")
           ) empty_context ts in
           (Typenames ts, env, Usage.empty)
-      | Infix -> Infix, empty_context, Usage.empty
+      | Infix def -> Infix def, empty_context, Usage.empty
       | Exp e ->
           let e = tc e in
           let () = unify pos ~handle:Gripers.bind_exp

--- a/tests/fixity.links
+++ b/tests/fixity.links
@@ -1,0 +1,84 @@
+# Tests fixity of operators.
+
+fun assertion(e, s) {
+  if (not(e)) println("Assertion failure: " ^^ s)
+  else ()
+}
+
+# Some silly operations
+prefix 9 @@;
+sig @@ : (a) -> [a]
+op @@ x { [x] }
+
+prefix 3 @@@@;
+sig @@@@ : ([a]) -> [[a]]
+op @@@@ xs { [xs] }
+
+infix 2 ++++;
+sig ++++ : ([[a]], [[a]]) -> [[a]]
+op xss ++++ yss { xss ++ yss }
+
+postfix 1 <<>>;
+sig <<>> : (a) -> (a, ())
+op x <<>> { (x, ()) }
+
+fun test1() { @@ 0 }
+fun test2() { @@@@ @@ 0 }
+fun test3() { 0 <<>> }
+fun test4() { @@@@ @@ 0 <<>> }
+fun test5() {
+  @@@@ [1,2] ++ [3,4] ++++ @@@@ [5,6] ++ @@ 7 ++ @@ 8 <<>>
+}
+
+prefix 7 -*;
+op -* x { -1*x }
+postfix 8 *++;
+op *+ x { x + 2 }
+
+fun test6() { -* -3 *+ }
+
+prefix 8 -*;
+postfix 7 *+;
+fun test7() { -* -3 *+ }
+
+prefix 8 -*;
+postfix 8 *+;
+fun test8() { -* -3 *+ }
+
+# Overloading of primitive arithmetic operations.
+fun test9() { 2 + 3 * 3 - 2 / 3 }
+
+infixl 9 +;
+fun test10() { 2 + 3 * 3 - 2 / 3 }
+
+infixl 6 +;
+infixl 1 /;
+fun test11() { 2 + 3 * 3 - 2 / 3 }
+
+infixl 2 *;
+fun test12() { 2 + 3 * 3 - 2 / 3 }
+
+infixl 8 --;
+op x -- y { x - y }
+infixl 6 /;
+infixl 5 *;
+infixl 4 +;
+fun test13() { 2 + 3 * 3 -- 2 / 3 }
+
+fun main() {
+  assertion(test1() == [0], "test1");
+  assertion(test2() == [[0]], "test2");
+  assertion(test3() == (0, ()), "test3");
+  assertion(test4() == ([[0]], ()), "test4");
+  assertion(test5() == ([[1,2,3,4],[5,6,7,8]], ()), "test5");
+  assertion(test6() == 1, "test6");
+  assertion(test7() == 5, "test7");
+  assertion(test8() == 5, "test8");
+  assertion(test9() == 11, "test9");
+  assertion(test10() == 15, "test10");
+  assertion(test11() == 3, "test11");
+  assertion(test12() == 1, "test12");
+  assertion(test13() == 2, "test13");
+}
+
+main()

--- a/tests/operators.tests
+++ b/tests/operators.tests
@@ -77,3 +77,9 @@ stdout : [1, 2, 4, 8] : [Int]
 List concatenation
 1 :: [] ++ [] ++ 2 :: 3 :: 4 :: [] ++ 5 :: []
 stdout : [1, 2, 3, 4, 5] : [Int]
+
+Fixity tests
+./fixity.links
+filemode : true
+stdout : () : ()
+args : --path=tests/


### PR DESCRIPTION
Prior to this patch the associativity and precedence of user-definable
operators would be stored in the internal state of the lexer. This
state was not preserved between invocations of the lexer on per
compilation unit and per REPL entry. As a consequence, during
subsequent parses every previously defined operator would default to
be left associative and have precedence 9.

This patch removes the operator associativity and precedence
information from the lexer. Instead of handling associativity and
precedence in the lexer and parser, they are now handled by the
transformation `shunting` which applies a variation of the Shunting
Yard algorithm on expressions. The transform uses our transformation
infrastructure to preserve and pass an operator table between
subsequent invocation of this transform. As a result both the lexer
and parser are greatly simplified. I believe this patch opens the door
for more rule simplifications in the parser, but I will leave that for
future work.

Currently, a default operator table is hard-coded in the `shunting`
module. My front-end bootstrapping patch hoists this table out of the
compiler and into a Links source file.