### PR TITLE
Partially fix #835

### DIFF
--- a/core/frontend.ml
+++ b/core/frontend.ml
@@ -204,6 +204,7 @@ module Typeability_preserving = struct
            Basicsettings.Sessions.exceptions_enabled
            (module DesugarSessionExceptions)
        ; (module DesugarProcesses)
+       ; (module WrapTableIterators)
        ; (module DesugarFors)
        ; (module DesugarRegexes)
        ; (module DesugarFormlets)

--- a/core/query/query.ml
+++ b/core/query/query.ml
@@ -627,19 +627,14 @@ struct
 
   let check_policies_compatible env_policy block_policy =
     let open QueryPolicy in
-    let resolve = function
-      | Flat -> `Flat
-      | Nested -> `Nested
-      | Default ->
-          if (Settings.get Database.shredding) then `Nested else `Flat in
-    let show = function | `Nested -> "nested" | `Flat -> "flat" in
-    let expected = resolve env_policy in
-    let actual = resolve block_policy in
-    if expected = actual then () else
-      let error = Printf.sprintf
-        "Incompatible query evaluation annotations. Expected %s, got %s."
-        (show expected) (show actual) in
-      raise (Errors.runtime_error error)
+    match (env_policy, block_policy) with
+      | (x, y) when x = y -> ()
+      | (_, Default) -> ()
+      | _ ->
+        let error = Printf.sprintf
+          "Incompatible query evaluation annotations. Expected %s, got %s."
+          (QueryPolicy.show env_policy) (QueryPolicy.show block_policy) in
+        raise (Errors.runtime_error error)
 
   let rec xlate env : Ir.value -> Q.t = let open Ir in function
     | Constant c -> Q.Constant c

--- a/core/sugartoir.ml
+++ b/core/sugartoir.ml
@@ -1270,7 +1270,6 @@ struct
 
   let compile env (bindings, body) =
     Debug.print ("compiling to IR");
-(*     Debug.print (Sugartypes.show_program (bindings, body)); *)
     let body =
       match body with
         | None -> WithPos.dummy (Sugartypes.RecordLit ([], None))

--- a/core/typeSugar.ml
+++ b/core/typeSugar.ml
@@ -3495,7 +3495,8 @@ let rec type_check : context -> phrase -> phrase * Types.datatype * Usage.t =
                              [ usages body
                              ; from_option Usage.empty (opt_map usages where)
                              ; from_option Usage.empty (opt_map usages orderby) ]))
