### PR TITLE
Remove Ocamlformat from blacklist

### DIFF
--- a/.ocamlformat
+++ b/.ocamlformat
@@ -1,5 +1,6 @@
 break-cases=all
 doc-comments=before
+doc-comments-val=before
 module-item-spacing=preserve
 break-infix=fit-or-vertical
 indicate-nested-or-patterns=space

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,8 @@ before_install:
   - ./opam2_local switch create ocaml-base-compiler.4.06.0
   - eval `./opam2_local config env`
   - ./opam2_local install conf-libev
-  - ./opam2_local install -y postgresql ounit2 ocamlformat
+  - ./opam2_local install -y postgresql ounit2
+  - ./tools/install_ocamlformat
   - make rule-check
   - psql -c 'create database links;' -U postgres
 script:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -66,7 +66,7 @@ steps:
 
   - script: |
       eval `./opam2_local env`
-      ./opam2_local install ocamlformat.0.14.1 -y
+      ./tools/install_ocamlformat
     displayName: 'OCamlformat'
 
   - script: |

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -66,7 +66,7 @@ steps:
 
   - script: |
       eval `./opam2_local env`
-      ./opam2_local install ocamlformat -y
+      ./opam2_local install ocamlformat.0.14.1 -y
     displayName: 'OCamlformat'
 
   - script: |

--- a/tools/install_ocamlformat
+++ b/tools/install_ocamlformat
@@ -1,0 +1,1 @@
+./opam2_local install -y ocamlformat.0.14.1

--- a/tools/rule-check
+++ b/tools/rule-check
@@ -5,7 +5,7 @@
 #
 
 RULEDIR="tools/rules"
-BLACKLIST=("ocamlformat_check")
+BLACKLIST=("")
 
 function is_blacklisted () {
     local target="$1"


### PR DESCRIPTION
This branch updates our `.ocamlformat` file to be compatible with Ocamlformat 0.14.1. It also fixes ocamlformat to version 0.14.1 so that any future compatability updates don't affect the codebase. I've moved the installation of ocamlformat to `./tools/install_ocamlformat` which is then used by both `.travis.yml` as well as `azure-pipelines.yml`.