### PR TITLE
Distinguished end-of-file token.

### DIFF
--- a/core/lexer.mll
+++ b/core/lexer.mll
@@ -173,9 +173,8 @@ let opchar = [ '.' '!' '$' '&' '*' '+' '/' '<' '=' '>' '@' '\\' '^' '-' '|' ]
 *)
 
 rule lex ctxt nl = parse
-  | eof                                 { END }
+  | eof                                 { EOF }
   | '#' ([^ '\n'] *)                    { lex ctxt nl lexbuf }
-  | "End"                               { END }
   | ';'                                 { SEMICOLON }
   | directive_prefix (def_id as id)     { KEYWORD id}
   | '\n'                                { nl (); bump_lines lexbuf 1; lex ctxt nl lexbuf }
@@ -250,7 +249,7 @@ rule lex ctxt nl = parse
   | def_blank                           { lex ctxt nl lexbuf }
   | _                                   { raise (LexicalError (lexeme lexbuf, lexeme_end_p lexbuf)) }
 and starttag ctxt nl = parse
-  | eof                                 { END }
+  | eof                                 { EOF }
   | def_qname as var                    { VARIABLE var }
   | '='                                 { EQ }
   | '#' ([^ '\n'] *)                    { starttag ctxt nl lexbuf }
@@ -271,7 +270,7 @@ and xmlcomment_lex ctxt nl = parse
   | "--"                                { raise (LexicalError (lexeme lexbuf, lexeme_end_p lexbuf)) }
   | _                                   { xmlcomment_lex ctxt nl lexbuf }
 and xmllex ctxt nl = parse
-  | eof                                 { END }
+  | eof                                 { EOF }
   | "<!--"                              { xmlcomment_lex ctxt nl lexbuf }
   | "{{"                                { CDATA "{" }
   | "}}"                                { CDATA "}" }
@@ -290,7 +289,7 @@ and xmllex ctxt nl = parse
                                           ctxt#push_lexer (starttag ctxt nl); LXML var }
   | _                                   { raise (LexicalError (lexeme lexbuf, lexeme_end_p lexbuf)) }
 and attrlex ctxt nl = parse
-  | eof                                 { END }
+  | eof                                 { EOF }
   | '"'                                 { (* fall back *)
                                           ctxt#pop_lexer; RQUOTE }
   | '{'                                 { (* scan the expression, then back here *)
@@ -298,7 +297,7 @@ and attrlex ctxt nl = parse
   | [^ '{' '"']* as string              { bump_lines lexbuf (count_newlines string); STRING string }
   | _                                   { raise (LexicalError (lexeme lexbuf, lexeme_end_p lexbuf)) }
 and regex' ctxt nl = parse
-  | eof                                 { END }
+  | eof                                 { EOF }
   | '/'                                 { ctxt#push_lexer (regex ctxt nl); SLASH }
   | "s/"                                { ctxt#push_lexer (regexrepl ctxt nl); (* push twice is intentional *)
                       ctxt#push_lexer (regexrepl ctxt nl);
@@ -308,7 +307,7 @@ and regex' ctxt nl = parse
   | '\n'                                { nl (); bump_lines lexbuf 1; regex' ctxt nl lexbuf }
   | def_blank                           { regex' ctxt nl lexbuf }
 and regex ctxt nl = parse
-  | eof                                 { END }
+  | eof                                 { EOF }
   | '/'                                 { ctxt#pop_lexer; ctxt#pop_lexer; SLASH }
   | '/' (regex_flags as f)              { ctxt#pop_lexer; ctxt#pop_lexer; SLASHFLAGS (f) }
   | '.'                                 { DOT }
@@ -328,7 +327,7 @@ and regex ctxt nl = parse
   | def_blank                           { regex ctxt nl lexbuf }
   | (_ as c)                            { STRING (String.make 1 c) }
 and regexrepl ctxt nl = parse
-  | eof                                 { END }
+  | eof                                 { EOF }
   | regexrepl_fsa as var                { REGEXREPL(var) }
   | '{'                                 { (* scan the expression, then back here *)
                                           ctxt#push_lexer (lex ctxt nl); LBRACE }

--- a/core/parser.mly
+++ b/core/parser.mly
@@ -244,7 +244,7 @@ let parse_foreign_language pos lang =
 
 %}
 
-%token END
+%token EOF
 %token EQ IN
 %token FUN LINFUN FROZEN_FUN FROZEN_LINFUN RARROW LOLLI FATRARROW VAR OP
 %token SQUIGRARROW SQUIGLOLLI TILDE
@@ -333,12 +333,12 @@ interactive:
 | SEMICOLON                                                    { Definitions []   }
 | exp SEMICOLON                                                { Expression $1    }
 | directive                                                    { Directive $1     }
-| END                                                          { Directive ("quit", []) (* rather hackish *) }
+| EOF                                                          { Directive ("quit", []) (* rather hackish *) }
 
 file:
-| END                                                          { ([], None) }
-| declarations exp? END                                        { ($1, $2     ) }
-| exp END                                                      { ([], Some $1) }
+| EOF                                                          { ([], None) }
+| declarations exp? EOF                                        { ($1, $2     ) }
+| exp EOF                                                      { ([], Some $1) }
 
 directive:
 | KEYWORD args SEMICOLON                                       { ($1, $2) }
@@ -854,7 +854,7 @@ labeled_exps:
  * Datatype grammar
  */
 just_datatype:
-| datatype END                                                 { $1 }
+| datatype EOF                                                 { $1 }
 
 datatype:
 | mu_datatype | straight_arrow | squiggly_arrow                { with_pos $loc $1 }
@@ -922,7 +922,6 @@ session_datatype:
 | QUESTION primary_datatype_pos DOT datatype                   { Datatype.Input  ($2, $4) }
 | LBRACKETPLUSBAR row BARPLUSRBRACKET                          { Datatype.Select $2       }
 | LBRACKETAMPBAR row BARAMPRBRACKET                            { Datatype.Choice $2       }
-| END                                                          { Datatype.End             }
 | primary_datatype                                             { $1                       }
 | qualified_type_name                                          { Datatype.QualifiedTypeApplication ($1, []) }
 | qualified_type_name LPAREN type_arg_list RPAREN              { Datatype.QualifiedTypeApplication ($1, $3) }
@@ -956,6 +955,7 @@ primary_datatype:
                                                                    | "XmlItem" -> Primitive Primitive.XmlItem
                                                                    | "String"  -> Primitive Primitive.String
                                                                    | "Database"-> DB
+                                                                   | "End"     -> Datatype.End
                                                                    | t         -> TypeApplication (t, [])
                                                                }
 | CONSTRUCTOR LPAREN type_arg_list RPAREN                      { Datatype.TypeApplication ($1, $3) }


### PR DESCRIPTION
This patch resolves #815 by introducing a distinguished end-of-file
token. Furthermore, this patch also garbage collects `End` as a
keyword to allow it to appear as a variant label at the term level. At
the type level `End` is still interpreted as the end datatype.

The below snippet illustrates various uses of `End`.

```
links> End;
End : [|End|_::Any|]
links> sig f : (End) ~> () fun f(x) { close(x) };
f = fun : (End) ~> ()
links> sig g : ([|End|]) ~> () fun g(_) { () };
g = fun : ([|End|]) ~> ()
links> sig h : ([|End:End|]) ~> () fun h(End(x)) { close(x)  };
h = fun : ([|End:End|]) ~> ()
```