### PR TITLE
Abstract syntax for SQL modifications

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -45,7 +45,7 @@ BUILD_DIR:=$(ROOT)/_build
 # The build command and some standard build system flags
 BUILD=dune build
 SOURCES=links
-DB_SOURCES=links-postgresql,links-sqlite3
+DB_SOURCES=links-postgresql,links-sqlite3,links-mysql
 # Note: this relies on lazy expansion of `SOURCES'.
 COMMON_FLAGS=--only-packages $(SOURCES) --build-dir=$(BUILD_DIR)
 DEV_FLAGS=$(COMMON_FLAGS) --profile=dev

--- a/Makefile
+++ b/Makefile
@@ -45,7 +45,7 @@ BUILD_DIR:=$(ROOT)/_build
 # The build command and some standard build system flags
 BUILD=dune build
 SOURCES=links
-DB_SOURCES=links-postgresql,links-sqlite3,links-mysql
+DB_SOURCES=links-postgresql,links-sqlite3
 # Note: this relies on lazy expansion of `SOURCES'.
 COMMON_FLAGS=--only-packages $(SOURCES) --build-dir=$(BUILD_DIR)
 DEV_FLAGS=$(COMMON_FLAGS) --profile=dev

--- a/core/database.ml
+++ b/core/database.ml
@@ -86,11 +86,8 @@ let execute_command  (query:string) (db: database) : Value.t =
               ("An error occurred executing the query " ^ query ^ ": " ^ msg))
     end
 
