### PR TITLE
remove last vestiges of CGI script web mode

### DIFF
--- a/bin/links.ml
+++ b/bin/links.ml
@@ -108,11 +108,4 @@ let main () =
   | [], [] -> Repl.interact context''
   | _, _ -> ()
 
-let _ =
-  (* Determine whether web mode should be enabled. *)
-  begin match Utility.getenv "REQUEST_METHOD" with
-    | Some _ -> Settings.set BS.web_mode true
-    | None -> ()
-  end;
-  main()
-
+let _ = main()

--- a/bin/repl.ml
+++ b/bin/repl.ml
@@ -48,7 +48,7 @@ let ps1 = "links> "
 
 (** Print a value (including its type if `printing_types' is [true]). *)
 let print_value rtype value =
-  if Settings.get BS.web_mode || not (Settings.get print_pretty)
+  if Settings.get Webserver_types.webs_running || not (Settings.get print_pretty)
   then begin
       print_string (Value.string_of_value value);
       print_endline (if Settings.get printing_types then
@@ -361,4 +361,3 @@ let interact : Context.t -> unit
   in
   Sys.set_signal Sys.sigint (Sys.Signal_handle (fun _ -> raise Sys.Break));
   loop context
-

--- a/bin/repl.ml
+++ b/bin/repl.ml
@@ -361,3 +361,4 @@ let interact : Context.t -> unit
   in
   Sys.set_signal Sys.sigint (Sys.Signal_handle (fun _ -> raise Sys.Break));
   loop context
+

--- a/core/basicsettings.ml
+++ b/core/basicsettings.ml
@@ -1,12 +1,3 @@
-(** [true] if we're in web mode *)
-let web_mode =
-  Settings.(flag "web_mode"
-            |> synopsis "Start Links in web mode"
-            |> privilege `System
-            |> convert parse_bool
-            |> CLI.(add (short 'w' <&> long "web-mode"))
-            |> sync)
-
 (** [true] if we're in interactive mode *)
 let interactive_mode =
   Settings.(flag "interactive_mode"

--- a/core/evalir.ml
+++ b/core/evalir.ml
@@ -128,7 +128,7 @@ struct
      result =
 
        fun req_data name cont args ->
-         if not(Settings.get Basicsettings.web_mode) then
+         if not(Settings.get webs_running) then
            raise (Errors.client_call_outside_webmode name);
          (*if not(Proc.singlethreaded()) then
            raise (internal_error "Remaining procs on server at client call!"); *)

--- a/core/typeSugar.ml
+++ b/core/typeSugar.ml
@@ -422,7 +422,7 @@ end
       error:Unify.error ->
       unit
 
-    let wm () = Settings.get  Basicsettings.web_mode
+    let wm () = Settings.get  Webserver_types.webs_running
 
     let code s =
       if wm () then

--- a/core/webserver.ml
+++ b/core/webserver.ml
@@ -352,7 +352,6 @@ struct
     Debug.print ("Starting server?\n");
     Lwt.async_exception_hook :=
       (fun exn -> Debug.print ("Caught asynchronous exception: " ^ (Printexc.to_string exn)));
-    Settings.set Basicsettings.web_mode true;
     Settings.set webs_running true;
     start_server (val_of (Settings.get hostname)) (val_of (Settings.get port)) rt
 end


### PR DESCRIPTION
Links originally supported running in "web mode" as a stateless CGI script.  

This was replaced by the appserver and removed as of #313.  However, a few vestiges remain, largely the `-w` flag and `web_mode` setting, which was only being used to determine whether to pretty-print REPL output and whether to print error messages as plain text or HTML.  Moreover, `web_mode` was being set either by the `-w` flag, by the presence of the CGI `REQUEST_METHOD` environment variable, or automatically when the app server starts.

There is a separate setting, `Webserver_types.webs_running`, which is also set when the app server starts, and can never be unset, thus we can use this to determine whether to pretty-print output or print errors as HTML instead of `web_mode`.  Moreover, the command line or CGI usage for running Links in (CGI) web mode are no longer used.  This PR removes the `web_mode` flag and uses `webs_running` instead.