### PR TITLE
Don't discard typechecked AST with recheck_frontend_transformations

### DIFF
--- a/core/frontend.ml
+++ b/core/frontend.ml
@@ -223,7 +223,7 @@ module Typeability_preserving = struct
         Debug.if_set Basicsettings.show_stages (fun () -> T.Typeable.name ^"...");
         T.Typeable.program state program
       in
-      (if verify_transformation T.Typeable.name then
+      if verify_transformation T.Typeable.name then
          let tyenv =
            Context.typing_environment payload.state.Transform.Typeable.context
          in
@@ -233,14 +233,16 @@ module Typeability_preserving = struct
             check *against* the datatype in transformation state
             [payload]. *)
          try
-           ignore (TypeSugar.Check.program
+           let (program, _, _) =
+             TypeSugar.Check.program
                      { tyenv with Types.desugared = true }
-                     payload.program)
+                     payload.program
                   (* TODO(dhil): Verify post-transformation invariants. *)
+            in (Transform.Typeable.Result { state; program })
          with exn ->
            let stacktrace = Printexc.get_raw_backtrace () in
-           trace_type_error T.Typeable.name Sugartypes.pp_program program payload.program stacktrace exn);
-      result
+           trace_type_error T.Typeable.name Sugartypes.pp_program program payload.program stacktrace exn
+      else result
     in
     let (Transform.Typeable.Result { state; program }) =
       let initial_state = Transform.Typeable.{ datatype; context = context' } in
@@ -261,7 +263,7 @@ module Typeability_preserving = struct
       let (Transform.Typeable.Result payload) as result =
         T.Typeable.sentence state program
       in
-      (if verify_transformation T.Typeable.name then
+      if verify_transformation T.Typeable.name then
          let tyenv =
            Context.typing_environment payload.state.Transform.Typeable.context
          in
@@ -271,14 +273,16 @@ module Typeability_preserving = struct
             check *against* the datatype in transformation state
             [payload]. *)
          try
-           ignore (TypeSugar.Check.sentence
+           let (program, _, _) =
+             TypeSugar.Check.sentence
                      { tyenv with Types.desugared = true }
-                     payload.program)
+                     payload.program
                   (* TODO(dhil): Verify post-transformation invariants. *)
+            in (Transform.Typeable.Result { state; program })
          with exn ->
            let stacktrace = Printexc.get_raw_backtrace () in
-           trace_type_error T.Typeable.name Sugartypes.pp_sentence program payload.program stacktrace exn);
-      result
+           trace_type_error T.Typeable.name Sugartypes.pp_sentence program payload.program stacktrace exn
+      else result
     in
     let (Transform.Typeable.Result { state; program }) =
       let initial_state = Transform.Typeable.{ datatype; context = context' } in

--- a/core/frontend.ml
+++ b/core/frontend.ml
@@ -233,12 +233,13 @@ module Typeability_preserving = struct
             check *against* the datatype in transformation state
             [payload]. *)
          try
-           let (program, _, _) =
+           let (program, datatype, _) =
              TypeSugar.Check.program
                      { tyenv with Types.desugared = true }
-                     payload.program
+                     payload.program in
                   (* TODO(dhil): Verify post-transformation invariants. *)
-            in (Transform.Typeable.Result { state; program })
+           let state = { payload.state with Typeable.datatype = datatype }
+           in (Transform.Typeable.Result { state; program })
          with exn ->
            let stacktrace = Printexc.get_raw_backtrace () in
            trace_type_error T.Typeable.name Sugartypes.pp_program program payload.program stacktrace exn
@@ -273,12 +274,13 @@ module Typeability_preserving = struct
             check *against* the datatype in transformation state
             [payload]. *)
          try
-           let (program, _, _) =
+           let (program, datatype, _) =
              TypeSugar.Check.sentence
                      { tyenv with Types.desugared = true }
-                     payload.program
+                     payload.program in
                   (* TODO(dhil): Verify post-transformation invariants. *)
