### PR TITLE
Fix compilation warning 67 emitted by OCaml 4.10.0

### DIFF
--- a/dune
+++ b/dune
@@ -1,19 +1,19 @@
 (env
  (dev
   (flags (:standard
-          -strict-formats  ;; Disallows legacy formats.
-          -strict-sequence ;; Enforces the lhs of a sequence to have type `unit'.
-          -safe-string     ;; Immutable strings.
-          -annot           ;; Dumps information per (file) module about types, bindings, tail-calls, etc. Used by some tools.
-          -warn-error -a   ;; Do not treat warnings as errors.
-          -w A-4-44-45-60  ;; Ignores warnings 4, 44, 45, and 60.
-          -g               ;; Adds debugging information to the resulting executable / library.
+          -strict-formats     ;; Disallows legacy formats.
+          -strict-sequence    ;; Enforces the lhs of a sequence to have type `unit'.
+          -safe-string        ;; Immutable strings.
+          -annot              ;; Dumps information per (file) module about types, bindings, tail-calls, etc. Used by some tools.
+          -warn-error -a      ;; Do not treat warnings as errors.
+          -w A-4-44-45-60-67  ;; Ignores warnings 4, 44, 45, 60, and 67.
+          -g                  ;; Adds debugging information to the resulting executable / library.
  )))
  (release
   (flags (:standard
           ;; The following flags are the same as for the "dev" profile.
           -strict-formats -strict-sequence -safe-string -annot
-          -w A-4-44-45-60  ;; ... except for warnings 4, 44, 45, and 60 which are ignored.
+          -w A-4-44-45-60-67  ;; Ignores warnings 4, 44, 45, 60, and 67.
   ))
   (ocamlopt_flags (:standard
                    -O3 ;; Applies (aggressive) optimisations to the resulting executable.
@@ -21,8 +21,8 @@
  (ci      ;; Same as release, except warnings are treated as errors.
   (flags (:standard
           -strict-formats -strict-sequence -safe-string -annot
-          -warn-error @A   ;; Treat warnings as errors...
-          -w A-4-44-45-60  ;; ... except for warnings 4, 44, 45, and 60 which are ignored.
+          -warn-error @A      ;; Treat warnings as errors...
+          -w A-4-44-45-60-67  ;; ... except for warnings 4, 44, 45, 60, and 67 which are ignored.
   ))
   (ocamlopt_flags (:standard -O3))
 ))


### PR DESCRIPTION
Our codebase triggers numerous instances of warning 67 with OCaml
4.10.0. This patch fixes those instances such that our codebase no
longer emits any warnings under any of our compilation profiles.