### PR TITLE
Fix bug in LINKS_LIB

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -87,7 +87,7 @@ create-startup-script:
 	@# This is an attempt to put in a safe guard
 	@# If the above resolution fails to yield an existent path then fall back to the relative path in BUILD_DIR.
 	$(eval ABS_BUILD_DIR:=$(shell test -d $(ABS_BUILD_DIR) && echo "$(ABS_BUILD_DIR)" || echo "$(BUILD_DIR)"))
-	@echo "LINKS_LIB=\"$(ABS_BUILD_DIR)/default\" $(ABS_BUILD_DIR)/default/bin/links.exe \"\$$@\"" >> links
+	@echo "LINKS_LIB=\"$(ABS_BUILD_DIR)/default/lib\" $(ABS_BUILD_DIR)/default/bin/links.exe \"\$$@\"" >> links
 	@chmod +x links
 	ln -fs links linx
 

--- a/Makefile
+++ b/Makefile
@@ -87,7 +87,7 @@ create-startup-script:
 	@# This is an attempt to put in a safe guard
 	@# If the above resolution fails to yield an existent path then fall back to the relative path in BUILD_DIR.
 	$(eval ABS_BUILD_DIR:=$(shell test -d $(ABS_BUILD_DIR) && echo "$(ABS_BUILD_DIR)" || echo "$(BUILD_DIR)"))
-	@echo "LINKS_LIB=\"$(ABS_BUILD_DIR)/default/lib\" $(ABS_BUILD_DIR)/default/bin/links.exe \"\$$@\"" >> links
+	@echo "LINKS_LIB=\"$(ABS_BUILD_DIR)/default\" $(ABS_BUILD_DIR)/default/bin/links.exe \"\$$@\"" >> links
 	@chmod +x links
 	ln -fs links linx
 

--- a/core/webserver.ml
+++ b/core/webserver.ml
@@ -315,6 +315,12 @@ struct
              end
           | Some s -> s
         in
+        if Sys.file_exists linkslib |> not
+         then raise (
+             Errors.SettingsError (
+               Format.asprintf
+                 "The javascript library path '%s' does not exist."
+                 linkslib));
         serve_static linkslib uri_path []
       (* Handle websocket connections *)
       else if (is_websocket_request path) then

--- a/core/webserver.ml
+++ b/core/webserver.ml
@@ -315,7 +315,7 @@ struct
              end
           | Some s -> s
         in
-        if Sys.file_exists linkslib |> not
+        if not (Sys.file_exists linkslib)
          then raise (
              Errors.SettingsError (
                Format.asprintf

--- a/core/webserver.ml
+++ b/core/webserver.ml
@@ -311,7 +311,7 @@ struct
              begin
                (match Utility.getenv "LINKS_LIB" with
                 | None -> Filename.dirname Sys.executable_name
-                | Some path -> path) / "lib" / "js"
+                | Some path -> path) / "js"
              end
           | Some s -> s
         in


### PR DESCRIPTION
Currently the makefile produces a bash script which initialises the jslib path to `<something>/lib/lib/<something>` This is fixed by removing `lib/` from the Makefile bit that generates the `./links` script.

For reference the links code that generates the full path: https://github.com/links-lang/links/blob/eaa33ca8c7fb4a7bab85424170379c2250d8ac6c/core/webserver.ml#L314