### PR TITLE
Properly register test for #698 in typed_ir.tests

### DIFF
--- a/tests/typed_ir.tests
+++ b/tests/typed_ir.tests
@@ -46,3 +46,8 @@ Curry (#574)
 tests/typed_ir/T574.links
 filemode : true
 stdout : () : ()
+
+asList (#698)
+tests/typed_ir/T698.links
+filemode : true
+stdout : () : ()


### PR DESCRIPTION
In another PR, @jstolarek observed that I had created a test file for an IR test, but forgot to register it in `typed_ir.tests`. The same problem happened in #820, where I added a test for  #698.