### PR TITLE
Update compiler flags

### DIFF
--- a/dune
+++ b/dune
@@ -20,7 +20,7 @@
  )))
  (ci      ;; Same as release, except warnings are treated as errors.
   (flags (:standard
-          -strict-formats -strict-sequence -safe-string -annot
+          -strict-formats -strict-sequence -safe-string -bin-annot
           -warn-error @A      ;; Treat warnings as errors...
           -w A-4-42-44-45-48-60-67  ;; ... except for warnings 4, 42, 44, 45, 48, 60, and 67 which are ignored.
   ))

--- a/dune
+++ b/dune
@@ -12,7 +12,7 @@
  (release
   (flags (:standard
           ;; The following flags are the same as for the "dev" profile.
-          -strict-formats -strict-sequence -safe-string -annot
+          -strict-formats -strict-sequence -safe-string -bin-annot
           -w A-4-42-44-45-48-60-67  ;; Ignores warnings 4, 42, 44, 45, 48, 60, and 67.
   ))
   (ocamlopt_flags (:standard

--- a/dune
+++ b/dune
@@ -4,7 +4,7 @@
           -strict-formats     ;; Disallows legacy formats.
           -strict-sequence    ;; Enforces the lhs of a sequence to have type `unit'.
           -safe-string        ;; Immutable strings.
-          -annot              ;; Dumps information per (file) module about types, bindings, tail-calls, etc. Used by some tools.
+          -bin-annot          ;; Dumps information per (file) module about types, bindings, tail-calls, etc. Used by some tools.
           -warn-error -a      ;; Do not treat warnings as errors.
           -w A-4-42-44-45-48-60-67  ;; Ignores warnings 4, 42, 44, 45, 48, 60, and 67.
           -g                  ;; Adds debugging information to the resulting executable / library.


### PR DESCRIPTION
Following the discussion in #750 this patch drops the `-annot` flag in
place of the `-bin-annot` flag, which seems to be hardcoded into
Dune. However, to ensure our tools continue to work it seems sensible
to supply this flag explicitly.