-            in e, typ body, us
+            in
+            e, typ body, us
         | Escape (bndr, e) ->
             (* There's a question here whether to generalise the
                return type of continuations.  With `escape'

--- a/core/typeSugar.ml
+++ b/core/typeSugar.ml
@@ -3495,10 +3495,7 @@ let rec type_check : context -> phrase -> phrase * Types.datatype * Usage.t =
                              [ usages body
                              ; from_option Usage.empty (opt_map usages where)
                              ; from_option Usage.empty (opt_map usages orderby) ]))
-            in
-            if is_query
-            then Query (None, QueryPolicy.Default, with_pos pos e, Some (typ body)), typ body, us
-            else e, typ body, us
+            in e, typ body, us
         | Escape (bndr, e) ->
             (* There's a question here whether to generalise the
                return type of continuations.  With `escape'

--- a/core/wrapTableIterators.ml
+++ b/core/wrapTableIterators.ml
@@ -1,0 +1,60 @@
+open Utility
+open CommonTypes
+open Sugartypes
+open SourceCode
+open SourceCode.WithPos
+
+(*
+ * Ensures that table iterators are wrapped in a query block:
+ *
+ * for (x <-- y) M
+ *  --->
+ * query { for (x <-- y) M }
+ *
+ * Note that this is safe if we're in another query block:
+ *
+ * query { for (x <-- y) M }
+ *  --->
+ * query { query { for (x <-- y) M } }
+ *
+ * Since nested query blocks are removed by the normaliser.
+*)
+class wrap_iterators env =
+  let open TransformSugar in
+  object (o : 'self_type)
+    inherit (TransformSugar.transform env) as super
+
+    method! phrase = function
+      | { node = Iteration (gens, body, cond, orderby); pos } ->
+          let wp = WithPos.make ~pos in
+          let envs = o#backup_envs in
+          let (o, gens) = listu o (fun o -> o#iterpatt) gens in
+          let (o, body, t) = o#phrase body in
+          let (o, cond, _) = option o (fun o -> o#phrase) cond in
+          let (o, orderby, _) = option o (fun o -> o#phrase) orderby in
+          let o = o#restore_envs envs in
+          let is_query = List.exists
+              (function
+                 | List  _ -> false
+                 | Table _ -> true) gens in
+          let node =
+            if is_query then
+              Query (None, QueryPolicy.Default,
+                wp (Iteration (gens, body, cond, orderby)), Some t)
+            else
+              Iteration (gens, body, cond, orderby) in
+          (o, wp node, t)
+      | p -> super#phrase p
+  end
+
+
+let wrap_iterators env =
+  ((new wrap_iterators env) : wrap_iterators :> TransformSugar.transform)
+
+module Typeable
+  = Transform.Typeable.Make(struct
+        let name = "wrap table iterators"
+        let obj env =
+          (wrap_iterators env : TransformSugar.transform :>
+            Transform.Typeable.sugar_transformer)
+      end)

--- a/core/wrapTableIterators.ml
+++ b/core/wrapTableIterators.ml
@@ -8,14 +8,9 @@ open Sugartypes
  *  --->
  * query { for (x <-- y) M }
  *
- * Note that this is safe if we're in another query block:
- *
- * query { for (x <-- y) M }
- *  --->
- * query { query { for (x <-- y) M } }
- *
- * Since nested query blocks are removed by the normaliser.
-*)
+ * Note that since we can't "break out" of a query block, we
+ * do not have to perform the pass inside query blocks.
+ *)
 class wrap_iterators env =
   let open TransformSugar in
   object (o : 'self_type)

--- a/core/wrapTableIterators.mli
+++ b/core/wrapTableIterators.mli
@@ -1,0 +1,1 @@
+include Transform.Typeable.S

--- a/tests/database.tests
+++ b/tests/database.tests
@@ -63,8 +63,8 @@ exit : 0
 
 Nested query annotations (2)
 query nested { query { for (i <- [1,2,3]) [(x = i)] } }
-stderr : @..*
-exit : 1
+stdout : [(x = 1), (x = 2), (x = 3)] : [(x:Int)]
+exit : 0
 
 Nested query annotations (3)
 query { query nested { for (i <- [1,2,3]) [(x = i)] } }

--- a/tests/database/factorials.links
+++ b/tests/database/factorials.links
@@ -48,6 +48,13 @@ fun lookupFactorials(n) server {
   }
 }
 
+fun unwrappedLookup(n) server {
+  for (row <-- factorials)
+  where (row.i <= n)
+  orderby (row.i)
+    [(i=row.i, f=row.f)]
+}
+
 fun test() {
   insertOne();
   deleteAll();
@@ -56,6 +63,7 @@ fun test() {
   assertEq(lookupFactorials(10), []);
   insertOne();
   assertEq(lookupFactorials(1), [(f=1,i=1)]);
+  assertEq(unwrappedLookup(1), [(f=1,i=1)]);
   insertTwoThree();
   ## The order is wrong.
   assertEq(lookupFactorials(3), [(i=3, f=6), (i=2, f=2), (f=1,i=1)]);

--- a/tests/shredding/factorials.links
+++ b/tests/shredding/factorials.links
@@ -7,6 +7,7 @@ fun insertOne() {
 }
 
 fun main() {
+  insertOne();
   var res1 = query flat { for (x <-- factorials) [(a=x.i,b=x.f)] };
   assertEq(res1, [(a=1, b=1)]);
   var res2 = query flat { for (x <- asList(factorials)) [(a=x.i,b=x.f)] };

--- a/tests/shredding/factorials.links
+++ b/tests/shredding/factorials.links
@@ -1,0 +1,16 @@
+var db = database "links";
+var factorials = table "factorials" with (i : Int, f : Int) from db;
+
+fun insertOne() {
+  insert factorials
+  values [(f=1, i=1)];
+}
+
+fun main() {
+  var res1 = query flat { for (x <-- factorials) [(a=x.i,b=x.f)] };
+  assertEq(res1, [(a=1, b=1)]);
+  var res2 = query flat { for (x <- asList(factorials)) [(a=x.i,b=x.f)] };
+  assertEq(res2, [(a=1, b=1)])
+}
+
+main()

--- a/tests/shredding/factorials.sql
+++ b/tests/shredding/factorials.sql
@@ -1,0 +1,6 @@
+DROP TABLE IF EXISTS factorials;
+
+CREATE TABLE factorials (
+    i integer,
+    f bigint
+);

--- a/tests/shredding/testsuite.config
+++ b/tests/shredding/testsuite.config
@@ -1,5 +1,6 @@
 empty
 emptyfun
+factorials
 unit
 jrules
 organisation


### PR DESCRIPTION
This patch partially addresses #835, in particular:

```
 query flat { for (x <--factorials) [(a=x.i,b=x.f)]};
 query flat { for (x <- asList(factorials)) [(a=x.i,b=x.f)]};
```

These queries (explicit `flat` modifier) did not run as expected when `shredding` was set to true. The reason for this is that all `Iteration` nodes are implicitly wrapped in a `Query` block if they contain a table generator, and unannotated query blocks took the evaluation policy set by the `shredding` option. Thus:

```
query flat { for (x <--factorials) [(a=x.i,b=x.f)]};
```
was effectively transformed into
```
query flat { query nested { for (x <--factorials) [(a=x.i,b=x.f)]} };
```

causing a mismatch.

This patch fixes this in two ways. Firstly, inner `default` query blocks take the evaluation policy of the outer block, rather than the policy defined by the setting. This should have been the initial design, really.

Secondly, `Query`-block insertion absolutely should not be done by the typechecker. This patch separates it out into a separate pass, `WrapTableIterators`, performed after desugaring.

The other part of #835 is a separate issue, and is out-of-scope for this PR.