### PR TITLE
fix Issue 835

### DIFF
--- a/core/database.ml
+++ b/core/database.ml
@@ -9,11 +9,12 @@ let connection_info
               |> convert Utility.some
               |> sync)
 
+    (* XXX
 let relax_query_type_constraint =
   Settings.(flag "relax_query_type_constraint"
             |> convert parse_bool
             |> sync)
-
+*)
 let shredding =
   Settings.(flag "shredding"
             |> synopsis "Enables database query shredding"

--- a/core/database.ml
+++ b/core/database.ml
@@ -9,12 +9,6 @@ let connection_info
               |> convert Utility.some
               |> sync)
 
-    (* XXX
-let relax_query_type_constraint =
-  Settings.(flag "relax_query_type_constraint"
-            |> convert parse_bool
-            |> sync)
-*)
 let shredding =
   Settings.(flag "shredding"
             |> synopsis "Enables database query shredding"

--- a/core/database.mli
+++ b/core/database.mli
@@ -1,7 +1,7 @@
 (** A generic interface for SQL-style databases. Vendor-specific implementations are elsewhere *)
 
 val connection_info : string option Settings.setting
-val relax_query_type_constraint : bool Settings.setting
+(* XXX val relax_query_type_constraint : bool Settings.setting *)
 val shredding : bool Settings.setting
 
 class virtual db_args : string -> object
@@ -27,4 +27,3 @@ val execute_select : (string * Types.datatype) list -> string -> Value.database 
 val execute_untyped_select : string -> Value.database -> Value.t
 
 val execute_insert_returning : string -> Sql.query ->  Value.database -> Value.t
-

--- a/core/database.mli
+++ b/core/database.mli
@@ -1,7 +1,6 @@
 (** A generic interface for SQL-style databases. Vendor-specific implementations are elsewhere *)
 
 val connection_info : string option Settings.setting
-(* XXX val relax_query_type_constraint : bool Settings.setting *)
 val shredding : bool Settings.setting
 
 class virtual db_args : string -> object

--- a/core/database.mli
+++ b/core/database.mli
@@ -26,3 +26,4 @@ val execute_select : (string * Types.datatype) list -> string -> Value.database 
 val execute_untyped_select : string -> Value.database -> Value.t
 
 val execute_insert_returning : string -> Sql.query ->  Value.database -> Value.t
+

--- a/core/evalir.ml
+++ b/core/evalir.ml
@@ -699,13 +699,6 @@ struct
               value env offset >>= fun offset ->
               Lwt.return (Some (Value.unbox_int limit, Value.unbox_int offset))
        end >>= fun range ->
-       let evaluator =
-         let open QueryPolicy in
-         match policy with
-           | Flat -> `Flat
-           | Nested -> `Nested
-           | Default ->
-               if Settings.get Database.shredding then `Nested else `Flat in
 
        let evaluate_standard () =
          match EvalQuery.compile env (range, e) with
@@ -755,11 +748,15 @@ struct
                 in
                 raise (Errors.runtime_error error_msg) in
 
-       begin
-         match evaluator with
-           | `Flat -> evaluate_standard ()
-           | `Nested -> evaluate_nested ()
-       end
+       let evaluator =
+         let open QueryPolicy in
+         match policy with
+           | Flat -> evaluate_standard
+           | Nested -> evaluate_nested
+           | Default ->
+               if Settings.get Database.shredding then evaluate_nested else evaluate_standard in
+       evaluator()
+
     | InsertRows (source, rows) ->
         begin
           value env source >>= fun source ->

--- a/core/irCheck.ml
+++ b/core/irCheck.ml
@@ -768,7 +768,14 @@ struct
             (* The type of the body must match the type the query is annotated with *)
             o#check_eq_types original_t t (SSpec special);
 
-            (if Settings.get Database.relax_query_type_constraint then
+            let check_flat_result =
+              let open QueryPolicy in
+              match policy with
+              | Flat -> true
+              | Nested -> false
+              | Default -> not(Settings.get Database.shredding) in
+
+            (if not(check_flat_result) then
               () (* Discussion pending about how to type-check here. Currently same as frontend *)
             else
               let list_content_type = TypeUtils.element_type ~overstep_quantifiers:false t in

--- a/core/typeSugar.ml
+++ b/core/typeSugar.ml
@@ -3421,8 +3421,8 @@ let rec type_check : context -> phrase -> phrase * Types.datatype * Usage.t =
             let context =
               begin
                 unify ~handle:Gripers.iteration_unl_effect
-		  (no_pos (`Effect context.effect_row),
-		   no_pos (`Effect (Types.make_empty_open_row default_effect_subkind)));
+                  (no_pos (`Effect context.effect_row),
+                   no_pos (`Effect (Types.make_empty_open_row default_effect_subkind)));
                 context
               end
             in

--- a/core/typeSugar.ml
+++ b/core/typeSugar.ml
@@ -3431,10 +3431,10 @@ let rec type_check : context -> phrase -> phrase * Types.datatype * Usage.t =
                              | List  _ -> false
                              | Table _ -> true) generators in*)
             let context =
-(*              if is_query
+(*            if is_query
               then { context with effect_row = Types.make_empty_closed_row () }
-		else *)
-	      begin
+              else *)
+              begin
                   unify ~handle:Gripers.iteration_unl_effect (no_pos (`Effect context.effect_row), no_pos (`Effect (Types.make_empty_open_row default_effect_subkind)));
                   context
               end

--- a/core/typeSugar.ml
+++ b/core/typeSugar.ml
@@ -335,7 +335,7 @@ sig
   val iteration_body : griper
   val iteration_where : griper
   val iteration_base_order : griper
-  val iteration_base_body : griper
+(* XXX val iteration_base_body : griper*)
 
   val escape : griper
   val escape_outer : griper
@@ -1149,11 +1149,12 @@ end
         ("An orderby clause must return a list of records of base type")
         (expr, t)
 
-    let iteration_base_body ~pos ~t1:(expr,t) ~t2:_ ~error:_ =
+(* XXX   let iteration_base_body ~pos ~t1:(expr,t) ~t2:_ ~error:_ =
       build_tyvar_names [t];
       with_but pos
         ("A database comprehension must return a list of records of base type")
         (expr, t)
+*)
 
     let escape ~pos ~t1:l ~t2:(_,t) ~error:_ =
       build_tyvar_names [snd l; t];
@@ -3425,17 +3426,18 @@ let rec type_check : context -> phrase -> phrase * Types.datatype * Usage.t =
 
         (* various expressions *)
         | Iteration (generators, body, where, orderby) ->
-            let is_query =
+(* XXX           let is_query =
               List.exists (function
                              | List  _ -> false
-                             | Table _ -> true) generators in
+                             | Table _ -> true) generators in*)
             let context =
