### PR TITLE
Fix linearity of `End` in presence of duality

### DIFF
--- a/core/types.ml
+++ b/core/types.ml
@@ -736,7 +736,7 @@ module Unl : Constraint = struct
       | `Not_typed -> assert false
       | `Effect _ | `Primitive _ | `Function _ -> true
       | `Lolli _ -> false
-      | (`Record _ | `Variant _ | `Alias _ | `MetaTypeVar _ | `ForAll _ | `Dual _) as t
+      | (`Record _ | `Variant _ | `Alias _ | `MetaTypeVar _ | `ForAll _) as t
         -> super#type_satisfies vars t
       | `Table _ -> true
       | `Lens _sort -> true
@@ -752,7 +752,7 @@ module Unl : Constraint = struct
              * block is unrestricted. With this in hand, we can calculate
              * linearity information, meaning that (r_linear ()) will return (Some lin). *)
             OptionUtils.opt_app not true (r_linear ())
-      | `End -> false
+      | `End | `Dual _ -> false
       | #session_type -> false
   end
 

--- a/examples/sessions/ap-multi-client.links
+++ b/examples/sessions/ap-multi-client.links
@@ -1,13 +1,14 @@
 fun grabber(ap) client {
   var s = accept(ap);
   var t = accept(ap);
-  <| s(x).t(y).s(z).t(w).s[x+y].t[z+w].{()} |>;
+  <| s(x).t(y).s(z).t(w).s[x+y].t[z+w].{close(s); close(t)} |>;
   grabber(ap);
 }
 
 fun giver(x, y, a, b) client {
   var s = request(a);
-  var z = receive(send(y,send(x,s))).1;
+  var (z, s) = receive(send(y,send(x,s)));
+  close(s);
   var t = accept(b);
   close(send(z, t));
 }

--- a/examples/sessions/draggable.links
+++ b/examples/sessions/draggable.links
@@ -69,17 +69,17 @@ fun draggableList(loc, id, items)
 
   fun mouseUp() {
     var c = request(ap);
-    <|MouseUp c.{()}|>
+    <|MouseUp c.{close(c)}|>
   }
 
   fun mouseDown(elem) {
     var c = request(ap);
-    <|MouseDown c.c[elem].{()}|>
+    <|MouseDown c.c[elem].{close(c)}|>
   }
 
   fun mouseOut(toElem) {
     var c = request(ap);
-    <|MouseOut c.c[toElem].{()}|>
+    <|MouseOut c.c[toElem].{close(c)}|>
   }
 
   <ul id="{id}"

--- a/examples/sessions/draggable.links
+++ b/examples/sessions/draggable.links
@@ -39,22 +39,24 @@ fun draggableList(loc, id, items)
       fun wait(c) {
         var s = accept(ap);
         <|offer s {
-          case MouseUp -> {wait(c)}
+          case MouseUp -> {close(s); wait(c)}
           case MouseDown -> s(elem).{
+            close(s);
             if (isElementNode(elem) && (parentNode(elem) == getNodeById(id))) {
               <|MouseDown c.c[elem].{drag(c)}|>
             } else {
               wait(c)
             }}
-          case MouseOut -> s(elem).{wait(c)}
+          case MouseOut -> s(elem).{close(s); wait(c)}
         }|>
       }
 
       fun drag(c) {
         offer(accept(ap)) {
-          case MouseUp(s)   -> <|MouseUp c.{wait(c)}|>
-          case MouseDown(s) -> <|s(elem).{drag(c)}|>
+          case MouseUp(s)   -> <|MouseUp c.{close(s); wait(c)}|>
+          case MouseDown(s) -> <|s(elem).{close(s); drag(c)}|>
           case MouseOut(s)  -> <|s(toElem).{
+            close(s);
             if (isElementNode(toElem) && (parentNode(toElem) == getNodeById(id))) {
               <| MouseOut c.c[toElem].{drag(c)} |>
             } else {

--- a/examples/sessions/fusegg.links
+++ b/examples/sessions/fusegg.links
@@ -1,5 +1,5 @@
-var x = link(fork (fun (s) {ignore(send(42, s))}),
-             fork (fun (c) {println(intToString(receive(c).1))}));
-var y = link(fork (fun (c) {println(intToString(receive(c).1))}),
-             fork (fun (s) {ignore(send(42, s))}));
+var x = link(fork (fun (s) {close(send(42, s))}),
+             fork (fun (c) {var (x, c) = receive(c); close(c); println(intToString(x))}));
+var y = link(fork (fun (c) {var (x, c) = receive(c); close(c); println(intToString(x))}),
+             fork (fun (s) {close(send(42, s))}));
 ()

--- a/examples/sessions/givengrab.links
+++ b/examples/sessions/givengrab.links
@@ -1,14 +1,15 @@
 fun main() {
   fun giver(x,y,a) {
-    (receive(send(y,send(x,request(a))))).1
+    var (res, a) = receive(send(y,send(x,request(a))));
+    close(a);
+    res
   }
 
   fun grabber(a) {
     var s = accept(a);
     var (x,s) = receive(s);
     var (y,s) = receive(s);
-    var _ = send(x+y,s);
-    ()
+    close(send(x+y,s))
   }
 
   var a = new();

--- a/examples/sessions/gng-client.links
+++ b/examples/sessions/gng-client.links
@@ -1,14 +1,16 @@
 fun main() client {
   fun giver(x,y,a) {
-    (receive(send(y,send(x,request(a))))).1
+    var (res, a) = receive(send(y,send(x,request(a))));
+    close(a);
+    res
   }
 
   fun grabber(a) {
     var s = accept(a);
     var (x,s) = receive(s);
     var (y,s) = receive(s);
-    var _ = send(x+y,s);
-    ()
+    var s = send(x+y,s);
+    close(s)
   }
 
   var a = new();

--- a/examples/webserver/draggable-sessions.links
+++ b/examples/webserver/draggable-sessions.links
@@ -40,22 +40,24 @@ fun draggableList(id, items)
       fun wait(c) {
         var s = accept(ap);
         <|offer s {
-          case MouseUp -> {wait(c)}
+          case MouseUp -> {close(s); wait(c)}
           case MouseDown -> s(elem).{
+            close(s);
             if (isElementNode(elem) && (parentNode(elem) == getNodeById(id))) {
               <|MouseDown c.c[elem].{drag(c)}|>
             } else {
               wait(c)
             }}
-          case MouseOut -> s(elem).{wait(c)}
+          case MouseOut -> s(elem).{close(s); wait(c)}
         }|>
       }
 
       fun drag(c) {
         offer(accept(ap)) {
-          case MouseUp(s)   -> <|MouseUp c.{wait(c)}|>
-          case MouseDown(s) -> <|s(elem).{drag(c)}|>
+          case MouseUp(s)   -> <|MouseUp c.{close(s); wait(c)}|>
+          case MouseDown(s) -> <|s(elem).{close(s); drag(c)}|>
           case MouseOut(s)  -> <|s(toElem).{
+            close(s);
             if (isElementNode(toElem) && (parentNode(toElem) == getNodeById(id))) {
               <| MouseOut c.c[toElem].{drag(c)} |>
             } else {

--- a/examples/webserver/draggable-sessions.links
+++ b/examples/webserver/draggable-sessions.links
@@ -70,17 +70,17 @@ fun draggableList(id, items)
 
   fun mouseUp() {
     var c = request(ap);
-    <|MouseUp c|>
+    <| MouseUp c.{close(c)}|>
   }
 
   fun mouseDown(elem) {
     var c = request(ap);
-    <|MouseDown c.c[elem]|>
+    <|MouseDown c.c[elem].{close(c)}|>
   }
 
   fun mouseOut(toElem) {
     var c = request(ap);
-    <|MouseOut c.c[toElem]|>
+    <|MouseOut c.c[toElem].{close(c)}|>
   }
 
   <ul id="{id}"

--- a/prelude.links
+++ b/prelude.links
@@ -1208,10 +1208,11 @@ fun connect(f, g) {
   var done = new();
   var _ = spawn {
     f(accept(ap));
-    ignore(send((), accept(done)))
+    close(send((), accept(done)))
   };
   var result = g(request(ap));
-  ignore(receive(request(done)));
+  var (_, s) = receive(request(done));
+  close(s);
   result
 }
 

--- a/prelude.links
+++ b/prelude.links
@@ -1192,15 +1192,27 @@ fun reproduce(ap, f) {
   reproduce(ap, f)
 }
 
+# Here we use an additional access point to synchronise on termination
+# of communicating threads. This synchronisation can be useful because
+# we do not have an explicit close function and by default the
+# top-level process does not wait for running threads to terminate.
+#
+# (In fact, this gymnastics is no longer necessary now that we have
+# spawnAngel which allows us to spawn a process that will continue to
+# run even if the main process terminates.)
 
 #sig connect : forall s::Session,e::Row,a.((s) ~e~> (), (~s) ~e~> a) ~e~> a
 sig connect : forall s::Session,e::Row,a.((s) {SessionFail:[||]}~> (), (~s) ~e~> a) ~e~> a
 fun connect(f, g) {
   var ap = new();
+  var done = new();
   var _ = spawn {
     f(accept(ap));
+    ignore(send((), accept(done)))
   };
-  g(request(ap))
+  var result = g(request(ap));
+  ignore(receive(request(done)));
+  result
 }
 
 ### sessions with split ends ###

--- a/tests/session-exceptions/cancel1.links
+++ b/tests/session-exceptions/cancel1.links
@@ -1,7 +1,8 @@
 fun goAlright() {
   try {
-    var s = fork (fun (s) { ignore(send(5, s)) });
-    var (res, _) = receive(s);
+    var s = fork (fun (s) { close(send(5, s)) });
+    var (res, s) = receive(s);
+    close(s);
     res
   } as (x) in {
     "result: " ^^ intToString(x)
@@ -13,7 +14,8 @@ fun goAlright() {
 fun go() {
   try {
     var s = fork (fun (s) { cancel(s) });
-    var (res, _) = receive(s);
+    var (res, s) = receive(s);
+    close(s);
     res
   } as (x) in {
     "result: " ^^ intToString(x)

--- a/tests/session-exceptions/cancel10.links
+++ b/tests/session-exceptions/cancel10.links
@@ -1,12 +1,14 @@
 fun go() {
-  var s = fork(fun(s) { ignore(send(5, s)) });
+  var s = fork(fun(s) { close(send(5, s)) });
   try {
     raise; 10
   } as (x) in {
-    var (res, _) = receive(s);
+    var (res, s) = receive(s);
+    close(s);
     x + res
   } otherwise {
-    var (res, _) = receive(s);
+    var (res, s) = receive(s);
+    close(s);
     res
   }
 }

--- a/tests/session-exceptions/cancel11.links
+++ b/tests/session-exceptions/cancel11.links
@@ -2,7 +2,7 @@ fun go() {
   try {
     var s = fork (fun (s) { cancel(s) });
     offer(s) {
-      case Foo(s) -> 100
+      case Foo(s) -> close(s); 100
     }
   } as (x) in {
     "result: " ^^ intToString(x)

--- a/tests/session-exceptions/cancel2.links
+++ b/tests/session-exceptions/cancel2.links
@@ -4,12 +4,12 @@ fun goAlright() {
   var ap = new(); # Yay synchronisation!
   try {
     var s = fork (fun (s) {
-  #    cancel(s);
-      ignore(request(ap));
-      ignore(receive(s));
+      close(request(ap));
+      var (_, s) = receive(s);
+      close(s)
     });
-    ignore(accept(ap));
-    ignore(send(5, s))
+    close(accept(ap));
+    close(send(5, s))
   } as (_) in {
     "send successful"
   } otherwise {
@@ -23,10 +23,10 @@ fun go() {
   try {
     var s = fork (fun (s) {
       cancel(s);
-      ignore(request(ap))
+      close(request(ap))
     });
-    ignore(accept(ap));
-    ignore(send(5, s))
+    close(accept(ap));
+    close(send(5, s))
   } as (_) in {
     "send successful"
   } otherwise {

--- a/tests/session-exceptions/cancel3.links
+++ b/tests/session-exceptions/cancel3.links
@@ -5,13 +5,14 @@ fun go() {
     var t = fork(fun(t) {
       var carried = request(ap);
       # Ensure the send takes place before cancellation
-      var _ = send(carried, t);
-      ignore(request(syncAP))
+      close(send(carried, t));
+      close(request(syncAP))
       });
     var carried = accept(ap);
-    ignore(accept(syncAP));
+    close(accept(syncAP));
     cancel(t);
-    var (res, _) = receive(carried);
+    var (res, s) = receive(carried);
+    close(s);
     res
   } as (x) in {
     "received from carried: " ^^ intToString(x)

--- a/tests/session-exceptions/cancel4.links
+++ b/tests/session-exceptions/cancel4.links
@@ -1,12 +1,13 @@
 
 fun go() {
   var ap = new();
-  var s = fork(fun(s) { cancel(s); ignore(request(ap)) });
+  var s = fork(fun(s) { cancel(s); close(request(ap)) });
   try {
     var x =
       try {
-        var _ = accept(ap);
-        var (res, _) = receive(s);
+        close(accept(ap));
+        var (res, s) = receive(s);
+        close(s);
         res
       } as (x) in {
         x

--- a/tests/session-exceptions/cancel5.links
+++ b/tests/session-exceptions/cancel5.links
@@ -3,12 +3,14 @@ fun go() {
   try {
     var s = fork(fun(s) {
       var t = request(ap);
-      ignore(receive(s));
-      ignore(send(5, t))
+      var (_, s) = receive(s);
+      close(s);
+      close(send(5, t))
     });
     cancel(s);
     var t = accept(ap);
-    var (x, _) = receive(t);
+    var (x, t) = receive(t);
+    close(t);
     x
   } as (x) in {
     intToString(x)

--- a/tests/session-exceptions/cancel6.links
+++ b/tests/session-exceptions/cancel6.links
@@ -5,10 +5,11 @@ fun go() {
     var s = fork (fun(s) {
       var t = accept(ap);
       raise;
-      ignore(send(linfun() { send(5, t) }, s))
+      close(send(linfun() { send(5, t) }, s))
     });
     var t = request(ap);
-    var (res, _) = receive(t);
+    var (res, t) = receive(t);
+    close(t);
     cancel(s);
     res
   } as (x) in {

--- a/tests/session-exceptions/cancel7.links
+++ b/tests/session-exceptions/cancel7.links
@@ -4,13 +4,13 @@ fun go() {
   try {
     var s = fork (fun(s) {
       var t = accept(ap);
-      var clos = linfun() { send(5, t) };
+      var clos = linfun() { close(send(5, t)) };
       raise;
-      ignore(send(clos, s))
+      close(send(clos, s))
     });
     var t = request(ap);
-    var (res, _) = receive(t);
-    #cancel(t);
+    var (res, t) = receive(t);
+    close(t);
     cancel(s);
     1
   } as (x) in {

--- a/tests/session-exceptions/cancel8.links
+++ b/tests/session-exceptions/cancel8.links
@@ -6,13 +6,14 @@ fun go() {
     var s = fork (fun(s) {
       var t = accept(ap);
       var clos = linfun() { send(5, t) };
-      ignore(send(clos, s));
-      ignore(request(syncAP))
+      close(send(clos, s));
+      close(request(syncAP))
     });
     var t = request(ap);
-    ignore(accept(syncAP));
+    close(accept(syncAP));
     cancel(s);
-    var (res, _) = receive(t);
+    var (res, t) = receive(t);
+    close(t);
     res
   } as (x) in {
     "success: " ^^ intToString(x)

--- a/tests/session-exceptions/cancel9.links
+++ b/tests/session-exceptions/cancel9.links
@@ -6,10 +6,11 @@ fun go() {
       var t = accept(ap);
       raise;
       var clos = linfun() { send(5, t) };
-      ignore(send(clos, s))
+      close(send(clos, s))
     });
     var t = request(ap);
-    var (res, _) = receive(t);
+    var (res, t) = receive(t);
+    close(t);
     cancel(s);
     res
   } as (x) in {

--- a/tests/typecheck_examples.tests
+++ b/tests/typecheck_examples.tests
@@ -555,6 +555,7 @@ args : --config=tests/examples_default.config
 Typecheck example file examples/sessions/draggable.links
 examples/sessions/draggable.links
 filemode : true
+ignore : broken example
 args : --config=tests/examples_default.config
 
 Typecheck example file examples/sessions/Elvina/Bookshop_1.links
@@ -816,6 +817,7 @@ args : --config=tests/examples_default.config
 Typecheck example file examples/webserver/draggable-sessions.links
 examples/webserver/draggable-sessions.links
 filemode : true
+ignore : broken example
 args : --config=tests/examples_default.config
 
 Typecheck example file examples/webserver/draggable.links

--- a/tests/typecheck_examples.tests
+++ b/tests/typecheck_examples.tests
@@ -555,7 +555,6 @@ args : --config=tests/examples_default.config
 Typecheck example file examples/sessions/draggable.links
 examples/sessions/draggable.links
 filemode : true
-ignore : broken example
 args : --config=tests/examples_default.config
 
 Typecheck example file examples/sessions/Elvina/Bookshop_1.links
@@ -817,7 +816,6 @@ args : --config=tests/examples_default.config
 Typecheck example file examples/webserver/draggable-sessions.links
 examples/webserver/draggable-sessions.links
 filemode : true
-ignore : broken example
 args : --config=tests/examples_default.config
 
 Typecheck example file examples/webserver/draggable.links


### PR DESCRIPTION
As hinted at by a1ffb17f2890a9647d4456be07f303bf2de82ba0, Links was not handling the linearity of the `End` type correctly. This was because of a very subtle bug in checking linearity of dualised session types.

~~This has brought to light what seem to be some rather strange bugs, however. In particular, `examples/sessions/draggable.links` (and by extension `examples/webserver/draggable-sessions.links`) are broken, and I can't see how they would ever have worked: the `mouseUp()` and `mouseDown()` functions request on an AP, do a CP-style selection, and then seem to simply return the channel, which can't be eliminated since the session type does not contain an `End`. Am I missing something here? I've marked as broken examples for now.~~

(fixed the above after some explanation by @slindley)