### PR TITLE
Fix #575

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -87,7 +87,7 @@ steps:
       case $AGENT_OS in
         "Linux") sudo apt-get install postgresql libpq-dev sqlite3 libsqlite3-dev &&
                  sudo LINKS_CI=1 tools/configure-postgresql &&
-                 sudo systemctl reload postgresql &&
+                 sudo systemctl start postgresql &&
                  sudo -u postgres createuser -s $(whoami) &&
                  sudo -u postgres createdb -O $(whoami) links;;
         "Darwin") brew install postgresql@9.5 libpq sqlite3 &&

--- a/core/irCheck.ml
+++ b/core/irCheck.ml
@@ -503,7 +503,7 @@ struct
                 | None -> make_record_type field_types
                 | Some t ->
                     begin
-                      match t with
+                      match TypeUtils.concrete_type t with
                         | `Record row ->
                             handle_extended_record (extend_row_safe field_types row)
                         | _ -> raise_ir_type_error "Trying to extend non-record type" (SVal orig)
@@ -521,7 +521,7 @@ struct
 
         | Inject (name, v, t) ->
             let v, vt, o = o#value v in
-            let _ = match t with
+            let _ = match TypeUtils.concrete_type t with
               | `Variant _ ->
                  o#check_eq_types  (variant_at ~overstep_quantifiers:false name t) vt (SVal orig)
               | _ -> raise_ir_type_error "trying to inject into non-variant type" (SVal orig) in
@@ -663,7 +663,7 @@ struct
 
         | Ir.Case (v, cases, default) ->
             let v, vt, o = o#value v in
-            begin match vt with
+            begin match TypeUtils.concrete_type vt with
             | `Variant row as variant ->
                let unwrapped_row = fst (unwrap_row row) in
                let present_fields, has_presence_polymorphism  =

--- a/core/lib.ml
+++ b/core/lib.ml
@@ -26,7 +26,11 @@ module AliasEnv = Env.String
 let alias_env : Types.tycon_environment = DefaultAliases.alias_env
 
 let alias_env : Types.tycon_environment =
+  AliasEnv.bind "Repeat" (`Alias ([], (DesugarDatatypes.read ~aliases:alias_env Linksregex.Repeat.datatype))) alias_env
+
+let alias_env : Types.tycon_environment =
   AliasEnv.bind "Regex" (`Alias ([], (DesugarDatatypes.read ~aliases:alias_env Linksregex.Regex.datatype))) alias_env
+
 
 let datatype = DesugarDatatypes.read ~aliases:alias_env
 

--- a/core/lib.ml
+++ b/core/lib.ml
@@ -31,7 +31,6 @@ let alias_env : Types.tycon_environment =
 let alias_env : Types.tycon_environment =
   AliasEnv.bind "Regex" (`Alias ([], (DesugarDatatypes.read ~aliases:alias_env Linksregex.Regex.datatype))) alias_env
 
-
 let datatype = DesugarDatatypes.read ~aliases:alias_env
 
 type primitive =

--- a/tests/shredding/travel_portal.links
+++ b/tests/shredding/travel_portal.links
@@ -2,25 +2,21 @@ var db = database "links";
 
 var agencies =
   table "agencies"
-  with (oid: Int,
-        id: Int,
+  with (id: Int,
         name: String,
         based_in: String,
         phone: String)
-  where oid readonly
-  tablekeys [["oid"], ["id"]]
+  tablekeys [["id"]]
   from db;
 
 var externalTours =
   table "externaltours"
-  with (oid: Int,
-        id: Int,
+  with (id: Int,
         name: String,
         destination: String,
         type: String,
         price: Int)
-  where oid readonly
-  tablekeys [["oid"], ["id"]]
+  tablekeys [["id"]]
   from db;
 
 fun q() {

--- a/tests/shredding/travel_portal.sql
+++ b/tests/shredding/travel_portal.sql
@@ -6,7 +6,7 @@ CREATE TABLE agencies (
     name     text,
     based_in text,
     phone    text
-) WITH OIDS;
+);
 
 CREATE TABLE externaltours (
     id          integer primary key,
@@ -14,7 +14,7 @@ CREATE TABLE externaltours (
     destination text,
     type        text,
     price       integer
-) WITH OIDS;
+);
 
 insert into agencies (id, name, based_in, phone) values
   (1, 'BayTours', 'San Francisco', '415-1200'),

--- a/tests/typed_ir.tests
+++ b/tests/typed_ir.tests
@@ -51,3 +51,7 @@ asList (#698)
 tests/typed_ir/T698.links
 filemode : true
 stdout : () : ()
+
+isInt (#575)
+sig isInt : (String) -> Bool fun isInt (x) { x =~ /-?[0-9]+$/ }
+stdout : () : ()


### PR DESCRIPTION
There were three problems:
- Aliases were treated opaquely in some places in irCheck --> call TypeUtils.concrete_type in more places.
- Question, plus, star flags were ascribed Regex type --> introduced Repeat type alias and use that instead.
- There was a stray extra list constructor --> removed

This seems not to break anything, but I'm not sure if I have run all of the ir typing regression tests.  @jstolarek ?