### PR TITLE
Rename type variables in function signatures

### DIFF
--- a/tests/functions.tests
+++ b/tests/functions.tests
@@ -146,3 +146,10 @@ Linearity (9) - linear recursive functions should be disallowed
 linfun f(x) {f(x)} f
 stderr : @.*cannot be linear.*
 exit : 1
+
+Type variable freshening in type signatures (#865)
+./tests/functions/T865.links
+filemode : true
+exit : 0
+args : --config=tests/functions/T865.config
+stdout : () : ()

--- a/tests/functions/T865.config
+++ b/tests/functions/T865.config
@@ -1,0 +1,3 @@
+prelude=empty.links
+optimise=false
+recheck_frontend_transformations=true

--- a/tests/functions/T865.config
+++ b/tests/functions/T865.config
@@ -1,3 +1,3 @@
-prelude=empty.links
+prelude=tests/empty_prelude.links
 optimise=false
 recheck_frontend_transformations=true

--- a/tests/functions/T865.links
+++ b/tests/functions/T865.links
@@ -1,0 +1,7 @@
+sig reproduce_nonrec : forall a.(a) {}~> ()
+fun reproduce_nonrec(f) { () }
+
+sig reproduce_rec : forall a.(a) {}~> ()
+fun reproduce_rec(f) {
+  reproduce_rec(f)
+}


### PR DESCRIPTION
Fixes #865. See https://github.com/links-lang/links/issues/865#issuecomment-651879149 for description.