### PR TITLE
Abstract IR binders

### DIFF
--- a/bin/repl.ml
+++ b/bin/repl.ml
@@ -322,7 +322,7 @@ let handle previous_context current_context = function
                 | Location.Server | Location.Unknown ->
                    `FunctionPtr (var, None)
                 | Location.Client ->
-                   `ClientFunction (Js.var_name_binder (var, finfo))
+                   `ClientFunction (Js.var_name_var var)
               in
               let t = Var.info_type finfo in v, t
            | _ -> assert false

--- a/core/buildTables.ml
+++ b/core/buildTables.ml
@@ -173,7 +173,7 @@ struct
 
     method! binder b =
       let b, o = super#binder b in
-        if Scope.isGlobal (Var.scope_of_binder b) then
+        if Scope.is_global (Var.scope_of_binder b) then
           b, o#global (Var.var_of_binder b)
         else
           b, o

--- a/core/buildTables.ml
+++ b/core/buildTables.ml
@@ -7,8 +7,9 @@ struct
   type t = (Var.var, Ir.eval_fun_def) Hashtbl.t
 
   let make_eval_def : Ir.fun_def -> Ir.eval_fun_def =
-    fun ((_f, info), (_tyvars, xs, body), z, location, _) ->
-      info, (List.map Var.var_of_binder xs, body), opt_map Var.var_of_binder z, location
+    fun (b, (_tyvars, xs, body), z, location, _) ->
+    let info = Var.info_of_binder b in
+    info, (List.map Var.var_of_binder xs, body), opt_map Var.var_of_binder z, location
 
   let add fs def =
       let f = Var.var_of_binder (Ir.binder_of_fun_def def) in

--- a/core/closures.ml
+++ b/core/closures.ml
@@ -214,7 +214,7 @@ struct
           let o = List.fold_left (fun o q -> o#quantifier_remove q) o quantifiers in
           (b, o)
         | (Fun (f, (tyvars, xs, body), None, location, unsafe)) as b
-             when Scope.isLocal (Ir.binding_scope b) ->
+             when Scope.is_local (Ir.binding_scope b) ->
           (* reset free and bound variables to be empty *)
           let o = o#reset in
 
@@ -261,7 +261,7 @@ struct
           let o = List.fold_left (fun o q -> o#quantifier_remove q) o tyvars in
           (b, o)
 
-        | (Rec defs) as b when Scope.isLocal (Ir.binding_scope b) ->
+        | (Rec defs) as b when Scope.is_local (Ir.binding_scope b) ->
           (* reset free and bound variables to be empty *)
           let o = o#reset in
 
@@ -477,13 +477,13 @@ struct
       method! bindings =
         function
         | [] -> [], o
-        | b :: bs when Scope.isGlobal (Ir.binding_scope b) ->
+        | b :: bs when Scope.is_global (Ir.binding_scope b) ->
           let b, o = o#binding b in
           let bs', o = o#pop_hoisted_bindings in
           let bs, o = o#bindings bs in
           bs' @ (b :: bs), o
         | Fun ((f, _) as fb, (tyvars, xs, body), None, location, unsafe) :: bs ->
-          assert (Scope.isLocal (Var.scope_of_binder fb));
+          assert (Scope.is_local (Var.scope_of_binder fb));
           let fb = Globalise.binder fb in
           let (xs, o) =
             List.fold_right
@@ -551,7 +551,7 @@ struct
               List.fold_left
                 (fun (defs, (o : 'self)) ((f, _) as fb, (tyvars, xs, body), none, location, unsafe) ->
                    assert (none = None);
-                   assert (Scope.isLocal (Var.scope_of_binder fb));
+                   assert (Scope.is_local (Var.scope_of_binder fb));
                    let fb = Globalise.binder fb in
                    let xs, o =
                      List.fold_right

--- a/core/compilePatterns.ml
+++ b/core/compilePatterns.ml
@@ -1117,7 +1117,7 @@ let match_choices : var -> clause list -> bound_computation =
                               List.fold_left
                                 (fun cases -> function
                                   | ([(annotation, pattern)], body) ->
-                                    let (name, ((x, _) as b)) =
+                                    let (name, b) =
                                       match pattern with
                                       | Pattern.Variant (name, Pattern.Variable b) -> (name, b)
                                       | Pattern.Variant (name, Pattern.Any)        ->
@@ -1127,7 +1127,8 @@ let match_choices : var -> clause list -> bound_computation =
                                       | _ ->
                                         (* TODO: give a more useful error message - including the position
                                            (it may be necessary to detect the error earlier on) *)
-                                        failwith ("Only choice patterns are supported in choice compilation") in
+                                         failwith ("Only choice patterns are supported in choice compilation") in
+                                    let x = Var.var_of_binder b in
                                     let body = apply_annotation (Variable x) (annotation, body) in
                                     StringMap.add name (b, body env) cases
                                   | _ -> assert false)

--- a/core/compilePatterns.ml
+++ b/core/compilePatterns.ml
@@ -108,7 +108,7 @@ let rec desugar_pattern : Types.row -> Sugartypes.Pattern.with_pos -> Pattern.t 
       assert (Sugartypes.Binder.has_type bndr);
       let name = Sugartypes.Binder.to_name bndr in
       let t = Sugartypes.Binder.to_type bndr in
-      let xb, x = Var.fresh_var (t, name, Scope.Local) in
+      let xb, x = Var.(fresh_var (make_local_info (t, name))) in
       xb, (NEnv.bind name x nenv, TEnv.bind x t tenv, eff)
     in
       let open Sugartypes.Pattern in
@@ -1121,8 +1121,9 @@ let match_choices : var -> clause list -> bound_computation =
                                       match pattern with
                                       | Pattern.Variant (name, Pattern.Variable b) -> (name, b)
                                       | Pattern.Variant (name, Pattern.Any)        ->
-                                        let bt = TypeUtils.choice_at name t in
-                                        (name, Var.fresh_binder (bt, "_", Scope.Local))
+                                         let bt = TypeUtils.choice_at name t in
+                                         let info = Var.make_local_info (bt, "_") in
+                                         (name, Var.fresh_binder info)
                                       | _ ->
                                         (* TODO: give a more useful error message - including the position
                                            (it may be necessary to detect the error earlier on) *)

--- a/core/irCheck.ml
+++ b/core/irCheck.ml
@@ -492,9 +492,6 @@ struct
 
   type environment = datatype Env.t
 
-  let info_type (t, _, _) = t
-
-
   let checker tyenv =
   object (o)
     inherit IrTraversals.Transform.visitor(tyenv) as super
@@ -1320,9 +1317,11 @@ struct
 
 
     method! binder : binder -> (binder * 'self_type) =
-      fun (var, info) ->
-        let tyenv = Env.bind var (info_type info) tyenv in
-          (var, info), {< tyenv=tyenv >}
+      fun b ->
+      let var = Var.var_of_binder b in
+      let t = Var.type_of_binder b in
+      let tyenv = Env.bind var t tyenv in
+      b, {< tyenv=tyenv >}
 
     (* WARNING: use of remove_binder / remove_binding is only sound
        because we guarantee uniqueness of the names of bound term

--- a/core/irTraversals.ml
+++ b/core/irTraversals.ml
@@ -635,10 +635,12 @@ module ElimDeadDefs = struct
     method with_envs (env, rec_env, mutrec_env) =
       {< env = env; rec_env = rec_env; mutrec_env = mutrec_env >}
 
-    method init (x, _) =
+    method init b =
+      let x = Var.var_of_binder b in
       o#with_env (IntMap.add x 0 env)
 
-    method initrec (x, _) =
+    method initrec b =
+      let x = Var.var_of_binder b in
       o#with_envs (IntMap.add x 0 env, IntMap.add x (0, false) rec_env, IntMap.add x (0, true) mutrec_env)
 
     method set_rec_status f (r,m) =

--- a/core/irTraversals.ml
+++ b/core/irTraversals.ml
@@ -544,7 +544,7 @@ module Inline = struct
             let b, o = o#binding b in
               begin
                 match b with
-                | Let (b, (tyvars, Return v)) when Var.(Scope.isLocal (scope_of_binder b)) && is_inlineable_value v ->
+                | Let (b, (tyvars, Return v)) when Var.(Scope.is_local (scope_of_binder b)) && is_inlineable_value v ->
                    let x = Var.var_of_binder b in
                    let v =
                      match tyvars with

--- a/core/irTraversals.ml
+++ b/core/irTraversals.ml
@@ -67,8 +67,6 @@ struct
 
   type environment = datatype Env.Int.t
 
-  let info_type (t, _, _) = t
-
   let deconstruct f t = f t
 
   module Env = Env.Int
@@ -500,9 +498,11 @@ struct
               Module (name, defs), o
 
     method binder : binder -> (binder * 'self_type) =
-      fun (var, info) ->
-        let tyenv = Env.bind var (info_type info) tyenv in
-          (var, info), {< tyenv=tyenv >}
+      fun b ->
+      let var = Var.var_of_binder b in
+      let t   = Var.type_of_binder b in
+      let tyenv = Env.bind var t tyenv in
+      b, {< tyenv=tyenv >}
 
     method program : program -> (program * datatype * 'self_type) = o#computation
 
@@ -544,16 +544,17 @@ module Inline = struct
             let b, o = o#binding b in
               begin
                 match b with
-                  | Let ((x, (_, _, Scope.Local)), (tyvars, Return v)) when is_inlineable_value v ->
-                      let v =
-                        match tyvars with
-                          | [] -> v
-                          | tyvars -> TAbs (tyvars, v)
-                      in
-                        (o#with_env (IntMap.add x (fst3 (o#value v)) env))#bindings bs
-                  | _ ->
-                      let bs, o = o#bindings bs in
-                        b :: bs, o
+                | Let (b, (tyvars, Return v)) when Var.(Scope.isLocal (scope_of_binder b)) && is_inlineable_value v ->
+                   let x = Var.var_of_binder b in
+                   let v =
+                     match tyvars with
+                     | [] -> v
+                     | tyvars -> TAbs (tyvars, v)
+                   in
+                   (o#with_env (IntMap.add x (fst3 (o#value v)) env))#bindings bs
+                | _ ->
+                   let bs, o = o#bindings bs in
+                   b :: bs, o
               end
         | [] -> [], o
   end
@@ -748,25 +749,27 @@ module ElimDeadDefs = struct
             begin
               let b, o = o#binding b in
                 match b with
-                  | Let ((x, _), (_tyvars, _)) when o#is_dead x ->
+                  | Let (b, (_tyvars, _)) when o#is_dead (Var.var_of_binder b) ->
                       o#bindings bs
-                  | Fun ((f, _), _, _, _, _) when o#is_dead f ->
+                  | Fun (b, _, _, _, _) when o#is_dead (Var.var_of_binder b) ->
                       o#bindings bs
                   | Rec defs ->
                       Debug.if_set show_rec_uses (fun () -> "Rec block:");
                       let fs, defs =
                         List.fold_left
-                          (fun (fs, defs) (((f, (_, name, _)), _, _, _, _) as def) ->
+                          (fun (fs, defs) ((b, _, _, _, _) as def) ->
+                            let f = Var.var_of_binder b in
+                            let name = Var.name_of_binder b in
                              Debug.if_set show_rec_uses
                                (fun () ->
                                   "  (" ^ name ^ ") non-rec uses: "^string_of_int (IntMap.find f env)^
                                     ", rec uses: "^string_of_int (fst (IntMap.find f rec_env))^
                                     ", mut-rec uses: "^string_of_int (fst (IntMap.find f mutrec_env)));
                              if o#is_dead_rec f then fs, defs
-                             else
-                               IntSet.add f fs, def :: defs)
+                             else IntSet.add f fs, def :: defs)
                           (IntSet.empty, [])
-                          defs in
+                          defs
+                      in
 
                       (*
                          If none of the mutually recursive bindings appear elsewhere

--- a/core/irtojs.ml
+++ b/core/irtojs.ml
@@ -729,7 +729,7 @@ end = functor (K : CONTINUATION) -> struct
   struct
     let rec fun_def : Ir.fun_def -> code -> code =
       fun ((fb, (_, xsb, _), zb, location, _unsafe) : Ir.fun_def) code ->
-        let f_var, _ = fb in
+        let f_var = Var.var_of_binder fb in
         let bs = List.map name_binder xsb in
         let _, xs_names = List.split bs in
 

--- a/core/irtojs.ml
+++ b/core/irtojs.ml
@@ -343,14 +343,14 @@ end
 let cps_prims = ["recv"; "sleep"; "spawnWait"; "receive"; "request"; "accept"]
 
 (** Generate a JavaScript name from a binder, wordifying symbolic names *)
-let name_binder (x, info) =
-  let name = Js.name_binder (x, info) in
-  if (name = "") then
-    prerr_endline (Ir.show_binder (x, info))
-  else
-    ();
+let name_binder b =
+  let name = Js.name_binder b in
+  (* TODO(dhil): The below check is unnecessary as `Js.name_binder`
+     never returns the empty string. *)
+  (if (name = "") then
+     prerr_endline (Ir.show_binder b));
   assert (name <> "");
-  (x, Js.name_binder (x,info))
+  (Var.var_of_binder b, name)
 
 (** Continuation structures *)
 module type CONTINUATION = sig

--- a/core/js.ml
+++ b/core/js.ml
@@ -88,4 +88,4 @@ let var_name_var x = "_" ^ string_of_int x
 
 (** Generate a JavaScript name from a binder based on the unique
     integer for that binder. *)
-let var_name_binder (x, _) = var_name_var x
+let var_name_binder b = var_name_var (Var.var_of_binder b)

--- a/core/js.ml
+++ b/core/js.ml
@@ -72,20 +72,16 @@ struct
 end
 
 (** Generate a JavaScript name from a binder *)
-let name_binder (x, info) =
-  let (_, name, _) = info in
-  if String.length name = 0 then
-    "_" ^ string_of_int x
-  else
+let name_binder b =
+  let x = Var.var_of_binder b in
+  match Var.name_of_binder b with
+  | ""   -> "_" ^ string_of_int x
+  | name ->
     (* Closure conversion means we can no longer rely on top-level
        functions having unique names *)
-    (* match scope with *)
-    (* | `Local -> *)
-      if (Str.string_match (Str.regexp "^_g[0-9]") name 0) then
-        "_" ^ string_of_int x (* make the generated names slightly less ridiculous in some cases *)
-      else
-        Symbols.wordify name ^ "_" ^ string_of_int x
-    (* | `Global -> Symbols.wordify name *)
+     if (Str.string_match (Str.regexp "^_g[0-9]") name 0)
+     then "_" ^ string_of_int x (* make the generated names slightly less ridiculous in some cases *)
+     else Symbols.wordify name ^ "_" ^ string_of_int x
 
 (** Generate a JavaScript name from a variable number. *)
 let var_name_var x = "_" ^ string_of_int x

--- a/core/lens_ir_conv.ml
+++ b/core/lens_ir_conv.ml
@@ -60,7 +60,7 @@ module Env = struct
           | Location.Client ->
               raise
                 (Errors.runtime_error
-                   ( Js.var_name_binder (f, finfo)
+                   ( Js.var_name_binder (Var.make_binder f finfo)
                    |> Format.asprintf
                         "Attempt to use client function: %s in query" ))
         in

--- a/core/query/query.ml
+++ b/core/query/query.ml
@@ -536,8 +536,8 @@ struct
     | Some (finfo, (xs, body), z, location) ->
       Some
         begin
-          (* TODO(dhil): This is a bit of an around-about way to
-             obtain the binder name. *)
+          (* TODO(dhil): This is a bit of a round-about way to obtain
+             the binder name. *)
         match Var.(name_of_binder (make_binder f finfo)) with
         | "concatMap" ->
           Q.Primitive "ConcatMap"

--- a/core/serialisation.ml
+++ b/core/serialisation.ml
@@ -72,7 +72,7 @@ module Compressible = struct
       List.rev
         (E.fold
            (fun name (v, scope) compressed ->
-             if Scope.isGlobal scope
+             if Scope.is_global scope
              then compressed
              else (name, V.compress v) :: compressed)
            env [])

--- a/core/sugartoir.ml
+++ b/core/sugartoir.ml
@@ -1243,11 +1243,11 @@ struct
         | b::bs ->
             begin
               match b with
-              | Let (b', _) when Var.(Scope.isGlobal (scope_of_binder b')) ->
+              | Let (b', _) when Var.(Scope.is_global (scope_of_binder b')) ->
                  let x = Var.var_of_binder b' in
                  let x_name = Var.name_of_binder b' in
                  partition (b::locals @ globals, [], Env.String.bind x_name x nenv) bs
-              | Fun (b', _, _, _, _) when Var.(Scope.isGlobal (scope_of_binder b')) ->
+              | Fun (b', _, _, _, _) when Var.(Scope.is_global (scope_of_binder b')) ->
                  let f = Var.var_of_binder b' in
                  let f_name = Var.name_of_binder b' in
                  partition (b::locals @ globals, [], Env.String.bind f_name f nenv) bs
@@ -1274,7 +1274,7 @@ struct
                       partition (globals, b::locals, nenv) bs
                  end
               | Alien { binder; _ }
-                   when Var.Scope.isGlobal (Var.scope_of_binder binder) ->
+                   when Var.Scope.is_global (Var.scope_of_binder binder) ->
                  let f = Var.var_of_binder binder in
                  let f_name = Var.name_of_binder binder in
                  partition (b::locals @ globals, [], Env.String.bind f_name f nenv) bs

--- a/core/value.ml
+++ b/core/value.ml
@@ -587,7 +587,8 @@ module Eff_Handler_Continuation = struct
       type trap_result = (v, result) Trap.result
 
       let return k h v =
-        let ((var,_), comp) = h.return in
+        let (b, comp) = h.return in
+        let var = Var.var_of_binder b in
         E.computation (Env.bind var (v, Scope.Local) h.env) k comp
 
       let rec apply ~env k v =
@@ -642,8 +643,9 @@ module Eff_Handler_Continuation = struct
         let rec handle k' = function
           | ((User_defined h, pk) :: k) ->
              begin match StringMap.lookup opname h.cases with
-             | Some ((var, _), _, comp)
+             | Some (b, _, comp)
                   when session_exn_enabled && opname = session_exception_operation ->
+                let var = Var.var_of_binder b in
                 let continuation_thunk =
                   fun () -> E.computation (Env.bind var (arg, Scope.Local) h.env) k comp
                 in
@@ -653,7 +655,8 @@ module Eff_Handler_Continuation = struct
                       frames = comps;
                       continuation_thunk = continuation_thunk
                   })
-             | Some ((var, _), resumeb, comp) ->
+             | Some (b, resumeb, comp) ->
+                let var = Var.var_of_binder b in
                 let env =
                   let resume =
                     match h.depth with

--- a/core/var.ml
+++ b/core/var.ml
@@ -57,6 +57,7 @@ let make_info t name scope = (t, name, scope)
 let make_local_info  (t, name) = make_info t name Scope.Local
 let make_global_info (t, name) = make_info t name Scope.Global
 
+let make_binder var info = (var, info)
 let update_type newtype (var, (_, name, scope)) = (var, (newtype, name, scope))
 
 let fresh_binder_of_type = info_of_type ->- fresh_binder

--- a/core/var.ml
+++ b/core/var.ml
@@ -53,8 +53,9 @@ let fresh_var : var_info -> binder * var =
 let info_type (t, _, _) = t
 let info_of_type t = (t, "", Scope.Local)
 
-let make_local_info  (t, name) = (t, name, Scope.Local)
-let make_global_info (t, name) = (t, name, Scope.Global)
+let make_info t name scope = (t, name, scope)
+let make_local_info  (t, name) = make_info t name Scope.Local
+let make_global_info (t, name) = make_info t name Scope.Global
 
 let update_type newtype (var, (_, name, scope)) = (var, (newtype, name, scope))
 
@@ -67,6 +68,9 @@ let info_of_binder (_, info : binder) = info
 let type_of_binder (_, (t, _, _) : binder) = t
 let name_of_binder (_, (_, name, _) : binder) = name
 let scope_of_binder (_, (_, _, scope) : binder) = scope
+
+let globalise_binder (var, (t, name, _)) =
+  (var, (t, name, Scope.Global))
 
 (** Create a copy of a type environment mapping vars (= ints) to types
     instead of strings to types

--- a/core/var.ml
+++ b/core/var.ml
@@ -6,11 +6,11 @@ module Scope = struct
   type t = Local | Global
   [@@deriving show]
 
-  let isGlobal = function
+  let is_global = function
     | Global -> true
     | _      -> false
 
-  let isLocal = function
+  let is_local = function
     | Local -> true
     | _     -> false
 end

--- a/core/var.mli
+++ b/core/var.mli
@@ -1,0 +1,58 @@
+(** {0 IR variables} *)
+
+module Scope: sig
+  type t = Local | Global
+  [@@deriving show]
+
+  val isGlobal : t -> bool
+  val isLocal : t -> bool
+end
+
+(** Term variables *)
+type var = int
+  [@@deriving show,eq,yojson]
+type var_info
+  [@@deriving show]
+type binder = var * var_info
+  [@@deriving show]
+
+val dummy_var : int
+
+(** Generate just a fresh identifier *)
+val fresh_raw_var : unit -> var
+
+(** Given metadata, generate a full binder *)
+val fresh_binder : var_info -> binder
+
+(** Given metadata, generate a full binder and pair it with the new
+    variable identifer; note this identifier is already the first
+    component of the [binder] value *)
+val fresh_var : var_info -> binder * var
+
+(** {0 Manipulate binder metadata} *)
+
+val info_type : var_info -> Types.datatype
+val info_of_type : Types.datatype -> var_info
+
+val make_info : Types.datatype -> string -> Scope.t -> var_info
+val make_local_info : (Types.datatype * string) -> var_info
+val make_global_info : (Types.datatype * string) -> var_info
+
+val update_type : Types.datatype -> binder -> binder
+
+val fresh_binder_of_type : Types.datatype -> binder
+val fresh_var_of_type : Types.datatype -> binder * var
+val fresh_global_var_of_type : Types.datatype -> binder * var
+
+val var_of_binder : binder -> var
+val info_of_binder : binder -> var_info
+val type_of_binder : binder -> Types.datatype
+val name_of_binder : binder -> string
+val scope_of_binder : binder -> Scope.t
+
+val globalise_binder : binder -> binder
+
+(** Create a copy of a type environment mapping vars (= ints) to types
+    instead of strings to types
+*)
+val varify_env : (int Env.String.t * Types.datatype Env.String.t) -> Types.datatype Env.Int.t

--- a/core/var.mli
+++ b/core/var.mli
@@ -13,7 +13,7 @@ type var = int
   [@@deriving show,eq,yojson]
 type var_info
   [@@deriving show]
-type binder = var * var_info
+type binder
   [@@deriving show]
 
 val dummy_var : int
@@ -38,6 +38,7 @@ val make_info : Types.datatype -> string -> Scope.t -> var_info
 val make_local_info : (Types.datatype * string) -> var_info
 val make_global_info : (Types.datatype * string) -> var_info
 
+val make_binder : var -> var_info -> binder
 val update_type : Types.datatype -> binder -> binder
 
 val fresh_binder_of_type : Types.datatype -> binder

--- a/core/var.mli
+++ b/core/var.mli
@@ -4,8 +4,8 @@ module Scope: sig
   type t = Local | Global
   [@@deriving show]
 
-  val isGlobal : t -> bool
-  val isLocal : t -> bool
+  val is_global : t -> bool
+  val is_local : t -> bool
 end
 
 (** Term variables *)


### PR DESCRIPTION
This patch makes the representation of IR binders abstract, specifically the type definitions `Var.var_info` and `Var.binder`  are abstract, whilst `Var.var` is left concrete for now as making it abstract amounts to a more extensive change. Thus I will leave `Var.var` for a later patch.

The motivation is behind this change is to make it easier to make the notion of binders (and eventually "vars") richer to support #337. This patch includes only the first step. The next step is to make `Var.var` abstract and reorganise the interface of `Var` into two interfaces: one for binders and another for vars.