### PR TITLE
Fix #256 by adjusting (pretty) printing code

### DIFF
--- a/bin/repl.ml
+++ b/bin/repl.ml
@@ -12,7 +12,7 @@ let printing_types =
 
 (* Pretty print values (outside web mode) *)
 let print_pretty
-  = Settings.(flag "print_pretty"
+  = Settings.(flag ~default:true "print_pretty"
               |> synopsis "Pretty print values (outside web mode)"
               |> convert parse_bool
               |> sync)

--- a/core/value.ml
+++ b/core/value.ml
@@ -866,8 +866,8 @@ let string_of_pretty pretty_fun arg : string =
   pp_set_max_indent f 990000;
   (* Redefine the meaning of the pretty printing functions. The idea
      is to ignore newlines introduced by pretty printing as well as
-     indentation. 
-     Newlines can arise as a result of space hints so we need to generate 
+     indentation.
+     Newlines can arise as a result of space hints so we need to generate
      at least one space for a newline. *)
   let existing_functions = pp_get_formatter_out_functions f () in
   let out_functions =
@@ -876,7 +876,7 @@ let string_of_pretty pretty_fun arg : string =
       | _ -> out_string " " 0 1
     in
     { existing_functions with
-        out_newline = (fun () -> Debug.print "newline"; one_space 1);  (* to ensure that there is whitespace here even if not \n*)
+        out_newline = (fun () -> one_space 1);
         out_spaces  = one_space;
         out_indent  = one_space }
   in

--- a/core/value.ml
+++ b/core/value.ml
@@ -783,7 +783,7 @@ let rec p_value (ppf : formatter) : t -> 'a = function
      fprintf ppf "Spawn location: client %s" (ClientID.to_string cid)
   | `SpawnLocation `ServerSpawnLoc ->
      fprintf ppf "Spawn location: server"
-  | `XML xml -> p_xmlitem ~close_tags:false ppf xml
+  | `XML xml -> fprintf ppf "@[<hv>%a@]" (p_xmlitem ~close_tags:false) xml
   | `Continuation cont -> fprintf ppf "Continuation%s" (Continuation.to_string cont)
   | `Resumption _res -> fprintf ppf "Resumption"
   | `AccessPointID (`ClientAccessPoint (cid, apid)) ->
@@ -860,9 +860,15 @@ let string_of_pretty pretty_fun arg : string =
   let b = Buffer.create 200 in
   let f = Format.formatter_of_buffer b in
   let (out_string, _out_flush) = pp_get_formatter_output_functions f () in
+  (* We set margin/max indent to absurdly large values to avoid the need
+     for newlines. *)
+  pp_set_margin f 1000000;
+  pp_set_max_indent f 990000;
   (* Redefine the meaning of the pretty printing functions. The idea
      is to ignore newlines introduced by pretty printing as well as
-     indentation. *)
+     indentation. 
+     Newlines can arise as a result of space hints so we need to generate 
+     at least one space for a newline. *)
   let existing_functions = pp_get_formatter_out_functions f () in
   let out_functions =
     let one_space = function
@@ -870,9 +876,9 @@ let string_of_pretty pretty_fun arg : string =
       | _ -> out_string " " 0 1
     in
     { existing_functions with
-        out_newline = ignore;
-        out_spaces = one_space;
-        out_indent = one_space }
+        out_newline = (fun () -> Debug.print "newline"; one_space 1);  (* to ensure that there is whitespace here even if not \n*)
+        out_spaces  = one_space;
+        out_indent  = one_space }
   in
   pp_set_formatter_out_functions f out_functions;
   pretty_fun f arg;

--- a/tests/xml.tests
+++ b/tests/xml.tests
@@ -107,7 +107,16 @@ stdout : <foo id="bar" class="baz"><div/></foo> : Xml
 XML Construction 3
 makeXml("foo", [ ("id", "bar"), ("class", "baz") ], <div/>)
 stdout : <foo id="bar" class="baz"><div/></foo> : XmlItem
-ignore : Xml/XmlItem pretty-print bug
+
+Unpretty-printing attributes of XmlItem
+<foo id="bar" class="baz"><div/></foo>
+stdout : <foo id="bar" class="baz"><div/></foo> : Xml
+args : --set=print_pretty=false
+
+Unpretty-printing long snippets (#256)
+<a><b/><b/><b/><b/><b/><b/><b/><b/><b/><b/><b/><b/><b/><b/><b/><b/><b/><b/><b/><b/><b/><b/><b/><b/><b/><b/><b/><b/><b/><b/><b/><b/><b/><b/><b/><b/><b/><b/><b/><b/><b/></a>
+stdout : <a><b/><b/><b/><b/><b/><b/><b/><b/><b/><b/><b/><b/><b/><b/><b/><b/><b/><b/><b/><b/><b/><b/><b/><b/><b/><b/><b/><b/><b/><b/><b/><b/><b/><b/><b/><b/><b/><b/><b/><b/><b/></a> : Xml
+args : --set=print_pretty=false
 
 XML-Variant-Conversion
 variantToXml(xmlToVariant(<div class="i-am-a-div"><ul><li/><li></li><li>A</li></ul></div>))


### PR DESCRIPTION
This PR fixes a weird bug with pretty-printing XML where spaces were being omitted in unpredictable places.

The reason turns out to be that pretty-printing is actually disabled by default, and this means the default behavior of the formatter used for printing is overridden to ignore newlines and squash indentation or spaces of length longer than 1 to length 1.  However, since `Format` assumes that handling a space hint by generating a newline will result in separating whitespace, this gives undesirable behavior.  Fixing this resulted in further weird behavior, which I've attempted to avoid by also setting the formatter margin and max indent settings to absurdly large values.  

Another thing that seemed to help was enclosing individual `XmlItems` in `Format` boxes when they are encountered by the value printer so that they are treated just the same as a `Xml` (= `[XmlItem]`).  I'm not sure why this matters but at least it is more uniform,.

Finally, since it seemed silly for pretty-printing to be disabled by default, I've enabled it.  By analogy to Wadler's law, I expect this to generate more discussion than any other change.

This fixes #256 and passes all other tests without changes.

