### PR TITLE
Fix type ascription in lambda generated for comprehension bodies

### DIFF
--- a/core/desugarFors.ml
+++ b/core/desugarFors.ml
@@ -131,7 +131,7 @@ object (o : 'self_type)
 
                    let e = fn_appl "AsList" [r; w; n] [e] in
                    let var = Utility.gensym ~prefix:"_for_" () in
-                   let xb = binder ~ty:t var in
+                   let xb = binder ~ty:element_type var in
                      o, (e::es, with_dummy_pos (Pattern.As (xb, p))::ps,
                          var::xs, element_type::ts))
           (o, ([], [], [], []))

--- a/tests/typed_ir/T698.links
+++ b/tests/typed_ir/T698.links
@@ -1,0 +1,11 @@
+sig concatMap : ((a) -b-> [c], [a]) -b-> [c]
+fun concatMap(f, l) {
+  #dummy to avoid problems with unsafe signatures currently
+  #not being supported by IR type-checker
+  []
+}
+
+#The function we are actually interested in
+fun asList(t) server {
+  for (x <-- t) [x]
+}


### PR DESCRIPTION
Consider the expression `for (x <-- t) [x]`

where `t` has type `TableHandle(a,b,c)`

This currently desugars roughly to
```
concatMap(
    (fun (x : TableHandle(a,b,c))  {[x]}),
    (asList t))
```

However, this is wrong, because the type of `x` in the lambda should be `a` rather than  `TableHandle(a,b,c)`, because we wrap `t` in `AsList`

These desugarings happen after `TypeSugar`, which is why we only detected this as an IR type error (#698). Hence, this fixes #698.
