### PR TITLE
Preserve ordering in Draggable lists (database version) example.

### DIFF
--- a/examples/draggableDb.links
+++ b/examples/draggableDb.links
@@ -58,7 +58,7 @@ fun load() server {
   var t = itemsTable();
   var items =
     query { for (item <-- t)
-             orderby (-item.i)
+             orderby (item.i)
               [(name=item.name)]};
   map ((.name), items)
 }


### PR DESCRIPTION
This commit fixes a bug in the database version of the draggable lists
example that would cause the list of items to be displayed in inverse
order after a save.