-let execute_insert (table_name, field_names, vss) db =
-  execute_command (db#make_insert_query (table_name, field_names, vss)) db
-
-let execute_insert_returning (table_name, field_names, vss, returning) db =
-  let qs = db#make_insert_returning_query (table_name, field_names, vss, returning) in
+let execute_insert_returning returning q db =
+  let qs = db#make_insert_returning_query returning q in
   let rec run =
     function
       | [] -> assert false

--- a/core/database.mli
+++ b/core/database.mli
@@ -26,7 +26,5 @@ val execute_select : (string * Types.datatype) list -> string -> Value.database 
 
 val execute_untyped_select : string -> Value.database -> Value.t
 
-val execute_insert : (string * string list * string list list) ->  Value.database -> Value.t
-
-val execute_insert_returning : (string * string list * string list list * string) ->  Value.database -> Value.t
+val execute_insert_returning : string -> Sql.query ->  Value.database -> Value.t
 

--- a/core/evalir.ml
+++ b/core/evalir.ml
@@ -711,7 +711,7 @@ struct
          match EvalQuery.compile env (range, e) with
            | None -> computation env cont e
            | Some (db, q, t) ->
-               let q = db#string_of_query range q in
+               let q = db#string_of_query ~range q in
                let (fieldMap, _, _), _ =
                Types.unwrap_row(TypeUtils.extract_row t) in
                let fields =
@@ -739,7 +739,7 @@ struct
                   | _ -> assert false
                 in
                 let execute_shredded_raw (q, t) =
-                  let q = db#string_of_query range q in
+                  let q = db#string_of_query ~range q in
                   Database.execute_select_result (get_fields t) q db, t in
                 let raw_results =
                   EvalNestedQuery.Shred.pmap execute_shredded_raw p in
@@ -770,7 +770,7 @@ struct
               let (field_names,rows) = Value.row_columns_values rows in
               let q =
                 Query.insert table_name field_names rows
-                |> db#string_of_query None in
+                |> db#string_of_query in
               Debug.print ("RUNNING INSERT QUERY:\n" ^ q);
               let () = ignore (Database.execute_command q db) in
               apply_cont cont env (`Record [])
@@ -817,7 +817,7 @@ struct
       end >>= fun (db, table, field_types) ->
       let update_query =
         Query.compile_update db env ((Var.var_of_binder xb, table, field_types), where, body) in
-      let () = ignore (Database.execute_command (db#string_of_query None update_query) db) in
+      let () = ignore (Database.execute_command (db#string_of_query update_query) db) in
         apply_cont cont env (`Record [])
     | Delete ((xb, source), where) ->
         value env source >>= fun source ->
@@ -832,7 +832,7 @@ struct
         end >>= fun (db, table, field_types) ->
       let delete_query =
         Query.compile_delete db env ((Var.var_of_binder xb, table, field_types), where) in
-      let () = ignore (Database.execute_command (db#string_of_query None delete_query) db) in
+      let () = ignore (Database.execute_command (db#string_of_query delete_query) db) in
         apply_cont cont env (`Record [])
     | CallCC f ->
        value env f >>= fun f ->

--- a/core/query/evalQuery.ml
+++ b/core/query/evalQuery.ml
@@ -307,5 +307,5 @@ let compile : Value.env -> (int * int) option * Ir.computation -> (Value.databas
         | Some db ->
             let t = Types.unwrap_list_type (Q.type_of_expression v) in
             let q = ordered_query v in
-              Debug.print ("Generated query: "^(db#string_of_query range q));
+              Debug.print ("Generated query: "^(db#string_of_query ~range q));
               Some (db, q, t)

--- a/core/query/evalQuery.ml
+++ b/core/query/evalQuery.ml
@@ -307,5 +307,5 @@ let compile : Value.env -> (int * int) option * Ir.computation -> (Value.databas
         | Some db ->
             let t = Types.unwrap_list_type (Q.type_of_expression v) in
             let q = ordered_query v in
-              Debug.print ("Generated query: "^(Sql.string_of_query db range q));
+              Debug.print ("Generated query: "^(db#string_of_query range q));
               Some (db, q, t)

--- a/core/query/query.ml
+++ b/core/query/query.ml
@@ -1221,7 +1221,7 @@ let compile_update : Value.database -> Value.env ->
 (*       Debug.print ("body: "^Ir.show_computation body); *)
     let body = Eval.norm_comp env body in
     let q = update ((x, table), where, body) in
-      Debug.print ("Generated update query: " ^ (db#string_of_query None q));
+      Debug.print ("Generated update query: " ^ (db#string_of_query q));
       q
 
 let compile_delete : Value.database -> Value.env ->
@@ -1230,7 +1230,7 @@ let compile_delete : Value.database -> Value.env ->
     let env = Eval.bind (Eval.env_of_value_env QueryPolicy.Default env) (x, Q.Var (x, field_types)) in
     let where = opt_map (Eval.norm_comp env) where in
     let q = delete ((x, table), where) in
-      Debug.print ("Generated update query: " ^ (db#string_of_query None q));
+      Debug.print ("Generated update query: " ^ (db#string_of_query q));
       q
 
 let insert table_name field_names rows =

--- a/core/query/query.mli
+++ b/core/query/query.mli
@@ -68,7 +68,9 @@ sig
 end
 
 val compile_update : Value.database -> Value.env ->
-  ((Ir.var * string * Types.datatype StringMap.t) * Ir.computation option * Ir.computation) -> string
+  ((Ir.var * string * Types.datatype StringMap.t) * Ir.computation option * Ir.computation) -> Sql.query
 
 val compile_delete : Value.database -> Value.env ->
-  ((Ir.var * string * Types.datatype StringMap.t) * Ir.computation option) -> string
+  ((Ir.var * string * Types.datatype StringMap.t) * Ir.computation option) -> Sql.query
+
+val insert : string -> string list -> Value.t list list -> Sql.query

--- a/core/query/sql.ml
+++ b/core/query/sql.ml
@@ -2,27 +2,24 @@ open Utility
 open CommonTypes
 
 type index = (Var.var * string) list
-type range = (int * int) option
+type range = int * int
 
 type query =
   | UnionAll  of query list * int
   | Select    of select_clause
-  | Insert    of insert_query
-  | Update    of update_query
-  | Delete    of delete_query
+  | Insert    of {
+      ins_table: string;
+      ins_fields: string list;
+      ins_records: base list list
+    }
+  | Update    of {
+      upd_table: string;
+      upd_fields: (string * base) list;
+      upd_where: base option
+    }
+  | Delete    of { del_table: string; del_where: base option }
   | With      of Var.var * query * Var.var * query
 and select_clause = (base * string) list * (string * Var.var) list * base * base list
-and insert_query = {
-  ins_table: string;
-  ins_fields: string list;
-  ins_records: base list list
-}
-and update_query  = {
-  upd_table: string;
-  upd_fields: (string * base) list;
-  upd_where: base option
-}
-and delete_query  = { del_table: string; del_where: base option }
 and base =
   | Case      of base * base * base
   | Constant  of Constant.t

--- a/core/query/sql.ml
+++ b/core/query/sql.ml
@@ -2,12 +2,27 @@ open Utility
 open CommonTypes
 
 type index = (Var.var * string) list
+type range = (int * int) option
 
 type query =
   | UnionAll  of query list * int
   | Select    of select_clause
+  | Insert    of insert_query
+  | Update    of update_query
+  | Delete    of delete_query
   | With      of Var.var * query * Var.var * query
 and select_clause = (base * string) list * (string * Var.var) list * base * base list
+and insert_query = {
+  ins_table: string;
+  ins_fields: string list;
+  ins_records: base list list
+}
+and update_query  = {
+  upd_table: string;
+  upd_fields: (string * base) list;
+  upd_where: base option
+}
+and delete_query  = { del_table: string; del_where: base option }
 and base =
   | Case      of base * base * base
   | Constant  of Constant.t
@@ -125,9 +140,10 @@ let order_by_clause n =
    returned. This allows these operators to take lists that have any
    element type at all. *)
 
-let rec string_of_query db ignore_fields q =
-  let sq = string_of_query db ignore_fields in
-  let sb = string_of_base db false in
+let rec string_of_query quote ignore_fields q =
+  let sq = string_of_query quote ignore_fields in
+  let sb = string_of_base quote false in
+  let sbt = string_of_base quote true in
   let string_of_fields fields =
     if ignore_fields then
       "0 as \"@unit@\"" (* SQL doesn't support empty records! *)
@@ -137,7 +153,7 @@ let rec string_of_query db ignore_fields q =
         | fields ->
           mapstrcat ","
             (fun (b, l) ->
-              "(" ^ sb b ^ ") as "^ db#quote_field l) (* string_of_label l) *)
+              "(" ^ sb b ^ ") as "^ quote l) (* string_of_label l) *)
             fields
   in
   let string_of_select fields tables condition os =
@@ -154,6 +170,33 @@ let rec string_of_query db ignore_fields q =
     in
       "select " ^ fields ^ " from " ^ tables ^ where ^ orderby
   in
+  let string_of_delete table where =
+    let where =
+      OptionUtils.opt_app
+        (fun x -> "where (" ^ sbt x ^ ")") "" where in
+    Printf.sprintf "delete from %s %s" table where
+  in
+  let string_of_update table fields where =
+    let fields =
+      List.map (fun (k, v) -> quote k ^ " = " ^ sbt v) fields
+      |> String.concat ", " in
+
+    let where =
+      OptionUtils.opt_app
+        (fun x -> "where (" ^ sbt x ^ ")") "" where in
+    Printf.sprintf "update %s set %s %s" table fields where
+  in
+  let string_of_insert table fields values =
+    let fields = String.concat ", " fields in
+    let values =
+      values
+      (* Concatenate and bracket the values in each row *)
+      |> List.map ((List.map sbt) ->- String.concat ", " ->- Printf.sprintf "(%s)")
+      (* Join all rows *)
+      |> String.concat ", " in
+    Printf.sprintf "insert into %s (%s) values %s"
+      table fields values
+  in
     match q with
       | UnionAll ([], _) -> "select 42 as \"@unit@\" where false"
       | UnionAll ([q], n) -> sq q ^ order_by_clause n
@@ -167,24 +210,30 @@ let rec string_of_query db ignore_fields q =
             "select * from (select " ^ fields ^ ") as " ^ fresh_dummy_var () ^ " where " ^ sb condition
       | Select (fields, tables, condition, os) ->
           (* using quote_field assumes tables contains table names (not nested queries) *)
-          let tables = List.map (fun (t, x) -> db#quote_field t ^ " as " ^ (string_of_table_var x)) tables
+          let tables = List.map (fun (t, x) -> quote t ^ " as " ^ (string_of_table_var x)) tables
           in string_of_select fields tables condition os
+      | Delete { del_table; del_where } ->
+          string_of_delete del_table del_where
+      | Update { upd_table; upd_fields; upd_where } ->
+          string_of_update upd_table upd_fields upd_where
+      | Insert { ins_table; ins_fields; ins_records } ->
+          string_of_insert ins_table ins_fields ins_records
       | With (_, q, z, q') ->
           match q' with
           | Select (fields, tables, condition, os) ->
               (* Inline the query *)
-              let tables = List.map (fun (t, x) -> db#quote_field t ^ " as " ^ (string_of_table_var x)) tables in
+              let tables = List.map (fun (t, x) -> quote t ^ " as " ^ (string_of_table_var x)) tables in
               let q = "(" ^ sq q ^ ") as " ^ string_of_table_var z in
               string_of_select fields (q::tables) condition os
           | _ -> assert false
 
-and string_of_base db one_table b =
-  let sb = string_of_base db one_table in
+and string_of_base quote one_table b =
+  let sb = string_of_base quote one_table in
     match b with
       | Case (c, t, e) ->
           "case when " ^ sb c ^ " then " ^sb t ^ " else "^ sb e ^ " end"
       | Constant c -> Constant.to_string c
-      | Project (var, label) -> string_of_projection db one_table (var, label)
+      | Project (var, label) -> string_of_projection quote one_table (var, label)
       | Apply (op, [l; r]) when Arithmetic.is op
           -> Arithmetic.gen (sb l, op, sb r)
       | Apply (("intToString" | "stringToInt" | "intToFloat" | "floatToString"
@@ -192,7 +241,7 @@ and string_of_base db one_table b =
       | Apply ("floatToInt", [v]) -> "floor("^sb v^")"
 
       (* optimisation *)
-      | Apply ("not", [Empty q]) -> "exists (" ^ string_of_query db true q ^ ")"
+      | Apply ("not", [Empty q]) -> "exists (" ^ string_of_query quote true q ^ ")"
 
       | Apply ("not", [v]) -> "not (" ^ sb v ^ ")"
       | Apply (("negate" | "negatef"), [v]) -> "-(" ^ sb v ^ ")"
@@ -208,21 +257,21 @@ and string_of_base db one_table b =
       | Apply ("LIKE", [v; w]) -> "(" ^ sb v ^ ")" ^ " LIKE " ^ "(" ^ sb w ^ ")"
       | Apply (f, args) when SqlFuns.is f -> SqlFuns.name f ^ "(" ^ String.concat "," (List.map sb args) ^ ")"
       | Apply (f, args) -> f ^ "(" ^ String.concat "," (List.map sb args) ^ ")"
-      | Empty q -> "not exists (" ^ string_of_query db true q ^ ")"
-      | Length q -> "select count(*) from (" ^ string_of_query db true q ^ ") as " ^ fresh_dummy_var ()
+      | Empty q -> "not exists (" ^ string_of_query quote true q ^ ")"
+      | Length q -> "select count(*) from (" ^ string_of_query quote true q ^ ") as " ^ fresh_dummy_var ()
       | RowNumber [] -> "1"
       | RowNumber ps ->
-        "row_number() over (order by " ^ String.concat "," (List.map (string_of_projection db one_table) ps) ^ ")"
-and string_of_projection db one_table (var, label) =
+        "row_number() over (order by " ^ String.concat "," (List.map (string_of_projection quote one_table) ps) ^ ")"
+and string_of_projection quote one_table (var, label) =
   if one_table then
-    db#quote_field label
+    quote label
   else
-    string_of_table_var var ^ "." ^ (db#quote_field label)
+    string_of_table_var var ^ "." ^ (quote label)
 
-let string_of_query db range q =
+let string_of_query quote range q =
   let range =
     match range with
       | None -> ""
       | Some (limit, offset) -> " limit " ^string_of_int limit^" offset "^string_of_int offset
   in
-    string_of_query db false q ^ range
+    string_of_query quote false q ^ range

--- a/core/query/sql.ml
+++ b/core/query/sql.ml
@@ -265,7 +265,7 @@ and string_of_projection quote one_table (var, label) =
   else
     string_of_table_var var ^ "." ^ (quote label)
 
-let string_of_query quote range q =
+let string_of_query ?(range=None) quote q =
   let range =
     match range with
       | None -> ""

--- a/core/value.ml
+++ b/core/value.ml
@@ -79,8 +79,8 @@ class virtual database = object(self)
     raise (raise (internal_error ("insert ... returning is not yet implemented for the database driver: "^self#driver_name())))
   method virtual supports_shredding : unit -> bool
 
-  method string_of_query range q =
-    Sql.string_of_query self#quote_field range q
+  method string_of_query ?(range=None) =
+    Sql.string_of_query self#quote_field range
 end
 
 let equal_database db1 db2 = db1 == db2

--- a/core/value.ml
+++ b/core/value.ml
@@ -80,7 +80,7 @@ class virtual database = object(self)
   method virtual supports_shredding : unit -> bool
 
   method string_of_query ?(range=None) =
-    Sql.string_of_query self#quote_field range
+    Sql.string_of_query ~range self#quote_field
 end
 
 let equal_database db1 db2 = db1 == db2

--- a/core/value.ml
+++ b/core/value.ml
@@ -74,16 +74,13 @@ class virtual database = object(self)
   method virtual escape_string : string -> string
   method virtual quote_field : string -> string
   method virtual exec : string -> dbvalue
-  method make_insert_query : (string * string list * string list list) -> string =
-    fun (table_name, field_names, vss) ->
-      "insert into " ^ table_name ^
-        "("^String.concat "," field_names ^") values "^
-        String.concat "," (List.map (fun vs -> "(" ^ String.concat "," vs ^")") vss)
-  method make_insert_returning_query : (string * string list * string list list * string) -> string list =
-    fun _ ->
+  method make_insert_returning_query : string -> Sql.query -> string list =
+    fun _ _ ->
     raise (raise (internal_error ("insert ... returning is not yet implemented for the database driver: "^self#driver_name())))
   method virtual supports_shredding : unit -> bool
 
+  method string_of_query range q =
+    Sql.string_of_query self#quote_field range q
 end
 
 let equal_database db1 db2 = db1 == db2
@@ -1096,23 +1093,18 @@ and xmlitem_of_variant =
 
 (* Some utility functions for databases used by insertion *)
 
-let row_columns_values db v =
-  let escaped_string_of_value db =
-    function
-      | `String s -> "\'" ^ db # escape_string s ^ "\'"
-      | v -> string_of_value v
-  in
+let row_columns_values v =
   let row_columns : t -> string list = function
     | `List ((`Record fields)::_) -> List.map fst fields
     | v -> raise (type_error ~action:"form query columns from" "a list of records" v)
   in
-  let row_values db = function
+  let row_values = function
     | `List records ->
     (List.map (function
-          | `Record fields -> List.map (escaped_string_of_value db -<- snd) fields
+          | `Record fields -> List.map snd fields
           | v -> raise (type_error ~action:"form query field from" "record" v)) records)
     | v -> raise (type_error ~action:"form query row from" "list" v)
   in
-  (row_columns v, row_values db v)
+  (row_columns v, row_values v)
 
 

--- a/core/value.mli
+++ b/core/value.mli
@@ -33,7 +33,7 @@ class virtual database :
       Sql.query ->
       string list
     method virtual supports_shredding : unit -> bool
-    method string_of_query : Sql.range -> Sql.query -> string
+    method string_of_query : ?range:(Sql.range option) -> Sql.query -> string
   end
 
 

--- a/core/value.mli
+++ b/core/value.mli
@@ -28,9 +28,12 @@ class virtual database :
     method virtual escape_string : string -> string
     method virtual quote_field : string -> string
     method virtual exec : string -> dbvalue
-    method make_insert_query : (string * string list * string list list) -> string
-    method make_insert_returning_query : (string * string list * string list list * string) -> string list
+    method make_insert_returning_query :
+      string (* "returning" field *) ->
+      Sql.query ->
+      string list
     method virtual supports_shredding : unit -> bool
+    method string_of_query : Sql.range -> Sql.query -> string
   end
 
 
@@ -295,4 +298,4 @@ val is_channel : t -> bool
 
 val session_exception_operation : string
 
-val row_columns_values : database -> t -> string list * string list list
+val row_columns_values : t -> string list * t list list

--- a/database/mysql-driver/mysql_database.ml
+++ b/database/mysql-driver/mysql_database.ml
@@ -255,10 +255,12 @@ class mysql_database spec = object(self)
   method escape_string = Mysql.escape
   method quote_field f =
     "`" ^ Str.global_replace (Str.regexp "`") "``" f ^ "`"
-  method! make_insert_returning_query : (string * string list * string list list * string) -> string list =
-    fun (table_name, field_names, vss, _returning) ->
-      [self#make_insert_query(table_name, field_names, vss);
-       "select last_insert_id()"]
+
+  method! make_insert_returning_query : string -> Sql.query -> string list =
+    fun _returning q ->
+      assert (match q with | Sql.Insert _ -> true | _ -> false);
+      [self#string_of_query None q; "select last_insert_id()"]
+
   method supports_shredding () = false
 end
 

--- a/database/pg-driver/pg_database.ml
+++ b/database/pg-driver/pg_database.ml
@@ -127,9 +127,9 @@ class pg_database host port dbname user password = object(self)
       : string -> Sql.query -> string list =
     fun returning q ->
       assert (match q with | Sql.Insert _ -> true | _ -> false);
-      [Printf.sprintf "%s returning %s" (self#string_of_query None q) returning]
+      [Printf.sprintf "%s returning %s" (self#string_of_query q) returning]
 
-  method! string_of_query range =
+  method! string_of_query ?(range=None) =
     let string_of_insert table_name field_names vss =
       let insert_table = "insert into " ^ table_name in
       let quoted_field_names = (List.map self#quote_field field_names) in
@@ -166,7 +166,7 @@ class pg_database host port dbname user password = object(self)
               (List.map (Sql.string_of_base self#quote_field true))
               ins_records in
           string_of_insert ins_table ins_fields vss
-      | q -> super#string_of_query range q
+      | q -> super#string_of_query ~range q
 
   method supports_shredding () = true
 end

--- a/database/pg-driver/pg_database.ml
+++ b/database/pg-driver/pg_database.ml
@@ -98,7 +98,7 @@ class pg_dbresult (pgresult:Postgresql.result) = object
 end
 
 class pg_database host port dbname user password = object(self)
-  inherit Value.database
+  inherit Value.database as super
 
   val connection =
     try
@@ -123,41 +123,50 @@ class pg_database host port dbname user password = object(self)
     "\"" ^ Str.global_replace (Str.regexp "\"") "\"\"" f ^ "\""
 
 
-(* jcheney: Added quoting to avoid problems with mysql keywords. *)
-  method! make_insert_query (table_name, field_names, vss) =
-    let insert_table = "insert into " ^ table_name in
-    let quoted_field_names = (List.map self#quote_field field_names) in
-    let body =
-      match field_names, vss with
-        | _, [] -> failwith("We should not even generate code for empty inserts.")
-        | [],    [_] ->
-            (* HACK:
-
-               PostgreSQL doesn't allow an empty tuple of columns to
-               be specified for an insert. *)
-            " default values"
-        | [],    _::_::_ ->
-            (* In order to handle this case we need support for the
-               standard mult-row insert syntax (Postgres version 8.2
-               and later), and we will need access to the type of the
-               table. In fact, we only really need the name of one of
-               the columns, c. Then we can do:
-
-               insert into table(c) values (c),...,(c)
-            *)
-            failwith("Unable to translate a multi-row insert with empty rows to PostgreSQL")
-        | _::_,  _ ->
-           let values =
-             String.concat "), (" (List.map (String.concat ",") vss)
-           in "(" ^ String.concat "," quoted_field_names ^") VALUES (" ^ values ^ ")"
-    in insert_table ^ body
-
   method! make_insert_returning_query
-      : (string * string list * string list list * string) -> string list =
-    fun (table_name, field_names, vss, returning) ->
-      [self#make_insert_query(table_name,
-                              field_names,
-                              vss) ^ " returning " ^ self#quote_field returning]
+      : string -> Sql.query -> string list =
+    fun returning q ->
+      assert (match q with | Sql.Insert _ -> true | _ -> false);
+      [Printf.sprintf "%s returning %s" (self#string_of_query None q) returning]
+
+  method! string_of_query range =
+    let string_of_insert table_name field_names vss =
+      let insert_table = "insert into " ^ table_name in
+      let quoted_field_names = (List.map self#quote_field field_names) in
+      let body =
+        match field_names, vss with
+          | _, [] -> failwith("We should not even generate code for empty inserts.")
+          | [],    [_] ->
+              (* HACK:
+
+                 PostgreSQL doesn't allow an empty tuple of columns to
+                 be specified for an insert. *)
+              " default values"
+          | [],    _::_::_ ->
+              (* In order to handle this case we need support for the
+                 standard mult-row insert syntax (Postgres version 8.2
+                 and later), and we will need access to the type of the
+                 table. In fact, we only really need the name of one of
+                 the columns, c. Then we can do:
+
+                 insert into table(c) values (c),...,(c)
+              *)
+              failwith("Unable to translate a multi-row insert with empty rows to PostgreSQL")
+          | _::_,  _ ->
+             let values =
+               String.concat "), (" (List.map (String.concat ",") vss)
+             in "(" ^ String.concat "," quoted_field_names ^") VALUES (" ^ values ^ ")"
+      in insert_table ^ body
+    in
+    let open Sql in
+    function
+      | Insert { ins_table; ins_fields; ins_records } ->
+          let vss =
+            List.map
+              (List.map (Sql.string_of_base self#quote_field true))
+              ins_records in
+          string_of_insert ins_table ins_fields vss
+      | q -> super#string_of_query range q
 
   method supports_shredding () = true
 end

--- a/dune
+++ b/dune
@@ -13,7 +13,7 @@
   (flags (:standard
           ;; The following flags are the same as for the "dev" profile.
           -strict-formats -strict-sequence -safe-string -annot
-          -w A-4-44-45-60-67  ;; Ignores warnings 4, 44, 45, 60, and 67.
+          -w A-4-44-45-48-60-67  ;; Ignores warnings 4, 44, 45, 48, 60, and 67.
   ))
   (ocamlopt_flags (:standard
                    -O3 ;; Applies (aggressive) optimisations to the resulting executable.
@@ -22,7 +22,7 @@
   (flags (:standard
           -strict-formats -strict-sequence -safe-string -annot
           -warn-error @A      ;; Treat warnings as errors...
-          -w A-4-44-45-60-67  ;; ... except for warnings 4, 44, 45, 60, and 67 which are ignored.
+          -w A-4-44-45-48-60-67  ;; ... except for warnings 4, 44, 45, 48, 60, and 67 which are ignored.
   ))
   (ocamlopt_flags (:standard -O3))
 ))

--- a/dune
+++ b/dune
@@ -6,7 +6,7 @@
           -safe-string        ;; Immutable strings.
           -annot              ;; Dumps information per (file) module about types, bindings, tail-calls, etc. Used by some tools.
           -warn-error -a      ;; Do not treat warnings as errors.
-          -w A-4-44-45-60-67  ;; Ignores warnings 4, 44, 45, 60, and 67.
+          -w A-4-44-45-48-60-67  ;; Ignores warnings 4, 44, 45, 48, 60, and 67.
           -g                  ;; Adds debugging information to the resulting executable / library.
  )))
  (release


### PR DESCRIPTION
# Motivation
Previously, SQL update and deletion operations were constructed as strings in `query.ml`. Since insertions are implementation-dependent, the picture there is even worse: we needed to do some gymnastics to get a bunch of strings, which were then passed to the `Value.database` implementation.

When we're wanting to do query rewrites (say, if we wanted to do temporal database operations, for example), the string-based approach is very inflexible. Furthermore, insertions are treated non-uniformly, which is a pity.

# Changes
This patch adds abstract syntax for SQL insertions, updates, and deletions in the `Sql` module, and adapts the rest of the codebase to use them. More specifically:

  - `Sql` contains the new abstract syntax nodes `Insert`, `Update`, and `Delete`.
  - `Sql.string_of_query` takes a field quotation function of type `string -> string`, rather than taking a `Value.database`. In turn, this breaks the dependency from `Sql` to `Value`.
  - We add a `string_of_query` method to `Value.database`, which is an overridable implementation-specific query serialisation function which calls into `Sql.string_of_query` by default.
  - The `make_insert_query` method is deleted from `Value.database`. Instead, implementation-dependent insertion functionality is achieved by overriding `string_of_query` for `Insert` AST nodes.
  - The `make_insert_returning_query` method is simplified to take an insertion query and a `returning` field, rather than serialised values.
