### PR TITLE
handle checkbox and radio group form elements

### DIFF
--- a/core/desugarLAttributes.ml
+++ b/core/desugarLAttributes.ml
@@ -25,7 +25,7 @@ let has_lattrs : phrase -> bool = function
 let apply name args : phrase = fn_appl name [] args
 
 let server_use name =
-  apply "assoc" [constant_str name; apply "environment" []]
+  apply "assocDefault" [constant_str name; apply "environment" []; constant_str ""]
 
 let client_use id =
   apply "getInputValue" [constant_str id]

--- a/core/lib.ml
+++ b/core/lib.ml
@@ -964,6 +964,10 @@ let env : (string * (located_primitive * Types.datatype * pure)) list = [
   (`Client, datatype "(String) ~> String",
   PURE);
 
+  "getRadioGroupValue",
+  (`Client, datatype "([String]) ~> String",
+  PURE);
+
   "event",
   (`Client, datatype "Event",
   PURE);

--- a/lib/js/jslib.js
+++ b/lib/js/jslib.js
@@ -1766,6 +1766,21 @@ function _getInputValue(id) {
 
 var getInputValue = LINKS.kify(_getInputValue);
 
+// getRadioGroupValue : [String] -> String
+function _getRadioGroupValue(ids) {
+  let ptr = ids;
+  while ( LINKEDLIST.isNil(ptr) == false ) {
+    var element = document.getElementById(ptr._head);
+    if (element.checked) {
+      return element.value;
+    }
+    ptr = ptr._tail;
+  }
+  return "";
+}
+
+var getRadioGroupValue = LINKS.kify(_getRadioGroupValue);
+
 //getValue : domRef -> xml
 //    NOTE: this is recursive.
 function _getValue(nodeRef) {

--- a/lib/js/jslib.js
+++ b/lib/js/jslib.js
@@ -251,7 +251,7 @@ const LINKEDLIST =  (function(){
     some: function(f, xs) {
       let ptr = xs;
       let found = false;
-      while ( (found || LINKEDLIST.isNil(ptr)) == false ) {
+      while ( (found || LINKEDLIST.isNil(ptr)) === false ) {
           found = f(ptr._head);
           ptr = ptr._tail;
       }
@@ -1754,10 +1754,10 @@ function _nodeTextContent(node) {
 
 // getInputValue : String -> String
 function _getInputValue(id) {
-  var element = document.getElementById(id);
+  const element = document.getElementById(id);
   DEBUG.assert(element != null, "invalid input node (id " + id + ")");
   DEBUG.assert(element.value != undefined, "invalid input value in id " + id)
-  if ((element.type != "radio" && element.type != "checkbox") || element.checked) {
+  if ((element.type !== "radio" && element.type !== "checkbox") || element.checked) {
     return element.value;
   } else {
     return "";
@@ -1769,8 +1769,8 @@ var getInputValue = LINKS.kify(_getInputValue);
 // getRadioGroupValue : [String] -> String
 function _getRadioGroupValue(ids) {
   let ptr = ids;
-  while ( LINKEDLIST.isNil(ptr) == false ) {
-    var element = document.getElementById(ptr._head);
+  while ( LINKEDLIST.isNil(ptr) === false ) {
+    const element = document.getElementById(ptr._head);
     if (element.checked) {
       return element.value;
     }

--- a/lib/js/jslib.js
+++ b/lib/js/jslib.js
@@ -1757,7 +1757,11 @@ function _getInputValue(id) {
   var element = document.getElementById(id);
   DEBUG.assert(element != null, "invalid input node (id " + id + ")");
   DEBUG.assert(element.value != undefined, "invalid input value in id " + id)
-  return element.value;
+  if ((element.type != "radio" && element.type != "checkbox") || element.checked) {
+    return element.value;
+  } else {
+    return "";
+  }
 }
 
 var getInputValue = LINKS.kify(_getInputValue);

--- a/prelude.links
+++ b/prelude.links
@@ -462,6 +462,15 @@ fun assoc(x,l) {
   }
 }
 
+sig assocDefault : (String,[(String,b)],b) ~> b
+fun assocDefault(x,l,d) {
+  switch (l) {
+    case []    -> d
+    case (k,v)::xs -> if (k == x) v
+                      else assocDefault(x, xs, d)
+  }
+}
+
 sig removeAssoc : (a,[(a,b)]) ~> [(a,b)]
 fun removeAssoc(x,l) {
   switch (l) {


### PR DESCRIPTION
This PR adjusts the code inserted when desugaring `l:` attributes.  

On the server side, if an expected `l:` attribute name/id is not present in the field parameters, it is initialized to the empty string.

On the client side, if the element is a checkbox or radio button, then the `value` field is returned only if the `checked` field is true.  Otherwise, the empty string is returned instead.

This fixes #208, but radio buttons/groups of more than one radio button still do not work. See #902, which I'll try to fix as well.