### PR TITLE
Changelog 0.9.2

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,7 @@
 # 0.9.2
 
-This minor release contains various bug fixes, improvements, and a **breaking** change.
+This minor release contains various bug fixes, improvements, and a **breaking**
+change.
 
 ## Breaking change: Trailing semicolons are no longer permitted
 The surface syntax of Links has been changed.  Up until now it was possible to
@@ -41,13 +42,13 @@ fun foo(x) {
 A third option is to simply drop the trailing semicolon, though, this only works
 as intended if the type of the last expression is `()`.
 
-## TODO: Bug breaking web examples
 
 ## SML-style function definitions
 
-Links now supports "switch functions", a new syntax for defining functions in terms of match clauses
-directly, similar to SML. This allows writing the following function
-```
+Links now supports "switch functions", a new syntax for defining functions in
+terms of match clauses directly, similar to SML. This allows writing the
+following function
+```links
 fun ack(_,_) switch {
   case (0, n) -> n + 1
   case (m, 0) -> ack(m - 1, 1)
@@ -56,7 +57,7 @@ fun ack(_,_) switch {
 ```
 instead of the following, more verbose version:
 
-```
+```links
 fun ack(a, b) {
   switch(a, b) {
     case (0, n) -> n + 1
@@ -67,7 +68,7 @@ fun ack(a, b) {
 ```
 
 Switch functions can also be anonymous, allowing function like the following:
-```
+```links
 fun(_, _) switch {
   case (0, n) -> 0
   case (m, n) -> m + n
@@ -80,17 +81,19 @@ fun(_, _) switch {
 The minimum required OCaml version has been raised to 4.08.
 
 
-## Miscellaneous:
+## Miscellaneous
 
+- Fixed a bug breaking the TODO list example (#812)
 - Checkboxes and radio groups in form elements are now handled correctly (#903)
 - Links supports MySQL databases again! (#858)
 - Fixed a bug where the effect of `orderby` was inconsistent between database
   drivers w.r.t. reversing the order of results (#858)
-- Relational lenses can now be used with MySQL and Sqlite3  databases, too (#897)
+- Relational lenses can now be used with MySQL and Sqlite3 databases, too (#897)
 - Remove setting `use_keys_in_shredding`, behaving as if it was always true (#892)
 - Remove setting `query`, behaving as if it was off
   (i.e., `query` behaves like `query flat`) (#892)
-- Fixed a bug where regular expressions in nested queries did not work correctly (#852)
+- Fixed a bug where regular expressions in nested queries did not work correctly
+  (#852)
 - Implemented support for negative patterns in let bindings (#811)
 
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -10,9 +10,9 @@ Links now supports "switch functions", a new syntax for defining functions in te
 directly, similar to SML. This allows writing the following function
 ```
 fun ack(_,_) switch {
-  case (0, n) ->  n + 1
+  case (0, n) -> n + 1
   case (m, 0) -> ack(m - 1, 1)
-  case (m,n) ->  ack(m - 1, ack(m, n - 1))
+  case (m, n) -> ack(m - 1, ack(m, n - 1))
 }
 ```
 instead of the following, more verbose version:
@@ -20,14 +20,14 @@ instead of the following, more verbose version:
 ```
 fun ack(a, b) {
   switch(a, b) {
-    case (0, n) ->  n + 1
+    case (0, n) -> n + 1
     case (m, 0) -> ack(m - 1, 1)
-    case (m,n) ->  ack(m - 1, ack(m, n - 1))
+    case (m, n) -> ack(m - 1, ack(m, n - 1))
   }
 }
 ```
 
-Switch functions can also be anonymous, allowing the following:
+Switch functions can also be anonymous, allowing function like the following:
 ```
 fun(_, _) switch {
   case (0, n) -> 0
@@ -38,18 +38,18 @@ fun(_, _) switch {
 
 # Require OCaml 4.08
 
-The minimum required OCaml version has been raised to 4.08
+The minimum required OCaml version has been raised to 4.08.
 
 
 ## Minor changes:
 
 - The last expression in a block may no longer be followed by a semicolon (#900)
 - Checkboxes and radio groups in form elements are now handled correctly (#903)
-- Relational lenses can now be used with MySQL and Sqlite3  datbases, too (#897)
+- Links supports MySQL databases again! (#858)
+- Relational lenses can now be used with MySQL and Sqlite3  databases, too (#897)
 - Remove setting `use_keys_in_shredding`, behaving as if it was always true (#892)
 - Remove setting `query`, behaving as if it was off
   (i.e., `query` behaves like `query flat`) (#892)
-- Links supports MySQL databases again! (#858)
 - Fixed a bug where regular expressions in nested queries did not work correctly (#852)
 - Implemented support for negative patterns in let bindings (#811)
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -36,12 +36,12 @@ fun(_, _) switch {
 ```
 
 
-# Require OCaml 4.08
+## Require OCaml 4.08
 
 The minimum required OCaml version has been raised to 4.08.
 
 
-## Minor changes:
+## Miscellaneous:
 
 - The last expression in a block may no longer be followed by a semicolon (#900)
 - Checkboxes and radio groups in form elements are now handled correctly (#903)

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,45 @@
 # 0.9.2
 
-This minor release contains various bug fixes and improvements.
+This minor release contains various bug fixes, improvements, and a **breaking** change.
+
+## Breaking change: Trailing semicolons are no longer permitted
+The surface syntax of Links has been changed.  Up until now it was possible to
+end a block with a semicolon.  A trailing semicolon was interpreted as
+implicitly ending the block with a `()` expression.  The rationale for this
+change is to make the Links syntax more consistent, i.e. now all blocks must end
+with an explicit expression.  To sum up, previously both of the following were
+allowed
+
+```links
+fun foo(x) {
+  bar(y);
+  baz(x);
+}
+fun foo'(x) {
+  bar(y);
+  baz(x)
+}
+```
+
+Now the first form is no longer accepted. Instead you have to drop the semicolon
+and either end the block with an explicit `()` or wrap the last expression in an
+`ignore` application.
+
+```links
+fun foo(x) {
+  bar(y);
+  baz(x);
+  ()
+}
+
+fun foo(x) {
+  bar(y);
+  ignore(baz(x))
+}
+```
+
+A third option is to simply drop the trailing semicolon, though, this only works
+as intended if the type of the last expression is `()`.
 
 ## TODO: Bug breaking web examples
 
@@ -43,7 +82,6 @@ The minimum required OCaml version has been raised to 4.08.
 
 ## Miscellaneous:
 
-- The last expression in a block may no longer be followed by a semicolon (#900)
 - Checkboxes and radio groups in form elements are now handled correctly (#903)
 - Links supports MySQL databases again! (#858)
 - Relational lenses can now be used with MySQL and Sqlite3  databases, too (#897)

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,61 @@
+# 0.9.2
+
+This minor release contains various bug fixes and improvements.
+
+## TODO: Bug breaking web examples
+
+## SML-style function definitions
+
+Links now supports "switch functions", a new syntax for defining functions in terms of match clauses
+directly, similar to SML. This allows writing the following function
+```
+fun ack(_,_) switch {
+  case (0, n) ->  n + 1
+  case (m, 0) -> ack(m - 1, 1)
+  case (m,n) ->  ack(m - 1, ack(m, n - 1))
+}
+```
+instead of the following, more verbose version:
+
+```
+fun ack(a, b) {
+  switch(a, b) {
+    case (0, n) ->  n + 1
+    case (m, 0) -> ack(m - 1, 1)
+    case (m,n) ->  ack(m - 1, ack(m, n - 1))
+  }
+}
+```
+
+Switch functions can also be anonymous, allowing the following:
+```
+fun(_, _) switch {
+  case (0, n) -> 0
+  case (m, n) -> m + n
+}
+```
+
+
+# Require OCaml 4.08
+
+The minimum required OCaml version has been raised to 4.08
+
+
+## Minor changes:
+
+- The last expression in a block may no longer be followed by a semicolon (#900)
+- Checkboxes and radio groups in form elements are now handled correctly (#903)
+- Relational lenses can now be used with MySQL and Sqlite3  datbases, too (#897)
+- Remove setting `use_keys_in_shredding`, behaving as if it was always true (#892)
+- Remove setting `query`, behaving as if it was off
+  (i.e., `query` behaves like `query flat`) (#892)
+- Links supports MySQL databases again! (#858)
+- Fixed a bug where regular expressions in nested queries did not work correctly (#852)
+- Implemented support for negative patterns in let bindings (#811)
+
+
+
+
 # 0.9.1
 
 This minor release contains various bug fixes and improvements.

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -84,6 +84,8 @@ The minimum required OCaml version has been raised to 4.08.
 
 - Checkboxes and radio groups in form elements are now handled correctly (#903)
 - Links supports MySQL databases again! (#858)
+- Fixed a bug where the effect of `orderby` was inconsistent between database
+  drivers w.r.t. reversing the order of results (#858)
 - Relational lenses can now be used with MySQL and Sqlite3  databases, too (#897)
 - Remove setting `use_keys_in_shredding`, behaving as if it was always true (#892)
 - Remove setting `query`, behaving as if it was off

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -74,8 +74,8 @@ fun(_, _) switch {
   case (m, n) -> m + n
 }
 ```
-
-
+Note: currently switch function syntax is only supported for uncurried functions.
+As switch functions have experimental status they are disabled by default. To enable them you must set the option `pattern_matching_sugar=true` in a configuration file. 
 ## Require OCaml 4.08
 
 The minimum required OCaml version has been raised to 4.08.

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -75,7 +75,9 @@ fun(_, _) switch {
 }
 ```
 Note: currently switch function syntax is only supported for uncurried functions.
-As switch functions have experimental status they are disabled by default. To enable them you must set the option `pattern_matching_sugar=true` in a configuration file. 
+As switch functions have experimental status they are disabled by default. To
+enable them you must set the option `switch_functions=true` in a
+configuration file.
 ## Require OCaml 4.08
 
 The minimum required OCaml version has been raised to 4.08.


### PR DESCRIPTION
This is a draft for the changelog for the 0.9.2 release.

I vaguely remember that this release fixes some problem in 0.9.1 where many (all?) web or database examples were broken, but I may be wrong. Does this ring a bell? I went through all commits sine 0.9.1 to create the changelog, but I couldn't find something sounding like that.