### PR TITLE
Attempt at retaining dual aliases (fixing #522)

### DIFF
--- a/core/desugarPages.ml
+++ b/core/desugarPages.ml
@@ -51,7 +51,7 @@ let rec desugar_page (o, page_type) =
             let formlet_type = Types.concrete_type formlet_type in
             let a = Types.fresh_type_variable (lin_any, res_any) in
             let b = Types.fresh_type_variable (lin_any, res_any) in
-              Unify.datatypes (`Alias (("Formlet", [(PrimaryKind.Type, default_subkind)], [`Type a]), b), formlet_type);
+              Unify.datatypes (`Alias (("Formlet", [(PrimaryKind.Type, default_subkind)], [`Type a], false), b), formlet_type);
               fn_appl "formP" [`Type a; `Row (o#lookup_effects)]
                       [formlet; handler; attributes]
         | PagePlacement (page) -> page

--- a/core/generalise.ml
+++ b/core/generalise.ml
@@ -58,7 +58,7 @@ let rec get_type_args : gen_kind -> TypeVarSet.t -> datatype -> type_arg list =
         | `Variant row -> get_row_type_args kind bound_vars row
         | `Table (r, w, n) -> gt r @ gt w @ gt n
         | `Lens _ -> []
-        | `Alias ((_, _, ts), t) ->
+        | `Alias ((_, _, ts, _), t) ->
             concat_map (get_type_arg_type_args kind bound_vars) ts @ gt t
         | `ForAll (qs, t) ->
            get_type_args kind (TypeVarSet.add_quantifiers qs bound_vars) t

--- a/core/instantiate.ml
+++ b/core/instantiate.ml
@@ -90,8 +90,8 @@ let instantiates : instantiation_maps -> (datatype -> datatype) * (row -> row) *
              List.fold_left remove_shadowed_quantifier inst_maps qs
            in
             `ForAll (qs, inst_typ updated_inst_maps rec_env t)
-        | `Alias ((name, qs, ts), d) ->
-            `Alias ((name, qs, List.map (inst_type_arg inst_maps rec_env) ts), inst d)
+        | `Alias ((name, qs, ts, is_dual), d) ->
+            `Alias ((name, qs, List.map (inst_type_arg inst_maps rec_env) ts, is_dual), inst d)
         | `Application (n, elem_type) ->
             `Application (n, List.map (inst_type_arg inst_maps rec_env) elem_type)
         | `RecursiveApplication app ->
@@ -465,4 +465,4 @@ let alias name tyargs env : Types.typ =
            definition with the type arguments *and* instantiate any
            top-level quantifiers *)
         let (_, body) = typ (instantiate_datatype (tenv, renv, penv) body) in
-          `Alias ((name, List.map snd vars, tyargs), body)
+          `Alias ((name, List.map snd vars, tyargs, false), body)

--- a/core/lens_type_conv.ml
+++ b/core/lens_type_conv.ml
@@ -14,7 +14,7 @@ let to_links_map m =
 
 let lookup_alias context ~alias =
   match Env.String.find_opt alias context with
-  | Some (`Alias (_, t)) -> `Alias ((alias, [], []), t)
+  | Some (`Alias (_, t)) -> `Alias ((alias, [], [], false), t)
   | _ -> Errors.MissingBuiltinType alias |> raise
 
 let rec type_of_lens_phrase_type ~context t =

--- a/core/typeSugar.ml
+++ b/core/typeSugar.ml
@@ -4689,7 +4689,7 @@ and type_cp (context : context) = fun {node = p; pos} ->
          CPUnquote (bindings, e), t, usage_builder u
     | CPGrab ((c, _), None, p) ->
        let (_, t, _) = type_check context (var c) in
-       let ctype = `Alias (("EndQuery", [], []), `Input (Types.unit_type, `End)) in
+       let ctype = `Alias (("EndQuery", [], [], false), `Input (Types.unit_type, `End)) in
        unify ~pos:pos ~handle:(Gripers.cp_grab c) (t, ctype);
        let (p, pt, u) = type_cp (unbind_var context c) p in
        CPGrab ((c, Some (ctype, [])), None, p), pt, use c u

--- a/core/typeUtils.ml
+++ b/core/typeUtils.ml
@@ -100,7 +100,6 @@ let rec select_type name t = match concrete_type t with
   | `ForAll (_, t) -> select_type name t
   | `Select row ->
     let t, _ = split_row name row in t
-(*  | `Alias (_,t) -> select_type name t*)
   | t ->
     error ("Attempt to select from non-selection type "^string_of_datatype t)
 

--- a/core/typeUtils.ml
+++ b/core/typeUtils.ml
@@ -38,7 +38,7 @@ let concrete_type t =
                       | _ -> `ForAll (qs, t)
                   end
           end
-      | `Dual s -> dual_type s
+      | `Dual s -> dual_type (ct rec_names s)
       | `RecursiveApplication ({ r_unique_name; r_dual; r_args; r_unwind ; _ } as appl) ->
           if (RecIdSet.mem (NominalId r_unique_name) rec_names) then
             `RecursiveApplication appl
@@ -100,8 +100,9 @@ let rec select_type name t = match concrete_type t with
   | `ForAll (_, t) -> select_type name t
   | `Select row ->
     let t, _ = split_row name row in t
+(*  | `Alias (_,t) -> select_type name t*)
   | t ->
-    error ("Attempt to select from non-selection type "^string_of_datatype (concrete_type t))
+    error ("Attempt to select from non-selection type "^string_of_datatype t)
 
 let rec split_choice_type name t = match concrete_type t with
   | `ForAll (_, t) -> split_choice_type name t

--- a/core/types.ml
+++ b/core/types.ml
@@ -1061,7 +1061,7 @@ let free_type_vars, free_row_type_vars, free_tyarg_vars =
           S.union_all
             [free_type_vars' rec_vars r; free_type_vars' rec_vars w; free_type_vars' rec_vars n]
       | `Lens _          -> S.empty
-      | `Alias ((_, _, ts,_), datatype) ->
+      | `Alias ((_, _, ts, _), datatype) ->
           S.union (S.union_all (List.map (free_tyarg_vars' rec_vars) ts)) (free_type_vars' rec_vars datatype)
       | `Application (_, tyargs) -> S.union_all (List.map (free_tyarg_vars' rec_vars) tyargs)
       | `RecursiveApplication { r_args; _ } ->
@@ -1235,13 +1235,7 @@ let rec dual_type : var_map -> datatype -> datatype =
       | `RecursiveApplication appl ->
           `RecursiveApplication { appl with r_dual = (not appl.r_dual) }
       | `End -> `End
-      (* it sometimes seems tempting to preserve aliases here, but it
-         won't always work - e.g. when we use dual_type to expose a
-         concrete type *)
       | `Alias ((f,ks,args,isdual),t)         -> `Alias ((f,ks,args,not(isdual)),dt t)
-      (* Still, we might hope to find a way of preserving 'dual
-         aliases' in order to simplify the pretty-printing of types... *)
-      (*| `Alias (_, t) -> dt t*)
       | t -> raise (Invalid_argument ("Attempt to dualise non-session type: " ^ show_datatype t))
 and dual_row : var_map -> row -> row =
   fun rec_points row ->
@@ -2408,7 +2402,7 @@ let make_fresh_envs : datatype -> datatype IntMap.t * row IntMap.t * field_spec 
       | `Variant row             -> make_env_r boundvars row
       | `Table (r, w, n)         -> union [make_env boundvars r; make_env boundvars w; make_env boundvars n]
       | `Lens _                  -> empties
-      | `Alias ((_, _, ts,_), d) -> union (List.map (make_env_ta boundvars) ts @ [make_env boundvars d])
+      | `Alias ((_, _, ts, _), d) -> union (List.map (make_env_ta boundvars) ts @ [make_env boundvars d])
       | `Application (_, ds)     -> union (List.map (make_env_ta boundvars) ds)
       | `RecursiveApplication { r_args ; _ } -> union (List.map (make_env_ta boundvars) r_args)
       | `ForAll (qs, t)          ->

--- a/core/types.mli
+++ b/core/types.mli
@@ -117,7 +117,7 @@ and typ =
     | `Effect of row
     | `Table of typ * typ * typ
     | `Lens of Lens.Type.t
-    | `Alias of ((string * Kind.t list * type_arg list) * typ)
+    | `Alias of ((string * Kind.t list * type_arg list * bool) * typ)
     | `Application of (Abstype.t * type_arg list)
     | `RecursiveApplication of rec_appl
     | `MetaTypeVar of meta_type_var


### PR DESCRIPTION
This appears to pass all tests and keeps aliases in the type syntax with an extra flag indicating whether the alias is dualized.  This should have no impact on typechecking, but just means that aliases don't evaporate when a type is dualized and when we print out a type containing residual dualized aliases we print the alias with `~` before it rather than expanding out the definition.

It would be helpful to have a test case illustrating the desired error message matches what @SimonJF had in mind, since my familiarity with session types/error messages is not sufficient to come up with a simple example.

It is also possible that this change breaks something non-obvious (that is not exercised by the test suite).  In particular I'm not especially confident that this change does not break unification somehow.  I would hope that this is dealt with correctly already by the code that just discards `Alias` nodes during unification.

WIP for discussion after #637.