-              if is_query
+(*              if is_query
               then { context with effect_row = Types.make_empty_closed_row () }
-              else begin
+		else *)
+	      begin
                   unify ~handle:Gripers.iteration_unl_effect (no_pos (`Effect context.effect_row), no_pos (`Effect (Types.make_empty_open_row default_effect_subkind)));
                   context
-                end
+              end
             in
             let generators, generator_usages, environments =
               List.fold_left
@@ -3483,10 +3485,11 @@ let rec type_check : context -> phrase -> phrase * Types.datatype * Usage.t =
                 (fun order ->
                    unify ~handle:Gripers.iteration_base_order
                      (pos_and_typ order, no_pos (`Record (Types.make_empty_open_row (lin_unl, res_base))))) orderby in
-            let () =
+(* XXX           let () =
               if is_query && not (Settings.get Database.relax_query_type_constraint) then
                 unify ~handle:Gripers.iteration_base_body
                   (pos_and_typ body, no_pos (Types.make_list_type (`Record (Types.make_empty_open_row (lin_unl, res_base))))) in
+*)
             let e = Iteration (generators, erase body, opt_map erase where, opt_map erase orderby) in
             let vs = List.fold_left StringSet.union StringSet.empty (List.map Env.domain environments) in
             let us = Usage.combine_many

--- a/examples/relational_lenses/config
+++ b/examples/relational_lenses/config
@@ -1,5 +1,4 @@
 database_args=localhost:5432:links:links
 database_driver=postgresql
-relax_query_type_constraint=on
 shredding=on
 relational_lenses=on

--- a/examples/relational_lenses/config.sample
+++ b/examples/relational_lenses/config.sample
@@ -1,5 +1,4 @@
 database_args=localhost:5432::links
 database_driver=postgresql
-relax_query_type_constraint=on
 shredding=on
 relational_lenses=on

