### PR TITLE
fix #754 

### DIFF
--- a/core/query/evalNestedQuery.ml
+++ b/core/query/evalNestedQuery.ml
@@ -386,7 +386,6 @@ struct
       | Apply (Primitive "tilde", [s; r]) as e ->
           Debug.print ("Applying lins_inner to tilde expression: " ^ QL.show e);
           Apply (Primitive "tilde", [lins_inner (z, z_fields) ys s; r])
-
       | Apply (Primitive f, es) ->
         Apply (Primitive f, List.map (lins_inner (z, z_fields) ys) es)
       | Record fields ->

--- a/core/query/evalNestedQuery.ml
+++ b/core/query/evalNestedQuery.ml
@@ -804,3 +804,4 @@ let compile_shredded : Value.env -> Ir.computation
           let t = Q.type_of_expression v in
           let p = unordered_query_package t v in
             Some (db, p)
+

--- a/core/query/evalNestedQuery.ml
+++ b/core/query/evalNestedQuery.ml
@@ -383,6 +383,10 @@ struct
         end
       | Apply (Primitive "Empty", [e]) -> Apply (Primitive "Empty", [lins_inner_query (z, z_fields) ys e])
       | Apply (Primitive "length", [e]) -> Apply (Primitive "length", [lins_inner_query (z, z_fields) ys e])
+      | Apply (Primitive "tilde", [s; r]) as e ->
+          Debug.print ("Applying lins_inner to tilde expression: " ^ QL.show e);
+          Apply (Primitive "tilde", [lins_inner (z, z_fields) ys s; r])
+
       | Apply (Primitive f, es) ->
         Apply (Primitive f, List.map (lins_inner (z, z_fields) ys) es)
       | Record fields ->
@@ -489,6 +493,9 @@ struct
       | Primitive p   -> Primitive p
       | Apply (Primitive "Empty", [e]) -> Apply (Primitive "Empty", [flatten_inner_query e])
       | Apply (Primitive "length", [e]) -> Apply (Primitive "length", [flatten_inner_query e])
+      | Apply (Primitive "tilde", [s; r]) as e ->
+          Debug.print ("Applying flatten_inner to tilde expression: " ^ QL.show e);
+          Apply (Primitive "tilde", [flatten_inner s; r])
       | Apply (Primitive f, es) -> Apply (Primitive f, List.map flatten_inner es)
       | If (c, t, e)  ->
         If (flatten_inner c, flatten_inner t, flatten_inner e)
@@ -798,4 +805,3 @@ let compile_shredded : Value.env -> Ir.computation
           let t = Q.type_of_expression v in
           let p = unordered_query_package t v in
             Some (db, p)
-

--- a/tests/shredding/jrules.links
+++ b/tests/shredding/jrules.links
@@ -51,9 +51,16 @@ fun v () {
   }
 }
 
+sig marketers2 : () -> [(name:String, clients:[Int])]
+fun marketers2 () {
+  for (m <-- marketers_names)
+  [(name=m.name, clients = for (x <-- mc) where (x.m == m.name && x.m =~ /a/) [x.c])]
+}
+
 fun test() {
   assertEq(u(), [((id=1), ["a", "c"]), ((id=2), ["c"]), ((id=3), ["c"]), ((id=42), [])]);
   assertEq(v(), [(name = "a")]);
+  assertEq(marketers2(), [(clients = [1], name = "a"), (clients = [], name = "b"), (clients = [], name = "c")]);
 }
 
 test()

--- a/tests/shredding/jrules.links
+++ b/tests/shredding/jrules.links
@@ -42,8 +42,18 @@ fun u () {
   }
 }
 
+sig v : () -> [(name:String)]
+fun v () {
+  query nested {
+    for (x <-- marketers_names)
+    where (x.name =~ /a/)
+    [x]
+  }
+}
+
 fun test() {
   assertEq(u(), [((id=1), ["a", "c"]), ((id=2), ["c"]), ((id=3), ["c"]), ((id=42), [])]);
+  assertEq(v(), [(name = "a")]);
 }
 
 test()


### PR DESCRIPTION
This PR attempts to fix #754 by adding cases that recognize regular expression matching tests in the let-insertion and flattening stages of shredding.  Previously these were handled generically and failing because these stages didn't provide any cases to handle variants (which is how regular expressions are represented at runtime in the IR).  

This makes simple tests using regexes inside nested queries, like the one in #754 work, but does not make regular expression handling on the database any more complete/safe than it already was.

I've added debug messages to the two new cases in case we should be doing something more with the regex expressions, so that if we run into problems there will be a debugging message that gives more of a clue what the problem is.