### PR TITLE
Proposal for simpler handling of unsafe sig and fix for #691

### DIFF
--- a/core/buildTables.ml
+++ b/core/buildTables.ml
@@ -7,7 +7,7 @@ struct
   type t = (Var.var, Ir.eval_fun_def) Hashtbl.t
 
   let make_eval_def : Ir.fun_def -> Ir.eval_fun_def =
-    fun ((_f, info), (_tyvars, xs, body), z, location) ->
+    fun ((_f, info), (_tyvars, xs, body), z, location, _) ->
       info, (List.map Var.var_of_binder xs, body), opt_map Var.var_of_binder z, location
 
   let add fs def =
@@ -196,7 +196,7 @@ struct
             (* we record the relevant free variables of the body *)
             o#close x fvs;
             o#close_cont (IntSet.union fvs fvs') bs
-        | Fun (f, (_tyvars, xs, body), z, _)::bs ->
+        | Fun (f, (_tyvars, xs, body), z, _, _)::bs ->
             let fvs = IntSet.remove (Var.var_of_binder f) fvs in
             let xs = match z with None -> xs | Some z -> z :: xs in
             let bound_vars =
@@ -210,7 +210,7 @@ struct
         | Rec defs::bs ->
             let fvs, bound_vars =
               List.fold_right