-            in (Transform.Typeable.Result { state; program })
+           let state = { payload.state with Typeable.datatype = datatype }
+           in (Transform.Typeable.Result { state; program })
          with exn ->
            let stacktrace = Printexc.get_raw_backtrace () in
            trace_type_error T.Typeable.name Sugartypes.pp_sentence program payload.program stacktrace exn

--- a/core/frontend.ml
+++ b/core/frontend.ml
@@ -233,12 +233,15 @@ module Typeability_preserving = struct
             check *against* the datatype in transformation state
             [payload]. *)
          try
-           let (program, datatype, _) =
+           let (program, datatype, tyenv') =
              TypeSugar.Check.program
                      { tyenv with Types.desugared = true }
                      payload.program in
                   (* TODO(dhil): Verify post-transformation invariants. *)
-           let state = { payload.state with Typeable.datatype = datatype }
+           let context = { payload.state.Transform.Typeable.context with
+                           Context.typing_environment = Types.extend_typing_environment tyenv tyenv' } in
+           let state   = { Typeable.datatype = datatype
+                         ; Typeable.context  = context }
            in (Transform.Typeable.Result { state; program })
          with exn ->
            let stacktrace = Printexc.get_raw_backtrace () in
@@ -274,12 +277,15 @@ module Typeability_preserving = struct
             check *against* the datatype in transformation state
             [payload]. *)
          try
-           let (program, datatype, _) =
+           let (program, datatype, tyenv') =
              TypeSugar.Check.sentence
                      { tyenv with Types.desugared = true }
                      payload.program in
                   (* TODO(dhil): Verify post-transformation invariants. *)
-           let state = { payload.state with Typeable.datatype = datatype }
+           let context = { payload.state.Transform.Typeable.context with
+                           Context.typing_environment = Types.extend_typing_environment tyenv tyenv' } in
+           let state   = { Typeable.datatype = datatype
+                         ; Typeable.context  = context }
            in (Transform.Typeable.Result { state; program })
          with exn ->
            let stacktrace = Printexc.get_raw_backtrace () in

--- a/tests/recheck_frontend_transformations.tests
+++ b/tests/recheck_frontend_transformations.tests
@@ -6,10 +6,10 @@ args : --set=recheck_frontend_transformations=true
 
 Generalisation obeys value restriction (#871)
 var foo = spawn { () }; ()
-exit : 0
+stderr : @.*Because of the value restriction.*
+exit : 1
+ignore : reproducibility broken by #891
 args : --config=tests/recheck_frontend_transformations.config
-stdout : @\(\) : \(Types\.Record \(Types\.Row .*\)\)
-stderr : @.*
 
 Type variable freshening in type signatures (#865)
 ./tests/recheck_frontend_transformations/T865.links

--- a/tests/recheck_frontend_transformations.tests
+++ b/tests/recheck_frontend_transformations.tests
@@ -6,9 +6,10 @@ args : --set=recheck_frontend_transformations=true
 
 Generalisation obeys value restriction (#871)
 var foo = spawn { () }; ()
-stderr : @.*Because of the value restriction.*
-exit : 1
+exit : 0
 args : --config=tests/recheck_frontend_transformations.config
+stdout : @\(\) : \(Types\.Record \(Types\.Row .*\)\)
+stderr : @.*
 
 Type variable freshening in type signatures (#865)
 ./tests/recheck_frontend_transformations/T865.links

--- a/tests/recheck_frontend_transformations.tests
+++ b/tests/recheck_frontend_transformations.tests
@@ -21,6 +21,7 @@ stderr : @.*
 Session exceptions desugaring (#882)
 ./tests/recheck_frontend_transformations/T882.links
 filemode : true
-exit : 1
+exit : 0
 args : --config=tests/recheck_frontend_transformations.config
+stdout : @\(\) : \(Types\.Record \(Types\.Row .*\)\)
 stderr : @.*

--- a/tests/recheck_frontend_transformations.tests
+++ b/tests/recheck_frontend_transformations.tests
@@ -4,13 +4,6 @@ exit : 1
 stderr : @.*Type error: Because of the value restriction.*
 args : --set=recheck_frontend_transformations=true
 
-Generalisation obeys value restriction (#871)
-var foo = spawn { () }; ()
-stderr : @.*Because of the value restriction.*
-exit : 1
-ignore : reproducibility broken by #891
-args : --config=tests/recheck_frontend_transformations.config
-
 Type variable freshening in type signatures (#865)
 ./tests/recheck_frontend_transformations/T865.links
 filemode : true

--- a/tests/recheck_frontend_transformations/T882.links
+++ b/tests/recheck_frontend_transformations/T882.links
@@ -1,9 +1,4 @@
 mutual {
-  fun foo(x) client {
-   receive { case Foo -> bar(x) }
-  }
-
-  fun bar(x) client {
-   receive { case Foo -> foo(x) }
-  }
+  fun f(x) { g(x) }
+  fun g(x) { f(x) }
 }

--- a/tests/typed_ir.tests
+++ b/tests/typed_ir.tests
@@ -92,6 +92,7 @@ Generalisation obeys value restriction (#871)
 var foo = spawn { () }; ()
 exit : 1
 stderr : @.*IR Type Error: Type variable.*is unbound.*
+args : --set=recheck_frontend_transformations=false
 
 fork (#874)
 tests/typed_ir/T874.links

--- a/tests/typed_ir.tests
+++ b/tests/typed_ir.tests
@@ -88,6 +88,11 @@ function pattern matching has right effects (#691)
 sig f : ([a]) {}-> a fun f ([x]) { x }
 stdout : () : ()
 
+Generalisation obeys value restriction (#871)
+var foo = spawn { () }; ()
+exit : 1
+stderr : @.*IR Type Error: Type variable.*is unbound.*
+
 fork (#874)
 tests/typed_ir/T874.links
 filemode : true

--- a/tests/typed_ir.tests.config
+++ b/tests/typed_ir.tests.config
@@ -4,4 +4,3 @@ prelude=tests/empty_prelude.links
 optimise=false
 generalise_toplevel=true
 show_quantifiers=true
-recheck_frontend_transformations=true

--- a/tests/typed_ir.tests.config
+++ b/tests/typed_ir.tests.config
@@ -4,3 +4,4 @@ prelude=tests/empty_prelude.links
 optimise=false
 generalise_toplevel=true
 show_quantifiers=true
+recheck_frontend_transformations=true


### PR DESCRIPTION
I see what's going on in #882 and I believe I have a solution - that is, if everyone agrees it is a good solution.

When `recheck_frontend_transformations` is enabled we typecheck the AST after every desugaring pass and discard the resulting typechecked AST. Except that typechecking is side-effecting and we don't really fully discard the result - unified flexible variables remain unified and that is what causes the problem here.

After the inners pass we have something like this in the AST (simplified and prettified):

```
f : forall a. a -> ...
f (x : a) = g @%b x
```

where `@` is a type application of a flexible type variable `%b`. Type variable renamer is run right at the beginning of `Funs` case in the typechecker and turns the above code into:

```
f : forall c. c -> ...
f (x : c) = g @%b x
```

Note how rigid type variable `a` is renamed into `c`, but flexible variable `%b` remains unchanged. The typechecking continues and right before finishing the `Funs` case the code is:

```
f : forall c. c -> ...
f (x : c) = g @c x
```

Note that flexible variable `%b` was unified with type variable `c`. We now discard the typechecked AST, except that the flexible variable remains unified. So at the beginning of next pass (`session_exceptions`) the AST looks like this:

```
f : forall a. a -> ...
f (x : a) = g @c x
```

The renamer turns that into:

```
f : forall d. d -> ...
f (x : d) = g @c x
```

and at this point typechecker concludes that the type of `g` is `c -> ...` but the argument is of type `d`.

So it looks like the renamer is doing the right thing and the problem arises from side-effecting nature of typechecking. My proposed solution is to keep the typechecked AST when `recheck_frontend_transformations=true` is enabled.

One thing I am not certain of is whether the `state` should be updated in any way. For now I am leaving it unchanged, but I'm wondering whether the second component returned by typechecking (`Types.datatype`) should be put into `state.datatype`? The tests pass without updating that field, but that of course doesn't mean anything.