### PR TITLE
Fixes #807

### DIFF
--- a/core/query/query.ml
+++ b/core/query/query.ml
@@ -1222,7 +1222,7 @@ let compile_delete : Value.database -> Value.env ->
   ((Ir.var * string * Types.datatype StringMap.t) * Ir.computation option) -> string =
   fun db env ((x, table, field_types), where) ->
     let env = Eval.bind (Eval.env_of_value_env QueryPolicy.Default env) (x, Q.Var (x, field_types)) in
-    let where = opt_map (Eval.computation env) where in
+    let where = opt_map (Eval.norm_comp env) where in
     let q = delete db ((x, table), where) in
       Debug.print ("Generated update query: "^q);
       q


### PR DESCRIPTION
This is a tiny fix for an overlooked detail in the `Query.compile_delete`. Unlike its sibling `compile_update`, this was trying to generate SQL without performing normalization first.