--- a/examples/wine.links
+++ b/examples/wine.links
@@ -116,9 +116,11 @@ fun assocd(x, l, d) {
 sig firstField : (TableHandle ((|r::Base), (|w::Base), (|n::Base)), ((|r)) {}-> Bool, ((|r)) {}-> a) ~e~> (a::Base)
 fun firstField(t, p, body) {
   var matches =
-    for (r <-- t)
-     where (p(r))
-      [(v=body(r))];
+    query {
+      for (r <-- t)
+       where (p(r))
+        [(v=body(r))]
+    };
   hd(matches).v
 }
 

--- a/tests/database.tests
+++ b/tests/database.tests
@@ -98,11 +98,10 @@ exit : 0
 
 Tame calls inside query blocks need to be enclosed by explicit query (1)
 sig firstField : (TableHandle ((|r::Base), (|w::Base), (|n::Base)), ((|r)) {}-> Bool, ((|r)) {}-> a) ~e~> (a::Base) fun firstField(t, p, body) { var matches = query { for (r <-- t) where (p(r)) [(v=body(r))] }; hd(matches).v}
-stdout : firstField = fun : (TableHandle((|a::Base),(|_::Base),(|_::Base)), ((|a::Base)) {}-> Bool, ((|a::Base)) {}-> d::Base) ~> d::Base
+stdout : () : ()
 exit : 0
 
 Tame calls inside query blocks need to be enclosed by explicit query (2)
 sig firstField : (TableHandle ((|r::Base), (|w::Base), (|n::Base)), ((|r)) {}-> Bool, ((|r)) {}-> a) ~e~> (a::Base) fun firstField(t, p, body) { var matches = for (r <-- t) where (p(r)) [(v=body(r))] ; hd(matches).v}
-stdout : firstField = fun : (TableHandle((|a::Base),(|_::Base),(|_::Base)), ((|a::Base)) {}-> Bool, ((|a::Base)) {}-> d::Base) ~> d::Base
 exit : 1
-stderr :  @..*
+stderr : @..*

--- a/tests/database.tests
+++ b/tests/database.tests
@@ -95,3 +95,14 @@ Ranges are wild, but can appear outside of query blocks (2)
 for (x <- [1..3] ) [(num=x)]
 stdout : [(num = 1), (num = 2), (num = 3)] : [(num:Int)]
 exit : 0
+
+Tame calls inside query blocks need to be enclosed by explicit query (1)
+sig firstField : (TableHandle ((|r::Base), (|w::Base), (|n::Base)), ((|r)) {}-> Bool, ((|r)) {}-> a) ~e~> (a::Base) fun firstField(t, p, body) { var matches = query { for (r <-- t) where (p(r)) [(v=body(r))] }; hd(matches).v}
+stdout : firstField = fun : (TableHandle((|a::Base),(|_::Base),(|_::Base)), ((|a::Base)) {}-> Bool, ((|a::Base)) {}-> d::Base) ~> d::Base
+exit : 0
+
+Tame calls inside query blocks need to be enclosed by explicit query (2)
+sig firstField : (TableHandle ((|r::Base), (|w::Base), (|n::Base)), ((|r)) {}-> Bool, ((|r)) {}-> a) ~e~> (a::Base) fun firstField(t, p, body) { var matches = for (r <-- t) where (p(r)) [(v=body(r))] ; hd(matches).v}
+stdout : firstField = fun : (TableHandle((|a::Base),(|_::Base),(|_::Base)), ((|a::Base)) {}-> Bool, ((|a::Base)) {}-> d::Base) ~> d::Base
+exit : 1
+stderr :  @..*

--- a/tests/database/factorials.links
+++ b/tests/database/factorials.links
@@ -55,6 +55,14 @@ fun unwrappedLookup(n) server {
     [(i=row.i, f=row.f)]
 }
 
+fun trivialNested1() server {
+  query { for (y <- for (x <-- factorials) [(b=[])]) [(a=0)]}
+}
+
+fun trivialNested2() server {
+  query { for (y <- for (x <- asList( factorials)) [(b=[])]) [(a=0)]}
+}
+
 fun test() {
   insertOne();
   deleteAll();
@@ -75,6 +83,8 @@ fun test() {
   assertEq(lookupFactorials(10), [(f=2,i=2),(f=1,i=1)]);
   updateTwoThree();
   assertEq(lookupFactorials(10), [(f=3,i=2),(f=1,i=1)]);
+  assertEq(trivialNested1(),[(a=0),(a=0)]);
+  assertEq(trivialNested2(),[(a=0),(a=0)]);
 }
 
 test()

--- a/tests/relational-lenses/config.sample
+++ b/tests/relational-lenses/config.sample
@@ -1,5 +1,4 @@
 database_driver=postgresql
 database_args=localhost:5432::links
 show_pre_sugar_typing=off
-relax_query_type_constraint=on
 relational_lenses=on

--- a/tests/shredding/config.sample
+++ b/tests/shredding/config.sample
@@ -1,5 +1,4 @@
 database_driver=postgresql
 database_args=localhost:5432::links
 show_pre_sugar_typing=off
-relax_query_type_constraint=on
 shredding=on


### PR DESCRIPTION
This attempts to fix #835 by simply disabling the syntactic heuristic for deciding whether an iteration is a query in the typechecker.  

This has the possibly unwelcome side effect that for any `Iteration` comprehension that would have previously been assumed to be a query (because of the presence of `<--`), if a tame function is called inside that `Iteration` block, we now need to explicitly enclose it in a `query` block when we didn't before.  I'm personally fine with this because it makes it more explicit what is going on, and I would also be fine with requiring `query` keywords to enclose any `Iteration` that is expected to evaluate as an external query, or rejecting attempts to use `<--` outside of a `query` block, but these would be more invasive and separate changes.

In our test suite there was exactly one place where this mattered and meant code needed to change: in `wine.links`.

It also means that we decease the number of places we use the `relax_query_type_constraint` setting to 1 : the only remaining use is in `irTyping`.  I think that the logic for determining whether a query has to have a flat return type is now captured in the `policy` parameter and so we should inspect that instead of using this flag.  I also think shredding should just be enabled by default now since we have a way within Links to choose whether to use it or not on a given query, so having the flag provide default behavior unnecessarily complicates matters.

To do:
- [ ] Argue about whether the proposed breaking change is reasonable.
- [x] Adjust irTyping to use the query policy flag to decide whether to enforce flat query results instead of `relax_query_type_constraint`
- [x] Cleanup and remove dead code