-                (fun (f, (_tyvars, xs, _body), z, _) (fvs, bound_vars) ->
+                (fun (f, (_tyvars, xs, _body), z, _, _unsafe) (fvs, bound_vars) ->
                    let f = Var.var_of_binder f in
                    let fvs = IntSet.remove f fvs in
                    let xs = match z with None -> xs | Some z -> z :: xs in
@@ -226,7 +226,7 @@ struct
 
             let fvs' =
               List.fold_left
-                (fun fvs' (_f, (_tyvars, _xs, body), _zs, _location) ->
+                (fun fvs' (_f, (_tyvars, _xs, body), _zs, _location, _unsafe) ->
                    IntSet.union fvs' (FreeVars.computation o#get_type_environment bound_vars body))
                 (IntSet.empty)
                 defs in

--- a/core/channelVarUtils.ml
+++ b/core/channelVarUtils.ml
@@ -44,7 +44,7 @@ let variables_in_computation comp =
         traverse_value scrutinee;
         traverse_stringmap (fun (_, c) -> traverse_computation c) cases;
         OptionUtils.opt_iter (fun (_, c) -> traverse_computation c) case_opt
-  and traverse_fundef (bnd, (_, _, _), _, _) =
+  and traverse_fundef (bnd, (_, _, _), _, _, _) =
     let fun_var = Var.var_of_binder bnd in
     match Tables.(lookup fun_defs fun_var) with
       | Some (_, _, (Some fvs_var), _) ->

--- a/core/compilePatterns.ml
+++ b/core/compilePatterns.ml
@@ -195,7 +195,7 @@ struct
     let eff = lookup_effects env in
       Apply
         (TApp
-           (Variable (NEnv.find "hd" Lib.nenv),
+           (Variable (NEnv.find "##hd" Lib.nenv),
             [(Type, t); (Row, eff)]),
          [v])
 
@@ -203,7 +203,7 @@ struct
     let eff = lookup_effects env in
       Apply
         (TApp
-           (Variable (NEnv.find "tl" Lib.nenv),
+           (Variable (NEnv.find "##tl" Lib.nenv),
             [(Type, t); (Row, eff)]),
          [v])
 end

--- a/core/ir.ml
+++ b/core/ir.ml
@@ -57,7 +57,7 @@ and tail_computation =
 
   | Case       of value * (binder * computation) name_map * (binder * computation) option
   | If         of value * computation * computation
-and fun_def = binder * (tyvar list * binder list * computation) * binder option * location
+and fun_def = binder * (tyvar list * binder list * computation) * binder option * location * bool
 and binding =
   | Let        of binder * (tyvar list * tail_computation)
   | Fun        of fun_def
@@ -109,7 +109,7 @@ let binding_scope : binding -> scope =
   | Rec []
   | Module _ -> assert false
 
-let binder_of_fun_def (fb, _, _, _) = fb
+let binder_of_fun_def (fb, _, _, _,_) = fb
 
 let tapp (v, tyargs) =
   match tyargs with

--- a/core/ir.ml
+++ b/core/ir.ml
@@ -103,8 +103,8 @@ and lens_predicate = Static of Lens.Phrase.t | Dynamic of value
 let binding_scope : binding -> scope =
   function
   | Let (b, _)
-  | Fun (b, _, _, _)
-  | Rec ((b, _, _, _)::_)
+  | Fun (b, _, _, _, _)
+  | Rec ((b, _, _, _, _)::_)
   | Alien { binder = b; _ } -> Var.scope_of_binder b
   | Rec []
   | Module _ -> assert false

--- a/core/ir.mli
+++ b/core/ir.mli
@@ -59,7 +59,7 @@ and tail_computation =
   | Special    of special
   | Case       of value * (binder * computation) name_map * (binder * computation) option
   | If         of value * computation * computation
-and fun_def = binder * (tyvar list * binder list * computation) * binder option * location
+and fun_def = binder * (tyvar list * binder list * computation) * binder option * location * bool
 and binding =
   | Let        of binder * (tyvar list * tail_computation)
   | Fun        of fun_def

--- a/core/irCheck.ml
+++ b/core/irCheck.ml
@@ -1284,7 +1284,7 @@ struct
                                 tyvars
                                 actual_parameter_types
                                 body
-                                (not unsafe) (* Treat recursive bindings with nusafe sig as nonrecursive *)
+                                (not unsafe) (* Treat recursive bindings with unsafe sig as nonrecursive *)
                                 (SBind binding) in
                   let o = o#add_function_closure_binder (Var.var_of_binder f) (tyvars, z) in
                   (* Debug.print ("added " ^ string_of_int (Var.var_of_binder f) ^ " to closure env"); *)

--- a/core/irTraversals.ml
+++ b/core/irTraversals.ml
@@ -441,7 +441,7 @@ struct
             let x, o = o#binder x in
             let tc, _, o = o#tail_computation tc in
               Let (x, (tyvars, tc)), o
-        | Fun (f, (tyvars, xs, body), z, location) ->
+        | Fun (f, (tyvars, xs, body), z, location, unsafe) ->
             let xs, body, z, o =
               let (z, o) = o#optionu (fun o -> o#binder) z in
               let (xs, o) =
@@ -455,22 +455,22 @@ struct
                 xs, body, z, o in
             let f, o = o#binder f in
               (* TODO: check that xs and body match up with f *)
-              Fun (f, (tyvars, xs, body), z, location), o
+              Fun (f, (tyvars, xs, body), z, location, unsafe), o
         | Rec defs ->
             (* it's important to traverse the function binders first in
                order to make sure they're in scope for all of the
                function bodies *)
             let defs, o =
               List.fold_right
-                (fun (f, (tyvars, xs, body), z, location) (fs, o) ->
+                (fun (f, (tyvars, xs, body), z, location, unsafe) (fs, o) ->
                    let f, o = o#binder f in
-                     ((f, (tyvars, xs, body), z, location)::fs, o))
+                     ((f, (tyvars, xs, body), z, location, unsafe)::fs, o))
                 defs
                 ([], o) in
 
             let defs, o =
               List.fold_left
-                (fun (defs, (o : 'self_type)) (f, (tyvars, xs, body), z, location) ->
+                (fun (defs, (o : 'self_type)) (f, (tyvars, xs, body), z, location, unsafe) ->
                    let (z, o) = o#optionu (fun o -> o#binder) z in
                    let xs, o =
                      List.fold_right
@@ -480,7 +480,7 @@ struct
                        xs
                        ([], o) in
                   let body, _, o = o#computation body in
-                    (f, (tyvars, xs, body), z, location)::defs, o)
+                    (f, (tyvars, xs, body), z, location, unsafe)::defs, o)
                 ([], o)
                 defs in
             let defs = List.rev defs in
@@ -689,13 +689,13 @@ module ElimDeadDefs = struct
         | Let (x, (_, Return _)) ->
             let b, o = super#binding b in
               b, o#init x
-        | Fun (f, _, _, _) ->
+        | Fun (f, _, _, _, _) ->
             let b, o = super#binding b in
               b, o#init f
         | Rec defs ->
             let fs, o =
               List.fold_right
-                (fun (f, _, _, _) (fs, o) ->
+                (fun (f, _, _, _, _) (fs, o) ->
                    let f, o = o#binder f in
                      (IntSet.add (Var.var_of_binder f) fs, o#initrec f))
                 defs
@@ -703,7 +703,7 @@ module ElimDeadDefs = struct
 
             let defs, o =
               List.fold_left
-                (fun (defs, (o : 'self_type)) (f, (tyvars, xs, body), z, location) ->
+                (fun (defs, (o : 'self_type)) (f, (tyvars, xs, body), z, location, unsafe) ->
                    let z, o = o#optionu (fun o -> o#binder) z in
                    let xs, o =
                      List.fold_right
@@ -715,7 +715,7 @@ module ElimDeadDefs = struct
                    let o = o#set_rec (Var.var_of_binder f) in
                    let body, _, o = o#computation body in
                    let o = o#set_mutrec (Var.var_of_binder f) in
-                     (f, (tyvars, xs, body), z, location)::defs, o)
+                     (f, (tyvars, xs, body), z, location, unsafe)::defs, o)
                 ([], o)
                 defs in
             let o = o#set_nonrecs fs in
@@ -750,13 +750,13 @@ module ElimDeadDefs = struct
                 match b with
                   | Let ((x, _), (_tyvars, _)) when o#is_dead x ->
                       o#bindings bs
-                  | Fun ((f, _), _, _, _) when o#is_dead f ->
+                  | Fun ((f, _), _, _, _, _) when o#is_dead f ->
                       o#bindings bs
                   | Rec defs ->
                       Debug.if_set show_rec_uses (fun () -> "Rec block:");
                       let fs, defs =
                         List.fold_left
-                          (fun (fs, defs) (((f, (_, name, _)), _, _, _) as def) ->
+                          (fun (fs, defs) (((f, (_, name, _)), _, _, _, _) as def) ->
                              Debug.if_set show_rec_uses
                                (fun () ->
                                   "  (" ^ name ^ ") non-rec uses: "^string_of_int (IntMap.find f env)^

--- a/core/irtojs.ml
+++ b/core/irtojs.ml
@@ -728,7 +728,7 @@ end = functor (K : CONTINUATION) -> struct
   module GenStubs =
   struct
     let rec fun_def : Ir.fun_def -> code -> code =
-      fun ((fb, (_, xsb, _), zb, location) : Ir.fun_def) code ->
+      fun ((fb, (_, xsb, _), zb, location, _unsafe) : Ir.fun_def) code ->
         let f_var, _ = fb in
         let bs = List.map name_binder xsb in
         let _, xs_names = List.split bs in
@@ -1134,13 +1134,13 @@ end = functor (K : CONTINUATION) -> struct
                    env', Fn ([x_name], body))
              in
              env', bind (generate_tail_computation env tc K.(skappa' <> skappas))
-          | Fun ((fb, _, _zs, _location) as def) :: bs ->
+          | Fun ((fb, _, _zs, _location, _unsafe) as def) :: bs ->
              let (f, f_name) = name_binder fb in
              let def_header = generate_function env [] def in
              let env', rest = gbs (VEnv.bind f f_name env) kappa bs in
              (env', LetFun (def_header, rest))
           | Rec defs :: bs ->
-             let fs = List.map (fun (fb, _, _, _) -> name_binder fb) defs in
+             let fs = List.map (fun (fb, _, _, _, _) -> name_binder fb) defs in
              let env', rest = gbs (List.fold_left (fun env (x, n) -> VEnv.bind x n env) env fs) kappa bs in
              (env', LetRec (List.map (generate_function env fs) defs, rest))
           | Module _ :: bs
@@ -1152,7 +1152,7 @@ end = functor (K : CONTINUATION) -> struct
   and generate_function env fs :
       Ir.fun_def ->
     (string * string list * code * Ir.location) =
-    fun (fb, (_, xsb, body), zb, location) ->
+    fun (fb, (_, xsb, body), zb, location, _unsafe) ->
       let (f, f_name) = name_binder fb in
       assert (f_name <> "");
       (* prerr_endline ("f_name: "^f_name); *)
@@ -1225,7 +1225,7 @@ end = functor (K : CONTINUATION) -> struct
           varenv,
           Some x_name,
           fun code -> Bind (x_name, Lit jsonized_val, code))
-      | Fun ((fb, _, _zs, _location) as def) ->
+      | Fun ((fb, _, _zs, _location, _unsafe) as def) ->
          let (f, f_name) = name_binder fb in
          let varenv = VEnv.bind f f_name varenv in
          let def_header = generate_function varenv [] def in
@@ -1234,7 +1234,7 @@ end = functor (K : CONTINUATION) -> struct
           None,
           fun code -> LetFun (def_header, code))
       | Rec defs ->
-         let fs = List.map (fun (fb, _, _, _) -> name_binder fb) defs in
+         let fs = List.map (fun (fb, _, _, _, _) -> name_binder fb) defs in
          let varenv =
            List.fold_left
              (fun env (n, x) -> VEnv.bind n x env)

--- a/core/lens_ir_conv.ml
+++ b/core/lens_ir_conv.ml
@@ -251,7 +251,7 @@ let lens_sugar_phrase_of_ir p env =
             Result.bind
               ~f:(fun v -> computation (Env.bind env (x, v)) (bs, tailcomp))
               v
-        | I.Fun (_, _, _, Location.Client) ->
+        | I.Fun (_, _, _, Location.Client, _) ->
             Result.error Of_ir_error.Client_function
         | I.Fun _ ->
             Result.error @@ Of_ir_error.Internal_error "Unexpected function."

--- a/core/lib.ml
+++ b/core/lib.ml
@@ -523,6 +523,25 @@ let env : (string * (located_primitive * Types.datatype * pure)) list = [
    datatype "([a]) ~> [a]",
   IMPURE);
 
+  (* HACK: tame versions of head and tail for use in pattern matching *)
+  "##hd",
+  (p1 (fun lst ->
+        match (Value.unbox_list lst) with
+          | [] -> runtime_error "hd() of empty list"
+          | x :: _ -> x
+      ),
+   datatype "([a]) -> a",
+  IMPURE);
+
+  "##tl",
+  (p1 (fun lst ->
+         match (Value.unbox_list lst) with
+            | [] -> runtime_error "tl() of empty list"
+            | _x :: xs -> Value.box_list xs
+      ),
+   datatype "([a]) -> [a]",
+  IMPURE);
+
   "length",
   (p1 (Value.unbox_list ->- List.length ->- Value.box_int),
    datatype "([a]) -> Int",

--- a/core/query/query.ml
+++ b/core/query/query.ml
@@ -748,9 +748,9 @@ struct
               | Let (xb, (_, tc)) ->
                   let x = Var.var_of_binder xb in
                     computation (bind env (x, tail_computation env tc)) (bs, tailcomp)
-              | Fun (_, _, _, Location.Client) ->
+              | Fun (_, _, _, Location.Client, _) ->
                   query_error "Client function"
-              | Fun ((f, _), _, _, _) ->
+              | Fun ((f, _), _, _, _, _) ->
                 (* This should never happen now that we have closure conversion*)
                 raise (internal_error
                   ("Function definition in query: " ^ string_of_int f ^

--- a/core/sugartoir.ml
+++ b/core/sugartoir.ml
@@ -185,13 +185,13 @@ sig
 
   val letfun :
     env ->
-    (var_info * (Quantifier.t list * (CompilePatterns.Pattern.t list * tail_computation sem)) * location) ->
+    (var_info * (Quantifier.t list * (CompilePatterns.Pattern.t list * tail_computation sem)) * location * bool) ->
     (var -> tail_computation sem) ->
     tail_computation sem
 
   val letrec :
     env ->
-    (var_info * (Quantifier.t list * (CompilePatterns.Pattern.t list * (var list -> tail_computation sem))) * location) list ->
+    (var_info * (Quantifier.t list * (CompilePatterns.Pattern.t list * (var list -> tail_computation sem))) * location * bool) list ->
     (var list -> tail_computation sem) ->
     tail_computation sem
 
@@ -278,11 +278,11 @@ struct
     val comp_binding : ?tyvars:tyvar list -> var_info * tail_computation -> var M.sem
 
     val fun_binding :
-      Var.var_info * (tyvar list * binder list * computation) * location ->
+      Var.var_info * (tyvar list * binder list * computation) * location * bool ->
       Var.var M.sem
     val rec_binding :
       (Var.var_info * (tyvar list * binder list * (Var.var list -> computation))
-       * location) list ->
+       * location * bool) list ->
       (Var.var list) M.sem
 
     val alien_binding : var_info * string * ForeignLanguage.t -> var M.sem
@@ -312,24 +312,24 @@ struct
       let xb, x = Var.fresh_var x_info in
         lift_binding (letm ~tyvars (xb, e)) x
 
-    let fun_binding (f_info, (tyvars, xsb, body), location) =
+    let fun_binding (f_info, (tyvars, xsb, body), location, unsafe) =
       let fb, f = Var.fresh_var f_info in
-        lift_binding (Fun (fb, (tyvars, xsb, body), None, location)) f
+        lift_binding (Fun (fb, (tyvars, xsb, body), None, location, unsafe)) f
 
     let rec_binding defs =
       let defs, fs =
         List.fold_right
-          (fun (f_info, (tyvars, xsb, body), location) (defs, fs) ->
+          (fun (f_info, (tyvars, xsb, body), location, unsafe) (defs, fs) ->
              let fb, f = Var.fresh_var f_info in
-               ((fb, (tyvars, xsb, body), None, location) :: defs, f :: fs))
+               ((fb, (tyvars, xsb, body), None, location, unsafe) :: defs, f :: fs))
           defs ([], [])
       in
         lift_binding
           (Rec
              (List.map
-                (fun (fb, (tyvars, xsb, body), none, location) ->
+                (fun (fb, (tyvars, xsb, body), none, location, unsafe) ->
                   assert (none = None);
-                   (fb, (tyvars, xsb, body fs), none, location))
+                   (fb, (tyvars, xsb, body fs), none, location, unsafe))
                 defs))
           fs
 
@@ -648,9 +648,9 @@ struct
     let f_info = (ft, "", Scope.Local) in
     let rest f : tail_computation sem = lift (Special (CallCC (Variable f)),
                                               body_type) in
-      M.bind (fun_binding (f_info, ([], [kb], body), loc_unknown)) rest
+      M.bind (fun_binding (f_info, ([], [kb], body), loc_unknown, false)) rest
 
-  let letfun env ((ft, _, _) as f_info, (tyvars, (ps, body)), location) rest =
+  let letfun env ((ft, _, _) as f_info, (tyvars, (ps, body)), location, unsafe) rest =
     let xsb : binder list =
       (* It is important to rename the quantifiers in the type to be
          those used in the body of the function. *)
@@ -675,12 +675,12 @@ struct
         ps
         xsb
     in
-      M.bind (fun_binding (f_info, (tyvars, xsb, body), location)) rest
+      M.bind (fun_binding (f_info, (tyvars, xsb, body), location, unsafe)) rest
 
   let letrec env defs rest =
     let defs =
       List.map
-        (fun ((ft, _, _) as f_info, (tyvars, (ps, body)), location) ->
+        (fun ((ft, _, _) as f_info, (tyvars, (ps, body)), location, unsafe) ->
            let xsb : binder list =
              (* It is important to rename the quantifiers in the type to be those used in
                 the body of the function. *)
@@ -705,7 +705,7 @@ struct
                  ps
                  xsb
            in
-             (f_info, (tyvars, xsb, body), location))
+             (f_info, (tyvars, xsb, body), location, unsafe))
         defs
     in
       M.bind (rec_binding defs) rest
@@ -1141,7 +1141,10 @@ struct
                     let s = ev body in
                     let ss = eval_bindings scope env' bs e in
                       I.comp env (p, s, ss)
-                | Fun { fun_binder = bndr; fun_definition = (tyvars, ([ps], body)); fun_location = location; _ }
+                | Fun { fun_binder           = bndr;
+                        fun_definition       = (tyvars, ([ps], body));
+                        fun_location         = location;
+                        fun_unsafe_signature = unsafe; _ }
                      when Binder.has_type bndr ->
                     let f  = Binder.to_name bndr in
                     let ft = Binder.to_type bndr in
@@ -1157,7 +1160,7 @@ struct
                     let qs = List.map SugarQuantifier.get_resolved_exn tyvars in
                       I.letfun
                         env
-                        ((ft, f, scope), (qs, (ps, body)), location)
+                        ((ft, f, scope), (qs, (ps, body)), location, unsafe)
                         (fun v -> eval_bindings scope (extend [f] [(v, ft)] env) bs e)
                 | Exp e' ->
                     I.comp env (CompilePatterns.Pattern.Any, ev e', eval_bindings scope env bs e)
@@ -1176,7 +1179,10 @@ struct
                         ([], [], []) in
                     let defs =
                       List.map
-                        (fun { rec_binder = bndr; rec_definition = ((tyvars, _), (pss, body)); rec_location = location; _ } ->
+                        (fun { rec_binder           = bndr;
+                               rec_definition       = ((tyvars, _), (pss, body));
+                               rec_location         = location;
+                               rec_unsafe_signature = unsafe; _ } ->
                           assert (List.length pss = 1);
                           let f  = Binder.to_name bndr in
                           let ft = Binder.to_type bndr in
@@ -1191,7 +1197,7 @@ struct
                                ps
                                ([], env) in
                            let body = fun vs -> eval (extend fs (List.combine vs inner_fts) body_env) body in
-                             ((ft, f, scope), (qs, (ps, body)), location))
+                             ((ft, f, scope), (qs, (ps, body)), location, unsafe))
                         (nodes_of_list defs)
                     in
                       I.letrec env defs (fun vs -> eval_bindings scope (extend fs (List.combine vs outer_fts) env) bs e)
@@ -1239,14 +1245,14 @@ struct
               match b with
                 | Let ((x, (_xt, x_name, Scope.Global)), _) ->
                     partition (b::locals @ globals, [], Env.String.bind x_name x nenv) bs
-                | Fun ((f, (_ft, f_name, Scope.Global)), _, _, _) ->
+                | Fun ((f, (_ft, f_name, Scope.Global)), _, _, _, _) ->
                     partition (b::locals @ globals, [], Env.String.bind f_name f nenv) bs
                 | Rec defs ->
                   (* we depend on the invariant that mutually
                      recursive definitions all have the same scope *)
                     let scope, nenv =
                       List.fold_left
-                        (fun (scope, nenv) ((f, (_ft, f_name, f_scope)), _, _, _) ->
+                        (fun (scope, nenv) ((f, (_ft, f_name, f_scope)), _, _, _, _) ->
                            match f_scope with
                              | Scope.Global -> Scope.Global, Env.String.bind f_name f nenv
                              | Scope.Local -> scope, nenv)

--- a/core/typeSugar.ml
+++ b/core/typeSugar.ml
@@ -362,7 +362,7 @@ sig
   val bind_rec_annotation : griper
   val bind_rec_rec : griper
 
-  val bind_unsafe_fun_annotation : griper
+(*XXX  val bind_unsafe_fun_annotation : griper *)
 
   val bind_exp : griper
 
@@ -2166,7 +2166,7 @@ let check_for_duplicate_names : Position.t -> Pattern.with_pos list -> string li
     else
       List.map fst (StringMap.bindings binderss)
 
-let map_effects fn =
+(* XXX let map_effects fn =
   let transform = object(o)
     inherit Types.Transform.visitor as super
 
@@ -2181,7 +2181,7 @@ let map_effects fn =
   end
   in
   transform#typ ->- fst
-
+*)
 (** Adds the wild effect to the right-most arrow on a type. *)
 (* XXX let make_unsafe_signature =
   let open Types in
@@ -2565,7 +2565,7 @@ let rec type_check : context -> phrase -> phrase * Types.datatype * Usage.t =
 
     let check_recursive_usage e v context =
       (* register wildness if this is a recursive variable instance *)
-      Debug.print ("check_recursive_usage: " ^ v ^ " " ^ (if StringSet.mem v context.rec_vars then "true" else "false"));
+(* XXX      Debug.print ("check_recursive_usage: " ^ v ^ " " ^ (if StringSet.mem v context.rec_vars then "true" else "false")); *)
       if StringSet.mem v context.rec_vars then
         begin
           let wild_open = Types.make_singleton_open_row ("wild", Types.Present Types.unit_type) default_effect_subkind in
@@ -4166,8 +4166,8 @@ and type_binding : context -> binding -> binding * context * Usage.t =
     let no_pos t = (_UNKNOWN_POS_, t) in
     let type_check = type_check in
     let unify pos (l, r) = unify_or_raise ~pos (l, r) in
-    let unify_nopos ~handle (l, r) = unify_or_raise ~pos ~handle (no_pos l, no_pos r)
-    and typ (_,t,_) = t
+(* XXX   let unify_nopos ~handle (l, r) = unify_or_raise ~pos ~handle (no_pos l, no_pos r) *)
+    let typ (_,t,_) = t
     and erase (e, _, _) = e
     and usages (_,_,u) = u
     and erase_pat (e, _, _) = e
@@ -4444,7 +4444,7 @@ and type_binding : context -> binding -> binding * context * Usage.t =
 
                  (* We make the patterns monomorphic after unifying with the signature. *)
                  make_mono pats;
-                 Debug.print (Format.sprintf "unsafe: %s %s" name (if unsafe then "true" else "false")); (* XXX *)
+(* XXX                 Debug.print (Format.sprintf "unsafe: %s %s" name (if unsafe then "true" else "false"));  *)
                  let inner_rec_vars =
                    if unsafe
                    then inner_rec_vars
@@ -4461,7 +4461,7 @@ and type_binding : context -> binding -> binding * context * Usage.t =
           *)
           let (defs, used) =
             let body_env = Env.extend context.var_env inner_env in
-            StringSet.pp Format.err_formatter inner_rec_vars; (* XXX *)
+(* XXX             StringSet.pp Format.err_formatter inner_rec_vars; *)
             let context = {context with rec_vars = StringSet.union context.rec_vars inner_rec_vars} in
             (* let fold_in_envs = List.fold_left (fun env pat' -> env ++ (pattern_env pat')) in *)
             List.split

--- a/prelude.links
+++ b/prelude.links
@@ -51,10 +51,17 @@ fun sortBy (f, l) {
   }
 }
 
-# need to be careful to make sure this doesn't get
-# optimised away - it does if we eta reduce it
 unsafe sig sortByBase : ((a) -b-> (| _::Base), [a]) -b-> [a]
-fun sortByBase(f, l) {sortBy(f, l)}
+fun sortByBase(f, l) {
+  switch (l) {
+    case [] -> []
+    case x::xs -> {
+      var lt = filter (fun (y) {f(y) < f(x)}, xs);
+      var ge = filter (fun (y) {f(y) >= f(x)}, xs);
+      sortByBase(f, lt) ++ [x] ++ sortByBase(f, ge)
+    }
+  }
+}
 
 fun all(p, l) {
    switch (l) {

--- a/tests/annotations.tests
+++ b/tests/annotations.tests
@@ -39,7 +39,8 @@ stdout : 42 : Int
 
 Unsafe type annotations on non-recursive functions
 unsafe sig f : (String) -> () fun f(x) { print(x) } f
-stdout : fun : (String) -> ()
+stderr : @.+
+exit : 1
 
 Unsafe type annotations on recursive functions
 unsafe sig f : (String) -> () fun f(x) { f(x) } f

--- a/tests/typed_ir.tests
+++ b/tests/typed_ir.tests
@@ -50,14 +50,14 @@ stdout : () : ()
 Unsafe type signatures #1 (#691)
 tests/typed_ir/T691a.links
 filemode : true
-exit : 1
-stderr : @..*
+exit : 0
+stdout : () : ()
 
 Unsafe type signatures #2 (#691)
 tests/typed_ir/T691b.links
 filemode : true
-exit : 1
-stderr : @..*
+exit : 0
+stdout : () : ()
 
 Wild effect compatibility #1 (#697)
 tests/typed_ir/T697a.links

--- a/tests/typed_ir.tests
+++ b/tests/typed_ir.tests
@@ -77,3 +77,7 @@ stdout : () : ()
 isInt (#575)
 sig isInt : (String) -> Bool fun isInt (x) { x =~ /-?[0-9]+$/ }
 stdout : () : ()
+
+function pattern matching has right effects (#691)
+sig f : ([a]) {}-> a fun f ([x]) { x }
+stdout : () : ()

--- a/tests/typed_ir/T694.links
+++ b/tests/typed_ir/T694.links
@@ -1,3 +1,4 @@
+unsafe sig concatMap : ((a) -b-> [c], [a]) -b-> [c]
 fun concatMap(f, l) {
   switch (l) {
     case [] -> []

--- a/tests/typed_ir/T697b.links
+++ b/tests/typed_ir/T697b.links
@@ -1,9 +1,11 @@
-sig concatMap : ((a) -b-> [c], [a]) -b-> [c]
+unsafe sig concatMap : ((a) -b-> [c], [a]) -b-> [c]
 fun concatMap(f, l) {
-  #dummy to avoid problems with unsafe signatures currently
-  #not being supported by IR type-checker
-  []
+  switch (l) {
+    case [] -> []
+    case hd::tl -> f(hd) ++ concatMap(f, tl)
+  }
 }
+
 
 fun swap(xs, x1, x2) {
  for (x <- xs) {

--- a/tests/typed_ir/T698.links
+++ b/tests/typed_ir/T698.links
@@ -1,9 +1,11 @@
-sig concatMap : ((a) -b-> [c], [a]) -b-> [c]
+unsafe sig concatMap : ((a) -b-> [c], [a]) -b-> [c]
 fun concatMap(f, l) {
-  #dummy to avoid problems with unsafe signatures currently
-  #not being supported by IR type-checker
-  []
+  switch (l) {
+    case [] -> []
+    case hd::tl -> f(hd) ++ concatMap(f, tl)
+  }
 }
+
 
 #The function we are actually interested in
 fun asList(t) server {


### PR DESCRIPTION
This PR disables the previous code for handling unsafe signatures and implements a new approach:

- `unsafe sig foo` means that the declared identifier is not treated as recursive, for the purpose of effect typing; that is, recursive calls to `foo` are tame.
- type inference is otherwise as normal, and we do not (and do not need to) adjust the inferred type

It also adds treatment of unsafe-signature behavior to the IR.  This unfortunately touches a lot of code because the function definition data is a tuple rather than record.  In IR typechecking, we treat identifiers in recursive blocks as non-recursive if they are declared with `unsafe sig`.

Finally, a remaining problem is that pattern matching against List cons is translated (by `compilePatterns.ml`) to calls to `hd` and `tl`, which are wild.  This PR introduces a small hack to work around this: adding tame versions of `hd` and `tl` which have names that can never appear in Links source code, and are only used for desugaring of pattern matching.  This is slightly bad though because it would mean that these versions of `hd` and `tl` could be present in query code and the IR typechecker would allow this; but this is a problem we already have because of #37.  I have some longer-term ideas how to remove this related to #47 and #37.