### PR TITLE
Test for a clean clone as part of CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,7 @@ language: c
 services:
   - postgresql
 before_install:
+  - git diff-index --quiet HEAD --
   - sudo add-apt-repository -y ppa:avsm/ppa
   - sudo apt-get -qq update
   - sudo apt-get install -y ocaml-nox ocaml-native-compilers python3-setuptools python3-pip libev-dev

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -26,6 +26,10 @@ steps:
     displayName: Environment
 
   - bash: |
+      git diff-index --quiet HEAD --
+    displayName: 'Check clean working tree after checkout'
+
+  - bash: |
       case $AGENT_OS in
         "Linux") sudo apt-get update ;;
         "Darwin") brew update ;;


### PR DESCRIPTION
What the title says. If the working tree isn't clean after cloning (e.g. because newlines are automatically converted in a way they shouldn't -see #5030) CI will catch it. Closes #507.