### PR TITLE
Various IR type-checking cleanups

### DIFF
--- a/core/closures.ml
+++ b/core/closures.ml
@@ -710,7 +710,8 @@ struct
             let tyvars = inner_quantifiers @ fn_tyvars in
             let (o, z) = match z with
               | Some zbinder ->
-                let zbinder = Var.update_type (Instantiate.datatype inner_maps (Var.type_of_binder zbinder)) zbinder in
+                let ztype = Types.for_all (inner_quantifiers, Instantiate.datatype inner_maps (Var.type_of_binder zbinder)) in
+                let zbinder = Var.update_type ztype zbinder in
                 (fst (o#binder zbinder), Some zbinder)
               | None -> o, None in
             let xs = List.fold_right (fun x xs ->

--- a/core/irCheck.ml
+++ b/core/irCheck.ml
@@ -1300,7 +1300,7 @@ struct
             let o, defs =
               List.fold_right
                 (fun  fundef (o, fs) ->
-                   let {fn_binder = f; fn_tyvars; fn_closure = z; _} = fundef in
+                   let {fn_binder = f; fn_closure = z; _} = fundef in
                    let o = o#add_function_closure_binder (Var.var_of_binder f) z in
                    let o, f = o#binder f in
                      (o, {fundef with fn_binder = f}::fs))
@@ -1331,7 +1331,7 @@ struct
                                 actual_parameter_types
                                 fn_body
                                 z
-                                (not unsafe) (* Treat recursive bindings with unsafe sig as nonrecursive *)
+                                (not fn_unsafe) (* Treat recursive bindings with unsafe sig as nonrecursive *)
                                 (SBind binding) in
                   let o = o#add_function_closure_binder (Var.var_of_binder f) z in
                   (* Debug.print ("added " ^ string_of_int (Var.var_of_binder f) ^ " to closure env"); *)

--- a/core/irCheck.ml
+++ b/core/irCheck.ml
@@ -585,13 +585,6 @@ struct
                        o#add_typevar_to_context var kind) o tyvars in
            let o, v, t = o#value v in
            let o = o#set_type_var_env previous_tyenv in
-           (* COMMENTED OUT CODE IS BROKEN: add then remove =/= id
-               because type variabl es are not guaranteed to be unique
-            *)
-           (* let o = List.fold_left
-            *   (fun o quant ->
-            *     let var = Quantifier.to_var quant in
-            *     o#remove_typevar_to_context var) o tyvars in *)
            let t = Types.for_all (tyvars, t) in
            o, TAbs (tyvars, v), t
         | TApp (v, ts)  ->
@@ -1155,12 +1148,6 @@ struct
         let o, body, body_type = o#computation body in
 
         let o = o#set_type_var_env previous_tyenv in
-        (* COMMENTED OUT CODE IS BROKEN: add then remove =/= id
-           because type variables are not guaranteed to be unique *)
-        (* let o = List.fold_left
-         *       (fun o quant ->
-         *         let var = Quantifier.to_var quant in
-         *         o#remove_typevar_to_context var) o tyvars in *)
         let o, _ = o#set_allowed_effects previously_allowed_effects in
 
 
@@ -1194,13 +1181,6 @@ struct
                             o#add_typevar_to_context var kind) o tyvars in
                 let o, tc, act = o#tail_computation tc in
                 let o = o#set_type_var_env previous_tyenv in
-                (* COMMENTED OUT CODE IS BROKEN: add then remove =/=
-                   id because type variables are not guaranteed to be
-                   unique *)
-                (* let o = List.fold_left
-                 *           (fun o quant ->
-                 *             let var = Quantifier.to_var quant in
-                 *             o#remove_typevar_to_context var) o tyvars in *)
                 let exp = Var.type_of_binder x in
                 let act_foralled = Types.for_all (tyvars, act) in
                 o#check_eq_types exp act_foralled (SBind orig);

--- a/tests/unit/ir/schinks.ml
+++ b/tests/unit/ir/schinks.ml
@@ -52,6 +52,11 @@ let tvar ?(pk = CT.PrimaryKind.Type) ?(sk = default_subkind) tname =
   let+ id = Repr.lookup_tname ~tname in
   Types.Meta (Unionfind.fresh (Types.Var (id, kind, `Rigid)))
 
+let wi_tvar ?(pk = CT.PrimaryKind.Type) ?(sk = default_subkind) tid : Types.t t =
+  let kind = (pk, sk) in
+  let+ () = Repr.add_tid ~tid in
+  Types.Meta (Unionfind.fresh (Types.Var (tid, kind, `Rigid))) |> State.return
+
 let tvar_row ?(sk = default_subkind) name = tvar ~pk:CT.PrimaryKind.Row ~sk name
 
 let fun_t ?effects parameters codomain =

--- a/tests/unit/ir/schinks.mli
+++ b/tests/unit/ir/schinks.mli
@@ -53,6 +53,8 @@ val forall : CommonTypes.Quantifier.t t list -> Types.t t -> Types.t t
 (** Creates a type variable to be used in a type, primary kind defauls to Type *)
 val tvar : ?pk:CT.PrimaryKind.t -> ?sk:CT.Subkind.t -> string -> Types.typ t
 
+val wi_tvar : ?pk:CT.PrimaryKind.t -> ?sk:CT.Subkind.t -> int -> Types.typ t
+
 (** shorthand for tvar ~pk set to Type *)
 val tvar_row : ?sk:CT.Subkind.t -> string -> Types.typ t
 

--- a/tests/unit/ir/schinks.mli
+++ b/tests/unit/ir/schinks.mli
@@ -37,7 +37,7 @@ module CT = CommonTypes
 (** Representation of IR fragments and Links types *)
 type 'a t
 
-val reify : 'a t -> ('a, string) Result.t
+val reify : 'a t -> 'a
 
 (*
  *
@@ -58,7 +58,10 @@ val wi_tvar : ?pk:CT.PrimaryKind.t -> ?sk:CT.Subkind.t -> int -> Types.typ t
 (** shorthand for tvar ~pk set to Type *)
 val tvar_row : ?sk:CT.Subkind.t -> string -> Types.typ t
 
-val unit : Types.typ t
+(** Creates a type variable to be used in a type, primary kind defauls to Type *)
+val targ : ?pk:CT.PrimaryKind.t -> Types.t t -> Types.type_arg t
+
+val unit_t : Types.typ t
 
 (* Function types *)
 
@@ -97,6 +100,12 @@ val q_row : ?sk:CT.Subkind.t -> string -> CT.Quantifier.t t
 (** Version of q allowing you to specify the integer id of the quantifier *)
 val wi_q : ?pk:CT.PrimaryKind.t -> ?sk:CT.Subkind.t -> int -> CT.Quantifier.t t
 
+val record_t : (string * Types.t t) list -> Types.typ t
+
+(** Lifts a type into t, marking all quantifiers and type variable ids therein
+  as reserved. *)
+val lift_type : Types.t -> Types.t t
+
 (*
  *
  * IR BINDERS
@@ -125,6 +134,14 @@ val s : string -> Ir.value t
 val var : string -> Ir.value t
 
 val wi_var : int -> Ir.value t
+
+val closure : string -> Ir.tyarg t list -> Ir.value t -> Ir.value t
+
+val record : (string * Ir.value t) list -> Ir.value t
+
+val extend_record : Ir.value t -> (string * Ir.value t) list -> Ir.value t
+
+val unit : Ir.value t
 
 (*
  *

--- a/tests/unit/ir/schinks_repr.ml
+++ b/tests/unit/ir/schinks_repr.ml
@@ -61,7 +61,6 @@ module Stage2 = struct
   let lookup_name ~name st = StringMap.find name st.varname_to_id
 end
 
-
 exception SchinksError of string
 
 type 'a lookup = ('a, Stage2.t) State.t
@@ -74,7 +73,6 @@ let make ?(state = ReprState.initial) mk =
   let lkp, state = State.run_state ~init:state mk in
   let state = Stage2.of_stage_1 state in
   State.run_state ~init:state lkp |> fst
-
 
 let lookup_tname ~tname =
   let+ st = State.get in

--- a/tests/unit/ir/schinks_repr.mli
+++ b/tests/unit/ir/schinks_repr.mli
@@ -8,23 +8,27 @@ module Stage2 : sig
   type t
 end
 
-module E : sig
-  type t
-end
+exception SchinksError of string
 
 type 'a lookup = ('a, Stage2.t) State.t
 
 type 'a stage1 = ('a, ReprState.t) State.t
 
-type 'a maker = 'a lookup stage1
+type 'a t = 'a lookup stage1
 
-type 'a t = ('a, E.t) Result.t maker
-
-val make : ?state:ReprState.t -> 'a maker -> ('a, 'b) result
+val make : ?state:ReprState.t -> 'a t -> 'a
 
 val lookup_tname : tname:string -> int lookup
 
 val lookup_name : name:string -> int lookup
+
+val add_tnames : tnames:string list -> unit stage1
+
+val add_names : names:string list -> unit stage1
+
+val add_tids : tids:int list -> unit stage1
+
+val add_ids : ids:int list -> unit stage1
 
 val add_tname : tname:string -> unit stage1
 

--- a/tests/unit/ir/test_cases/closures.ml
+++ b/tests/unit/ir/test_cases/closures.ml
@@ -1,0 +1,159 @@
+open Schinks
+open Driver
+
+open Links_core
+(* open Utility *)
+open CommonTypes
+
+
+(* Tests for closure conversion.
+  Note that for a function taking a closure, there are three places where
+  quantifiers matter:
+  1. The toplevel quantifiers of the type of the function
+  2. The quantifiers in the type abstraction built into a functions
+     (e.g., the "tyars")
+  3. The toplevel quantifiers of the type annotation of the closure variable.
+
+  The quantifiers in 1. and 2. must be
+  identical, modulo alpha-renaming
+  The quantifiers in 3. are a prefix of
+  those in 1 (and therefore also 2), modulo alpha-renaming.
+*)
+
+
+(* This tests that closures don't necessarily have to be records in terms,
+  even though closure conversion always yields records *)
+let prog_non_record_closure =
+  computation
+    [ fun_ "f" ([int] |--> int)
+        [("x", int)]
+        ~closure_var:("c",  int)
+        (tc_to_comp (return (var "c")))
+    ]
+    (return (closure "f" [] (i 3)))
+
+
+(* Tests the three different points where quantifiers are given (as described
+  above).
+  This function has two quantifiers for the closure itself, and two for the
+  function. (where the ones for the closure are repeated, yielding 4 in total)
+  *)
+let prog_closure_quantifiers =
+  fun_ "f" (forall [q "T1"; q "T2"; q "T3"; q "T4"] ([] |--> (tvar "T2")))
+    ~tparams:[q "Q1"; q "Q2"; q "Q3"; q "Q4"]
+    []
+    ~closure_var:("c", forall [q "U1"; q "U2"] (tvar "U2"))
+    (tc_to_comp (return (var "c")))
+
+
+let prog_closure_supply_good =
+  [
+    prog_closure_quantifiers; (* Reuse function above *)
+
+    let_ "x" (forall [q "Qx"; q "Qy" ] ([] |--> int))
+      (return (closure "f" [targ unit_t; targ int] (i 3))) (* okay *)
+  ]
+
+let prog_closure_supply_tyargs_wrong =
+  [
+    prog_closure_quantifiers; (* Reuse function above *)
+
+    let_ "x" (forall [q "Qx"; q "Qy" ] ([] |--> int))
+      (return (closure "f" [targ unit_t] (i 3))) (* insufficient type args *)
+  ]
+let error_closure_supply_tyargs_wrong = "Providing wrong number of closure \
+                                         type arguments"
+
+let prog_closure_supply_type_wrong =
+  [
+    prog_closure_quantifiers; (* Reuse function above *)
+
+    let_ "x" (forall [q "Qx"; q "Qy" ] ([] |--> int))
+      (* wrong type of supplied closure env: *)
+      (return (closure "f" [targ unit_t; targ string] (i 3)))
+  ]
+let error_closure_supply_type_wrong = "Type mismatch.+Expected.+String.+Actual.+Int"
+
+
+
+let prog_closure_supply_kind_wrong =
+  let some_row = lift_type (Links_core.Types.make_empty_closed_row ()) in
+  [
+    prog_closure_quantifiers; (* Reuse function above *)
+
+    let_ "x" (forall [q "Qx"; q "Qy" ] ([] |--> int))
+      (* wrong kind of first supplied targ: *)
+      (return (closure "f" [targ ~pk:PrimaryKind.Row some_row; targ int] (i 3)))
+  ]
+let error_closure_supply_kind_wrong = "Kind mismatch in type application"
+
+
+let prog_closure_quantifier_mismatch =
+  let base_sk = (fst Sugartypes.default_subkind, Restriction.Base) in
+
+  fun_ "f" (forall [q "T1"; q "T2"; q "T3"; q "T4"] ([] |--> (tvar "T2")))
+    ~tparams:[q "Q1"; q "Q2"; q "Q3"; q "Q4"]
+    []
+    (* Reject this due to the mismatch in U2, we don't allow any subkinding here: *)
+    ~closure_var:("c", forall [q "U1"; q ~sk:base_sk "U2"] (tvar "U2"))
+    (tc_to_comp (return (var "c")))
+let error_closure_quantifier_mismatch = "Mismatch in quantifier kinds in tyvar \
+                                         list vs closure variable quantifiers"
+
+
+let prog_no_closure_expected =
+  computation
+    [
+      (fun_ "f" ([] |--> unit_t)
+         []
+         (tc_to_comp (return unit)))
+    ]
+    (return (closure "f" [] unit))
+let error_no_closure_expected = "Providing closure to a function that does not need one"
+
+
+let prog_untracked =
+  (return (closure "f" [] unit))
+let error_untracked = "Variable . is unbound"
+
+
+
+
+
+let suite =
+  mk_suite
+    ~name:"closures"
+    [
+      expect_no_errors ~name:"non_record_closure"
+        prog_non_record_closure;
+
+      expect_no_errors ~name:"closure_quantifiers"
+        (binding_to_comp prog_closure_quantifiers);
+
+      expect_no_errors ~name:"closure_supply_good"
+       (bindings_to_comp prog_closure_supply_good);
+
+      expect_error ~name:"closure_supply_tyargs_wrong"
+       ~error_regex:error_closure_supply_tyargs_wrong
+       (bindings_to_comp prog_closure_supply_tyargs_wrong);
+
+      expect_error ~name:"closure_supply_type_wrong"
+       ~error_regex:error_closure_supply_type_wrong
+       (bindings_to_comp prog_closure_supply_type_wrong);
+
+      expect_error ~name:"closure_supply_kind_wrong"
+       ~error_regex:error_closure_supply_kind_wrong
+       (bindings_to_comp prog_closure_supply_kind_wrong);
+
+      expect_error ~name:"closure_quantifier_mismatch"
+       ~error_regex:error_closure_quantifier_mismatch
+       (binding_to_comp prog_closure_quantifier_mismatch);
+
+      expect_error ~name:"no_closure_expected"
+        ~error_regex:error_no_closure_expected
+        prog_no_closure_expected;
+
+      expect_error ~name:"untracked"
+        ~error_regex:error_untracked
+        (tc_to_comp prog_untracked)
+    ]

--- a/tests/unit/ir/test_cases/closures.mli
+++ b/tests/unit/ir/test_cases/closures.mli
@@ -1,0 +1,1 @@
+val suite : OUnit2.test

--- a/tests/unit/ir/test_cases/functions.ml
+++ b/tests/unit/ir/test_cases/functions.ml
@@ -22,6 +22,15 @@ let prog_type_annot_vs_param_type =
 let error_type_annot_vs_param_type = "Type mismatch"
 
 
+(* There is a difference between a function of type
+  [unit] -> int    and
+  [] -> int
+*)
+let prog_unit_vs_no_params =
+  fun_ "f" ([] |~~> int)
+    [("x", unit_t)]
+    (tc_to_comp (return (i 3)))
+let error_unit_vs_no_params = "Type mismatch"
 
 
 let suite =
@@ -34,4 +43,8 @@ let suite =
       expect_error ~name:"Divergence between overall type and parameter types"
         ~error_regex:error_type_annot_vs_param_type
         (binding_to_comp prog_type_annot_vs_param_type);
+
+      expect_error ~name:"unit_vs_no_params"
+        ~error_regex:error_unit_vs_no_params
+        (binding_to_comp prog_unit_vs_no_params);
     ]

--- a/tests/unit/ir/test_cases/quantifiers.ml
+++ b/tests/unit/ir/test_cases/quantifiers.ml
@@ -1,6 +1,6 @@
 open Schinks
 open Driver
-
+open Links_core.CommonTypes
 
 
 let prog_quantifier_mismatch_1 =
@@ -23,6 +23,65 @@ let prog_kind_mismatch_1 =
 let error_kind_mismatch_1 = "Type mismatch:"
 
 
+let prog_quantifier_out_of_scope1 =
+  [
+    fun_ "f"  (forall [wi_q 0] ([] |--> int))
+      ~tparams:[q "Q1"]
+      []
+      (tc_to_comp (return (i 3)));
+
+    fun_ "g"   ([] |--> int)
+      []
+      (computation
+        [
+          fun_ "nested" ([wi_tvar 0] |--> int) (* Error: type variable 0 isn't in scope anymore *)
+            ["x", wi_tvar 0]
+            (tc_to_comp (return (i 4)));
+        ]
+        (return (i 3)))
+
+  ]
+let error_quantifier_out_of_scope1 = "Type variable 0 is unbound"
+
+
+let prog_quantifier_out_of_scope2 =
+  [
+    fun_ "f"  (forall [wi_q 0] ([] |--> int))
+      ~tparams:[wi_q 1]
+      []
+      (tc_to_comp (return (i 3)));
+
+    fun_ "g"   ([] |--> int)
+      []
+      (computation
+        [
+          fun_ "nested" ([wi_tvar 1] |--> int) (* Error: type variable 1 isn't in scope anymore *)
+            ["x", wi_tvar 1]
+            (tc_to_comp (return (i 4)));
+        ]
+        (return (i 3)))
+
+  ]
+let error_quantifier_out_of_scope2 = "Type variable 1 is unbound"
+
+
+let prog_quantifier_shadowing =
+  fun_ "f" (forall [q "T1"] ([tvar "T1"] |--> unit))
+      ~tparams:[q "Q1"]
+      ["x", tvar "Q1"]
+      (bindings_to_comp
+        [
+          fun_ "nested1" (forall  [q ~pk:PrimaryKind.Row "Q1"] ([] |--> int)) (* Shadowing Q1 to be a row now *)
+            ~tparams:[q ~pk:PrimaryKind.Row "V1"]
+            []
+            (tc_to_comp (return (i 3)));
+
+          fun_ "nested2" ([tvar "Q1"] |--> int) (* Q1 is back to having primary kind type now *)
+            ["x", tvar "Q1"]
+            (tc_to_comp (return (i 4)));
+        ])
+
+
 let suite =
   mk_suite
     ~name:"quantifiers"
@@ -34,4 +93,17 @@ let suite =
       expect_error ~name:"error_kind_mismatch_1"
         ~error_regex:error_kind_mismatch_1
         (bindings_to_comp prog_kind_mismatch_1);
+
+      expect_error ~name:"quantifier_out_of_scope1"
+        ~error_regex:error_quantifier_out_of_scope1
+        (bindings_to_comp prog_quantifier_out_of_scope1);
+
+      expect_error ~name:"quantifier_out_of_scope2"
+        ~error_regex:error_quantifier_out_of_scope2
+        (bindings_to_comp prog_quantifier_out_of_scope2);
+
+      expect_no_errors ~name:"quantifier_shadowing"
+        (binding_to_comp prog_quantifier_shadowing);
+
+
     ]

--- a/tests/unit/ir/test_cases/quantifiers.ml
+++ b/tests/unit/ir/test_cases/quantifiers.ml
@@ -66,7 +66,7 @@ let error_quantifier_out_of_scope2 = "Type variable 1 is unbound"
 
 
 let prog_quantifier_shadowing =
-  fun_ "f" (forall [q "T1"] ([tvar "T1"] |--> unit))
+  fun_ "f" (forall [q "T1"] ([tvar "T1"] |--> unit_t))
       ~tparams:[q "Q1"]
       ["x", tvar "Q1"]
       (bindings_to_comp

--- a/tests/unit/unitTests.ml
+++ b/tests/unit/unitTests.ml
@@ -21,7 +21,13 @@ let suites =
          ( "ir"
          >:::
          let open Links_ir_unit_tests in
-         [ Binding.suite; Functions.suite; Effects.suite; Quantifiers.suite; Closures.suite ] );
+         [
+           Binding.suite;
+           Functions.suite;
+           Effects.suite;
+           Quantifiers.suite;
+           Closures.suite;
+         ] );
        ]
 
 let () = run_test_tt_main suites

--- a/tests/unit/unitTests.ml
+++ b/tests/unit/unitTests.ml
@@ -21,7 +21,7 @@ let suites =
          ( "ir"
          >:::
          let open Links_ir_unit_tests in
-         [ Binding.suite; Functions.suite; Effects.suite; Quantifiers.suite ] );
+         [ Binding.suite; Functions.suite; Effects.suite; Quantifiers.suite; Closures.suite ] );
        ]
 
 let () = run_test_tt_main suites


### PR DESCRIPTION
This PR 
- removes some comments about the earlier handling scoping of type variables being broken (this was already fixed by @slindley)
- adds test ensuring that the scoping of such type variables is now indeed correct
- adds new features to the IR DSL (closures, records, ...)
- slightly stratifies the types used within the IR DSL
- changes the generation and type-checking of closures such that it coincides with the description in the IR formalization. This only changes that the type of the binder of the closure variable will now carry the quantifiers specific to the closure.
  Overall, this doesn't fix any existing bugs, the only difference in behavior is that we can now detect the following, which wasn't possible earlier: When supplying a closure environment to a function as well as type arguments specific to the closure, we can now detect better if the number of these type arguments is wrong. This is because we can now distinguish better between quantifiers of a function that are specific to the closure (i.e., added during closure conversion), and those that were originally part of the function (i.e., before closure conversion). 
- adds a series of tests for the type-checking of closures