### PR TITLE
Cleanup query pretty-printing and remove shredding settings

### DIFF
--- a/core/commonTypes.ml
+++ b/core/commonTypes.ml
@@ -267,6 +267,6 @@ module Constant = struct
 end
 
 module QueryPolicy = struct
-  type t = Flat | Nested | Default
+  type t = Flat | Nested
     [@@deriving show]
 end

--- a/core/database.ml
+++ b/core/database.ml
@@ -8,12 +8,6 @@ let connection_info
               |> convert Utility.some
               |> sync)
 
-let shredding =
-  Settings.(flag "shredding"
-            |> synopsis "Enables database query shredding"
-            |> convert parse_bool
-            |> sync)
-
 (* Hacky database query result manipulation settings. *)
 let coerce_null_integers
   = Settings.(flag "coerce_null_integers"

--- a/core/database.mli
+++ b/core/database.mli
@@ -1,7 +1,6 @@
 (** A generic interface for SQL-style databases. Vendor-specific implementations are elsewhere *)
 
 val connection_info : string option Settings.setting
-val shredding : bool Settings.setting
 
 class virtual db_args : string -> object
   val strval : string

--- a/core/evalir.ml
+++ b/core/evalir.ml
@@ -754,7 +754,7 @@ struct
               else
                 let error_msg =
                   Printf.sprintf
-                    "The database driver '%s' does not support shredding."
+                    "The database driver '%s' does not support nested query results."
                     (db#driver_name ())
                 in
                 raise (Errors.runtime_error error_msg) in
@@ -764,8 +764,7 @@ struct
          match policy with
            | Flat -> evaluate_standard
            | Nested -> evaluate_nested
-           | Default ->
-               if Settings.get Database.shredding then evaluate_nested else evaluate_standard in
+       in
        evaluator()
 
     | InsertRows (source, rows) ->

--- a/core/evalir.ml
+++ b/core/evalir.ml
@@ -743,6 +743,7 @@ struct
                   | _ -> assert false
                 in
                 let execute_shredded_raw (q, t) =
+                  let q = Sql.inline_outer_with q in
                   let q = db#string_of_query ~range q in
                   Database.execute_select_result (get_fields t) q db, t in
                 let raw_results =

--- a/core/irCheck.ml
+++ b/core/irCheck.ml
@@ -812,12 +812,7 @@ struct
             (* The type of the body must match the type the query is annotated with *)
             o#check_eq_types original_t t (SSpec special);
 
-            let check_flat_result =
-              let open QueryPolicy in
-              match policy with
-              | Flat -> true
-              | Nested -> false
-              | Default -> not(Settings.get Database.shredding) in
+            let check_flat_result = (policy = QueryPolicy.Flat) in
 
             (if not(check_flat_result) then
               () (* Discussion pending about how to type-check here. Currently same as frontend *)

--- a/core/irCheck.ml
+++ b/core/irCheck.ml
@@ -812,9 +812,7 @@ struct
             (* The type of the body must match the type the query is annotated with *)
             o#check_eq_types original_t t (SSpec special);
 
-            let check_flat_result = (policy = QueryPolicy.Flat) in
-
-            (if not(check_flat_result) then
+            (if not (policy = QueryPolicy.Flat) then
               () (* Discussion pending about how to type-check here. Currently same as frontend *)
             else
               let list_content_type = TypeUtils.element_type ~overstep_quantifiers:false t in

--- a/core/parser.mly
+++ b/core/parser.mly
@@ -583,7 +583,7 @@ spawn_expression:
 
 query_policy:
 | VARIABLE                                                     { query_policy_of_string $loc $1 }
-| /* empty */                                                  { QueryPolicy.Default }
+| /* empty */                                                  { QueryPolicy.Flat }
 
 postfix_expression:
 | primary_expression | spawn_expression                        { $1 }

--- a/core/query/query.ml
+++ b/core/query/query.ml
@@ -636,13 +636,12 @@ struct
   | u -> u
 
   let check_policies_compatible env_policy block_policy =
-    match (env_policy, block_policy) with
-      | (x, y) when x = y -> ()
-      | _ ->
-        let error = Printf.sprintf
+    if env_policy != block_policy
+    then
+      let error = Printf.sprintf
           "Incompatible query evaluation annotations. Expected %s, got %s."
           (QueryPolicy.show env_policy) (QueryPolicy.show block_policy) in
-        raise (Errors.runtime_error error)
+      raise (Errors.runtime_error error)
 
   let rec xlate env : Ir.value -> Q.t = let open Ir in function
     | Constant c -> Q.Constant c

--- a/core/query/sql.ml
+++ b/core/query/sql.ml
@@ -33,7 +33,6 @@ and base =
   | RowNumber of (Var.var * string) list
     [@@deriving show]
 
-
 (* optimizing smart constructor for && *)
 let smart_and c c' =
   let open Constant in

--- a/core/query/sql.ml
+++ b/core/query/sql.ml
@@ -339,7 +339,7 @@ and pr_base quote one_table ppf b =
 
 
 (* NOTE: Inlines a WITH common table expression if it is the toplevel
- * constructor of a union of queries and is used immediately in a SELECT query. 
+ * constructor of a union of queries and is used immediately in a SELECT query.
  * This handles the common case where WITH is generated solely as an
  * abbreviation by shredding.  This is a very limited case of inlining WITH bindings. *)
 
@@ -359,7 +359,6 @@ let string_of_base quote one_table b =
   Format.asprintf "%a" (pr_base quote one_table) b
 
 let string_of_query ?(range=None) quote q =
-  let q = inline_outer_with q in 
   let pr_range ppf range =
     match range with
       | None -> ()

--- a/core/query/sql.ml
+++ b/core/query/sql.ml
@@ -4,24 +4,26 @@ open CommonTypes
 type index = (Var.var * string) list
 type range = int * int
 
+type table_name = string (* FIXME: allow variables? *)
+
 type query =
   | UnionAll  of query list * int
   | Select    of select_clause
   | Insert    of {
-      ins_table: string;
+      ins_table: table_name;
       ins_fields: string list;
       ins_records: base list list
     }
   | Update    of {
-      upd_table: string;
+      upd_table: table_name;
       upd_fields: (string * base) list;
       upd_where: base option
     }
-  | Delete    of { del_table: string; del_where: base option }
-  | With      of string * query * query
+  | Delete    of { del_table: table_name; del_where: base option }
+  | With      of table_name * query * query
 and select_clause = (base * string) list * from_clause list * base * base list
 and from_clause =
-  | TableRef of string * Var.var
+  | TableRef of table_name * Var.var
   | Subquery of query * Var.var
 and base =
   | Case      of base * base * base
@@ -276,19 +278,19 @@ and pr_base quote one_table ppf b =
   in
   let pp_sql_arithmetic ppf (l, op, r) =
     match op with
-    | "/" -> Format.fprintf ppf "floor(%a/%a)"
-          pr_b_one_table l
-          pr_b_one_table r
-    | "^" -> Format.fprintf ppf "floor(pow(%a,%a))"
-          pr_b_one_table l
-          pr_b_one_table r
-    | "^." -> Format.fprintf ppf "pow(%a,%a)"
-          pr_b_one_table l
-          pr_b_one_table r
-    | _ -> Format.fprintf ppf "(%a%s%a)"
-          pr_b_one_table l
-          (Arithmetic.sql_name op)
-          pr_b_one_table r
+      | "/" -> Format.fprintf ppf "floor(%a/%a)"
+            pr_b_one_table l
+            pr_b_one_table r
+      | "^" -> Format.fprintf ppf "floor(pow(%a,%a))"
+            pr_b_one_table l
+            pr_b_one_table r
+      | "^." -> Format.fprintf ppf "pow(%a,%a)"
+            pr_b_one_table l
+            pr_b_one_table r
+      | _ -> Format.fprintf ppf "(%a%s%a)"
+            pr_b_one_table l
+            (Arithmetic.sql_name op)
+            pr_b_one_table r
   in
     match b with
     | Case (c, t, e) ->

--- a/core/query/sql.ml
+++ b/core/query/sql.ml
@@ -294,50 +294,50 @@ and pr_base quote one_table ppf b =
             pr_b_one_table r
   in
     match b with
-    | Case (c, t, e) ->
-        Format.fprintf ppf "case when %a then %a else %a end"
-          pr_b_one_table c
-          pr_b_one_table t
-          pr_b_one_table e
-    | Constant c ->
-        Format.pp_print_string ppf (Constant.to_string c)
-    | Project (var, label) ->
-        pp_projection quote one_table ppf (var, label)
-    | Apply (op, [l; r]) when Arithmetic.is op ->
-        pp_sql_arithmetic ppf (l, op, r)
-          (* special case: not empty is translated to exists *)
-    | Apply ("not", [Empty q]) ->
-        Format.fprintf ppf "exists (%a)"
-          pr_q_true q
-    | Apply (uop, [v]) when StringSet.mem uop unary_ops ->
-        Format.fprintf ppf "%s(%a)"
-          (unary_map uop)
-          pr_b_one_table v
-    | Apply (op, [v; w]) when StringSet.mem op binary_ops ->
-        Format.fprintf ppf "(%a) %s (%a)"
-          pr_b_one_table v
-          (binary_map op)
-          pr_b_one_table w
-    | Apply (f, args) when SqlFuns.is f ->
-        Format.fprintf ppf "%a(%a)"
-          Format.pp_print_string (SqlFuns.name f)
-          (pp_comma_separated pr_b_one_table) args
-    | Apply (f, args) ->
-        Format.fprintf ppf "%a(%a)"
-          Format.pp_print_string f
-          (pp_comma_separated pr_b_one_table) args
-    | Empty q ->
-        Format.fprintf ppf "not exists (%a)"
-          pr_q_true q
-    | Length q ->
-        Format.fprintf ppf "select count(*) from (%a) as %a"
-          pr_q_true q
-          Format.pp_print_string (fresh_dummy_var ())
-    | RowNumber [] ->
-        Format.fprintf ppf "%a" Format.pp_print_string "1"
-    | RowNumber ps ->
+      | Case (c, t, e) ->
+          Format.fprintf ppf "case when %a then %a else %a end"
+            pr_b_one_table c
+            pr_b_one_table t
+            pr_b_one_table e
+      | Constant c ->
+          Format.pp_print_string ppf (Constant.to_string c)
+      | Project (var, label) ->
+          pp_projection quote one_table ppf (var, label)
+      | Apply (op, [l; r]) when Arithmetic.is op ->
+          pp_sql_arithmetic ppf (l, op, r)
+            (* special case: not empty is translated to exists *)
+      | Apply ("not", [Empty q]) ->
+          Format.fprintf ppf "exists (%a)"
+            pr_q_true q
+      | Apply (uop, [v]) when StringSet.mem uop unary_ops ->
+          Format.fprintf ppf "%s(%a)"
+            (unary_map uop)
+            pr_b_one_table v
+      | Apply (op, [v; w]) when StringSet.mem op binary_ops ->
+          Format.fprintf ppf "(%a) %s (%a)"
+            pr_b_one_table v
+            (binary_map op)
+            pr_b_one_table w
+      | Apply (f, args) when SqlFuns.is f ->
+          Format.fprintf ppf "%a(%a)"
+            Format.pp_print_string (SqlFuns.name f)
+            (pp_comma_separated pr_b_one_table) args
+      | Apply (f, args) ->
+          Format.fprintf ppf "%a(%a)"
+            Format.pp_print_string f
+            (pp_comma_separated pr_b_one_table) args
+      | Empty q ->
+          Format.fprintf ppf "not exists (%a)"
+            pr_q_true q
+      | Length q ->
+          Format.fprintf ppf "select count(*) from (%a) as %a"
+            pr_q_true q
+            Format.pp_print_string (fresh_dummy_var ())
+      | RowNumber [] ->
+          Format.fprintf ppf "%a" Format.pp_print_string "1"
+      | RowNumber ps ->
         Format.fprintf ppf "row_number() over (order by %a)"
-          (pp_comma_separated (pp_projection quote one_table)) ps
+            (pp_comma_separated (pp_projection quote one_table)) ps
 
 
 (* NOTE: Inlines a WITH common table expression if it is the toplevel
@@ -351,10 +351,10 @@ let rec inline_outer_with q =
     | fromclause -> fromclause
   in
   match q with
-  | With (z, q, Select (fields, tables, condition, os)) ->
-      Select(fields, List.map (replace_subquery z q) tables, condition, os)
-  | UnionAll(qs,n) -> UnionAll(List.map inline_outer_with qs,n)
-  | q -> q
+    | With (z, q, Select (fields, tables, condition, os)) ->
+        Select(fields, List.map (replace_subquery z q) tables, condition, os)
+    | UnionAll(qs,n) -> UnionAll(List.map inline_outer_with qs,n)
+    | q -> q
 
 
 let string_of_base quote one_table b =

--- a/core/query/sql.ml
+++ b/core/query/sql.ml
@@ -5,6 +5,7 @@ type index = (Var.var * string) list
 type range = int * int
 
 type table_name = string (* FIXME: allow variables? *)
+    [@@deriving show]
 
 type query =
   | UnionAll  of query list * int

--- a/core/query/sql.ml
+++ b/core/query/sql.ml
@@ -18,8 +18,11 @@ type query =
       upd_where: base option
     }
   | Delete    of { del_table: string; del_where: base option }
-  | With      of Var.var * query * Var.var * query
-and select_clause = (base * string) list * (string * Var.var) list * base * base list
+  | With      of string * query * query
+and select_clause = (base * string) list * from_clause list * base * base list
+and from_clause =
+  | TableRef of string * Var.var
+  | Subquery of query * Var.var
 and base =
   | Case      of base * base * base
   | Constant  of Constant.t
@@ -29,6 +32,7 @@ and base =
   | Length    of query
   | RowNumber of (Var.var * string) list
     [@@deriving show]
+
 
 (* optimizing smart constructor for && *)
 let smart_and c c' =
@@ -143,7 +147,6 @@ let pp_comma_separated pp_item = Format.pp_print_list ~pp_sep:pp_comma pp_item
 
 let rec pr_query quote ignore_fields ppf q =
   let pp_quote ppf q = Format.pp_print_string ppf (quote q) in
-  let tables_to_string = List.map (fun (t, x) -> Format.asprintf "%a as %s" pp_quote t (string_of_table_var x)) in
 
   let pr_q = pr_query quote ignore_fields in
   let pr_b = pr_base quote false in
@@ -167,39 +170,51 @@ let rec pr_query quote ignore_fields ppf q =
     let pp_orderby ppf os =
       match os with
         | [] -> ()
-        | _ -> Format.fprintf ppf " order by %a" (pp_comma_separated pp_os_condition) os in
+        | _ -> Format.fprintf ppf "\norder by %a" (pp_comma_separated pp_os_condition) os in
+    let pp_from_clause ppf fc =
+      match fc with
+        | TableRef (t, x) -> Format.fprintf ppf "%a as %s" pp_quote t (string_of_table_var x)
+        | Subquery (q, x) -> Format.fprintf ppf "(%a) as %s" pr_q q (string_of_table_var x) in
     let pp_where ppf condition =
       match condition with
         | Constant (Constant.Bool true) -> ()
-        | _ -> Format.fprintf ppf " where %a" pp_os_condition condition in
-
-    Format.fprintf ppf "select %a from %a%a%a"
+        | _ -> Format.fprintf ppf "\nwhere %a" pp_os_condition condition in
+    Format.fprintf ppf "select %a\nfrom %a%a%a"
       pr_fields fields
-      (pp_comma_separated Format.pp_print_string) tables
+      (pp_comma_separated pp_from_clause) tables
       pp_where condition
       pp_orderby os
   in
-
-  let pp_where_d_u ppf where = gen_pp_option ppf "where (%a)" pr_b_ignore_fields where in
+  let pp_opt_where ppf where = gen_pp_option ppf "where (%a)" pr_b_ignore_fields where in
   let pr_delete ppf table where =
-    Format.fprintf ppf "delete from %a %a" Format.pp_print_string table pp_where_d_u where
+    Format.fprintf ppf "delete from %a %a"
+      Format.pp_print_string table
+      pp_opt_where where
   in
   let pr_update ppf table fields where =
     let pp_field ppf (k, v) = gen_pp_pair ppf "%a = %a" pp_quote pr_b_ignore_fields (k, v) in
-    Format.fprintf ppf "update %a set %a %a" Format.pp_print_string table (pp_comma_separated pp_field) fields pp_where_d_u where
+    Format.fprintf ppf "update %a\nset %a %a"
+      Format.pp_print_string table
+      (pp_comma_separated pp_field) fields
+      pp_opt_where where
   in
   let pr_insert ppf table fields values =
-    let pp_value ppf x = Format.fprintf ppf "(%a)" (pp_comma_separated pr_b_ignore_fields) x in
-    Format.fprintf ppf "insert into %a (%a) values %a"
+    let pp_value ppf x =
+      Format.fprintf ppf "(%a)"
+        (pp_comma_separated pr_b_ignore_fields) x in
+    Format.fprintf ppf "insert into %a (%a)\nvalues %a"
       Format.pp_print_string table
       (pp_comma_separated Format.pp_print_string) fields
       (pp_comma_separated pp_value) values
   in
   match q with
-    | UnionAll ([], _) -> Format.pp_print_string ppf "select 42 as \"@unit@\" where false"
-    | UnionAll ([q], n) -> Format.fprintf ppf "%a%a" pr_q q Format.pp_print_string (order_by_clause n)
+    | UnionAll ([], _) -> Format.pp_print_string ppf "select 42 as \"@unit@\" from (select 42) x where false"
+    | UnionAll ([q], n) ->
+        Format.fprintf ppf "%a%a"
+          pr_q q
+          Format.pp_print_string (order_by_clause n)
     | UnionAll (qs, n) ->
-      let pp_sep_union ppf () = Format.fprintf ppf " union all " in
+      let pp_sep_union ppf () = Format.fprintf ppf "\nunion all\n" in
       let pp_value ppf x = Format.fprintf ppf "(%a)" pr_q x in
       Format.fprintf ppf "%a%a"
         (Format.pp_print_list ~pp_sep:pp_sep_union pp_value) qs
@@ -212,23 +227,18 @@ let rec pr_query quote ignore_fields ppf q =
         Format.pp_print_string (fresh_dummy_var ())
         pr_b condition
     | Select (fields, tables, condition, os) ->
-        (* using quote_field assumes tables contains table names (not nested queries) *)
-        (* FIXME: type Select forces tables to be list((table name, var)), but it can have subqueries instead of plain table names in general cases *)
-        pr_select ppf fields (tables_to_string tables) condition os
+        pr_select ppf fields tables condition os
     | Delete { del_table; del_where } ->
         pr_delete ppf del_table del_where
     | Update { upd_table; upd_fields; upd_where } ->
         pr_update ppf upd_table upd_fields upd_where
     | Insert { ins_table; ins_fields; ins_records } ->
         pr_insert ppf ins_table ins_fields ins_records
-    | With (_, q, z, q') ->
-        match q' with
-        | Select (fields, tables, condition, os) ->
-            (* Inline the query *)
-            (* FIXME: should emitting standard SQL WITH expressions here, move inline to a separate preprocessing step *)
-            let q = Format.asprintf "(%s) as %s" (Format.asprintf "%a" pr_q q) (string_of_table_var z) in
-            pr_select ppf fields (q::(tables_to_string tables)) condition os
-        | _ -> assert false
+    | With (z, q, q') ->
+        Format.fprintf ppf "with %s as (@[<v>%a@])\n%a"
+          z
+          pr_q q
+          pr_q q'
 
 and pr_base quote one_table ppf b =
   let pp_projection quote one_table ppf (var, label) =
@@ -239,54 +249,117 @@ and pr_base quote one_table ppf b =
   in
   let pr_b_one_table = pr_base quote one_table in
   let pr_q_true = pr_query quote true in
-  let unary_ops = StringSet.of_list ["intToString"; "stringToInt"; "intToFloat"; "floatToString"; "stringToFloat"; "floatToInt"; "not"; "negate"; "negatef"] in
-  let binary_ops = StringSet.of_list ["&&"; "||"; "=="; "<>"; "<"; ">"; "<="; ">="; "RLIKE"; "LIKE"] in
+  let unary_ops =
+    StringSet.of_list ["intToString"; "stringToInt"; "intToFloat";
+                       "floatToString"; "stringToFloat"; "floatToInt";
+                       "not"; "negate"; "negatef"] in
+  let binary_ops =
+    StringSet.of_list ["&&"; "||"; "=="; "<>"; "<"; ">"; "<="; ">="; "RLIKE"; "LIKE"] in
   let binary_map op =
     match op with
       | "&&" -> "and"
       | "||" -> "or"
       | "==" -> "="
-      | _ -> op
+      | _    -> op
   in
   let unary_map op =
     match op with
-      | "floatToInt" -> "floor"
-      | "not" -> "not "
-      | "negate" | "negatef" -> "-"
-      | "intToString" | "stringToInt" | "intToFloat" | "floatToString" | "stringToFloat" -> ""
-      | _ -> assert false
+      | "floatToInt"    -> "floor"
+      | "not"           -> "not "
+      | "negate"
+      | "negatef"       -> "-"
+      | "intToString"
+      | "stringToInt"
+      | "intToFloat"
+      | "floatToString"
+      | "stringToFloat" -> ""
+      | _               -> assert false
   in
   let pp_sql_arithmetic ppf (l, op, r) =
     match op with
-      | "/" -> Format.fprintf ppf "floor(%a/%a)" pr_b_one_table l pr_b_one_table r
-      | "^" -> Format.fprintf ppf "floor(pow(%a,%a))" pr_b_one_table l pr_b_one_table r
-      | "^." -> Format.fprintf ppf "pow(%a,%a)" pr_b_one_table l pr_b_one_table r
-      | _ -> Format.fprintf ppf "(%a%s%a)" pr_b_one_table l (Arithmetic.sql_name op) pr_b_one_table r
+    | "/" -> Format.fprintf ppf "floor(%a/%a)"
+          pr_b_one_table l
+          pr_b_one_table r
+    | "^" -> Format.fprintf ppf "floor(pow(%a,%a))"
+          pr_b_one_table l
+          pr_b_one_table r
+    | "^." -> Format.fprintf ppf "pow(%a,%a)"
+          pr_b_one_table l
+          pr_b_one_table r
+    | _ -> Format.fprintf ppf "(%a%s%a)"
+          pr_b_one_table l
+          (Arithmetic.sql_name op)
+          pr_b_one_table r
   in
     match b with
-      | Case (c, t, e) -> Format.fprintf ppf "case when %a then %a else %a end" pr_b_one_table c pr_b_one_table t pr_b_one_table e
-      | Constant c -> Format.pp_print_string ppf (Constant.to_string c)
-      | Project (var, label) -> pp_projection quote one_table ppf (var, label)
-      | Apply (op, [l; r]) when Arithmetic.is op -> pp_sql_arithmetic ppf (l, op, r)
-      (* special case: not empty is translated to exists *)
-      | Apply ("not", [Empty q]) -> Format.fprintf ppf "exists (%a)" pr_q_true q
-      | Apply (uop, [v]) when StringSet.mem uop unary_ops -> Format.fprintf ppf "%s(%a)" (unary_map uop) pr_b_one_table v
+    | Case (c, t, e) ->
+        Format.fprintf ppf "case when %a then %a else %a end"
+          pr_b_one_table c
+          pr_b_one_table t
+          pr_b_one_table e
+    | Constant c ->
+        Format.pp_print_string ppf (Constant.to_string c)
+    | Project (var, label) ->
+        pp_projection quote one_table ppf (var, label)
+    | Apply (op, [l; r]) when Arithmetic.is op ->
+        pp_sql_arithmetic ppf (l, op, r)
+          (* special case: not empty is translated to exists *)
+    | Apply ("not", [Empty q]) ->
+        Format.fprintf ppf "exists (%a)"
+          pr_q_true q
+    | Apply (uop, [v]) when StringSet.mem uop unary_ops ->
+        Format.fprintf ppf "%s(%a)"
+          (unary_map uop)
+          pr_b_one_table v
+    | Apply (op, [v; w]) when StringSet.mem op binary_ops ->
+        Format.fprintf ppf "(%a) %s (%a)"
+          pr_b_one_table v
+          (binary_map op)
+          pr_b_one_table w
+    | Apply (f, args) when SqlFuns.is f ->
+        Format.fprintf ppf "%a(%a)"
+          Format.pp_print_string (SqlFuns.name f)
+          (pp_comma_separated pr_b_one_table) args
+    | Apply (f, args) ->
+        Format.fprintf ppf "%a(%a)"
+          Format.pp_print_string f
+          (pp_comma_separated pr_b_one_table) args
+    | Empty q ->
+        Format.fprintf ppf "not exists (%a)"
+          pr_q_true q
+    | Length q ->
+        Format.fprintf ppf "select count(*) from (%a) as %a"
+          pr_q_true q
+          Format.pp_print_string (fresh_dummy_var ())
+    | RowNumber [] ->
+        Format.fprintf ppf "%a" Format.pp_print_string "1"
+    | RowNumber ps ->
+        Format.fprintf ppf "row_number() over (order by %a)"
+          (pp_comma_separated (pp_projection quote one_table)) ps
 
-      (* optimisation *)
-      | Apply (op, [v; w]) when StringSet.mem op binary_ops -> Format.fprintf ppf "(%a) %s (%a)" pr_b_one_table v (binary_map op) pr_b_one_table w
-      | Apply (f, args) when SqlFuns.is f ->
-        Format.fprintf ppf "%a(%a)" Format.pp_print_string (SqlFuns.name f) (pp_comma_separated pr_b_one_table) args
-      | Apply (f, args) ->
-        Format.fprintf ppf "%a(%a)" Format.pp_print_string f (pp_comma_separated pr_b_one_table) args
-      | Empty q -> Format.fprintf ppf "not exists (%a)" pr_q_true q
-      | Length q -> Format.fprintf ppf "select count(*) from (%a) as %a" pr_q_true q Format.pp_print_string (fresh_dummy_var ())
-      | RowNumber [] -> Format.fprintf ppf "%a" Format.pp_print_string "1"
-      | RowNumber ps -> Format.fprintf ppf "row_number() over (order by %a)" (pp_comma_separated (pp_projection quote one_table)) ps
+
+(* NOTE: Inlines a WITH common table expression if it is the toplevel
+ * constructor of a union of queries and is used immediately in a SELECT query. 
+ * This handles the common case where WITH is generated solely as an
+ * abbreviation by shredding.  This is a very limited case of inlining WITH bindings. *)
+
+let rec inline_outer_with q =
+  let replace_subquery z q = function
+    | TableRef(y,x) when y = z -> Subquery(q,x)
+    | fromclause -> fromclause
+  in
+  match q with
+  | With (z, q, Select (fields, tables, condition, os)) ->
+      Select(fields, List.map (replace_subquery z q) tables, condition, os)
+  | UnionAll(qs,n) -> UnionAll(List.map inline_outer_with qs,n)
+  | q -> q
+
 
 let string_of_base quote one_table b =
   Format.asprintf "%a" (pr_base quote one_table) b
 
 let string_of_query ?(range=None) quote q =
+  let q = inline_outer_with q in 
   let pr_range ppf range =
     match range with
       | None -> ()

--- a/core/typeSugar.ml
+++ b/core/typeSugar.ml
@@ -3078,13 +3078,8 @@ let rec type_check : context -> phrase -> phrase * Types.datatype * Usage.t =
             let () = unify ~handle:Gripers.query_outer
               (no_pos (T.Record context.effect_row), no_pos (T.Record outer_effects)) in
             let p = type_check (bind_effects context inner_effects) p in
-            let evaluator =
-              match policy with
-                | Nested -> Nested
-                | Flat -> Flat
-                | Default -> if (Settings.get Database.shredding) then Nested else Flat in
             let () =
-              match evaluator with
+              match policy with
                 | Nested -> ()
                 | Flat  ->
                      let shape =
@@ -3092,7 +3087,6 @@ let rec type_check : context -> phrase -> phrase * Types.datatype * Usage.t =
                          (T.Record (T.Row (StringMap.empty,
                             Types.fresh_row_variable (lin_any, res_base), false))) in
                      unify ~handle:Gripers.query_base_row (pos_and_typ p, no_pos shape)
-                | Default -> assert false
             in
             Query (range, policy, erase p, Some (typ p)), typ p, Usage.combine (range_usages) (usages p)
         (* mailbox-based concurrency *)

--- a/examples/initialise-list.links
+++ b/examples/initialise-list.links
@@ -79,7 +79,7 @@ fun insertItems(itemsTable, itemsList) {
     itemsList));
   delete (itemEntry <-- itemsTable)
     where (itemEntry.i < 0 || n < itemEntry.i);
-  var indexes = query { for (itemEntry <- asList(itemsTable)) [itemEntry.i] };
+  var indexes = query nested { for (itemEntry <- asList(itemsTable)) [itemEntry.i] };
   insert itemsTable values (i, name)
     for (i <- upto(0,n-1) `diff` indexes)
       [(i=i, name=sel(itemsList, i))];

--- a/examples/relational_lenses/config
+++ b/examples/relational_lenses/config
@@ -1,4 +1,3 @@
 database_args=localhost:5432:links:links
 database_driver=postgresql
-shredding=on
 relational_lenses=on

--- a/examples/relational_lenses/config.sample
+++ b/examples/relational_lenses/config.sample
@@ -1,4 +1,3 @@
 database_args=localhost:5432::links
 database_driver=postgresql
-shredding=on
 relational_lenses=on

--- a/tests/database.tests
+++ b/tests/database.tests
@@ -62,7 +62,7 @@ stdout : [(x = 1), (x = 2), (x = 3)] : [(x:Int)]
 exit : 0
 
 Nested query annotations (2)
-query nested { query { for (i <- [1,2,3]) [(x = i)] } }
+query flat { query { for (i <- [1,2,3]) [(x = i)] } }
 stdout : [(x = 1), (x = 2), (x = 3)] : [(x:Int)]
 exit : 0
 

--- a/tests/examples_default.config
+++ b/tests/examples_default.config
@@ -1,6 +1,5 @@
 #typecheck_ir=true
 typecheck_only=true
 enable_handlers=true
-shredding=true
 session_exceptions=false
 relational_lenses=true

--- a/tests/examples_effect_sugar.config
+++ b/tests/examples_effect_sugar.config
@@ -1,7 +1,6 @@
 #typecheck_ir=true
 typecheck_only=true
 enable_handlers=true
-shredding=true
 session_exceptions=false
 relational_lenses=true
 effect_sugar=true

--- a/tests/examples_session_exceptions.config
+++ b/tests/examples_session_exceptions.config
@@ -1,6 +1,5 @@
 #typecheck_ir=true
 typecheck_only=true
 enable_handlers=true
-shredding=true
 session_exceptions=true
 relational_lenses=true

--- a/tests/shredding/config.sample
+++ b/tests/shredding/config.sample
@@ -1,4 +1,3 @@
 database_driver=postgresql
 database_args=localhost:5432::links
 show_pre_sugar_typing=off
-shredding=on

--- a/tests/shredding/empty.links
+++ b/tests/shredding/empty.links
@@ -1,3 +1,3 @@
 var db = database "links";
 var factorials = table "factorials" with (i : Int, f : Int) from db;
-query {for (x <-- factorials) where (x.i == x.f) []}
+query nested {for (x <-- factorials) where (x.i == x.f) []}

--- a/tests/shredding/emptyfun.links
+++ b/tests/shredding/emptyfun.links
@@ -15,4 +15,4 @@ fun contains(xs) {
   containsInner(xs, fun(_) { false })
 }
 var containsEmpty = contains([]);
-query {for (y <-- factorials) [for (x <-- factorials) where (containsEmpty(x)) [x]]}
+query nested {for (y <-- factorials) [for (x <-- factorials) where (containsEmpty(x)) [x]]}

--- a/tests/shredding/jrules.links
+++ b/tests/shredding/jrules.links
@@ -28,7 +28,7 @@ var mc =
 
 sig marketers : () -> [(name:String, clients:[Int])]
 fun marketers () {
-  query {
+  query nested {
     for (m <-- marketers_names)
     [(name=m.name, clients = for (x <-- mc) where (x.m == m.name) [x.c])]
   }
@@ -36,7 +36,7 @@ fun marketers () {
 
 sig u : () -> [((id:Int), [String])]
 fun u () {
-  query {
+  query nested {
     for (c <-- clients)
        [(c, for (m <- marketers())
             where (not(empty(for (mc <- m.clients) where (mc == c.id) [()])))
@@ -55,7 +55,7 @@ fun v () {
 
 sig marketers2 : () -> [(name:String, clients:[Int])]
 fun marketers2 () {
-  query {
+  query nested {
     for (m <-- marketers_names)
       [(name=m.name, clients = for (x <-- mc) where (x.m == m.name && x.m =~ /a/) [x.c])]
   }

--- a/tests/shredding/organisation.links
+++ b/tests/shredding/organisation.links
@@ -118,7 +118,7 @@ fun employeesOfDept (d) {
 }
 
 fun q_org () {
-  query {
+  query nested {
     for (d <-- departments)
       [(name = d.name,
         employees = employeesOfDept(d),

--- a/tests/shredding/travel_portal.links
+++ b/tests/shredding/travel_portal.links
@@ -20,7 +20,7 @@ var externalTours =
   from db;
 
 fun q() {
-  query {
+  query nested {
     for (a <-- agencies)
       for (e <-- externalTours)
       where (a.name == e.name && e.type == "boat")
@@ -41,7 +41,7 @@ fun lin_e() {
 
 # Query q manually rewritten to calculate lineage
 fun q_lineage() {
-  query {
+  query nested {
     for (y_a <- lin_a())
       for (z_a <- for (y_e <- lin_e())
                     for (z_e <- if (y_a.data.name == y_e.data.name && y_e.data.type == "boat")
@@ -56,7 +56,7 @@ fun q_lineage() {
 }
 
 fun issue27() {
-  query {
+  query nested {
     for (a <-- agencies)
       [(name = a.name,
         based_in = a.based_in)]

--- a/tests/shredding/unit.links
+++ b/tests/shredding/unit.links
@@ -1,6 +1,6 @@
 var db = database "links";
 var factorials = table "factorials" with (i : Int, f : Int) from db;
-query {
+query nested {
   for (x <-- factorials)
   [(a=x.i,
     b=for(y <-- factorials) where (x.i == y.i) [()])]


### PR DESCRIPTION
This pull request:
- removes the shredding and use_keys_in_shredding settings, specializing remaining code to defaults of "shredding=off" and "use_keys_in_shredding=true" (resolves #844).  Since shredding is available by default using `query nested`, this specialization just means that writing `query` on its own defaults to `query flat` and there is no way to change this default behavior.
- updates various configuration and test files to adapt to this change in behavior
- makes minor changes to the recently updated query pretty printing, mostly through adding newlines in the most obvious places.
- finally, generalizes and corrects the treatment of `Select` and `With` in queries following issues noticed in #845:
   * `Select` constructors now take a list of `from_clause`s which can be either table references or subqueries (in either case with a tuple variable).  
   * The type of `With` is also adjusted to match the structure of actual SQL (specialized to the case of a single common table expression).  
   * The code that generates `With` in `query.ml` (building on the shredding code) now generates an actually correct `With` clause
   * Pretty-printing `Select` now no longer requires `Format.asprintf`, and pretty-printing `With` prints out an actual `WITH` clause. 
   * Instead of inlining `With` clauses during pretty-printing, there is a separate inlining pass, which is currently performed in the SQL pretty-printing toplevel function.  This should be done elsewhere, so that if we want to use the real `With` in SQL queries to materialize shared results, we can.
   * (I've also tested, by disabling the inlining temporarily, that the pretty-printer generates correct `With` SQL code and that using this in shredding instead of inlining `With` is correct or at least passes all tests.  However, this does make things slightly slower too because `With` materializes the shared table, so inlining is still the right thing to do when evaluating shredded queries.  But there might be other places where we actually want `With` left un-inlined and now we can.)

- [x] TODO: Hoist the `With` inlining out of `sql.ml` to the place where it should be happening, in the shredding evaluation code.