### PR TITLE
Rename option to toggle switch functions.

### DIFF
--- a/core/desugarSwitchFuns.ml
+++ b/core/desugarSwitchFuns.ml
@@ -28,19 +28,18 @@ open SourceCode
 
 let with_pos = SourceCode.WithPos.make
 
-let pattern_matching_sugar =
+let enabled =
   Settings.(
-    flag "pattern_matching_sugar"
-    |> synopsis
-         "Toggles whether to enable the switch pattern matching syntax sugar"
+    flag ~default:false "switch_functions"
+    |> synopsis "Toggles whether to enable the switch function syntax"
     |> convert parse_bool
     |> sync)
 
 let pattern_matching_sugar_guard pos =
   let pattern_matching_sugar_disabled pos =
-    Errors.disabled_extension ~pos ~setting:("pattern_matching_sugar", true) "Pattern Matching Sugar"
+    Errors.disabled_extension ~pos ~setting:("switch_functions", true) "Switch functions"
   in
-  if not (Settings.get pattern_matching_sugar)
+  if not (Settings.get enabled)
   then raise (pattern_matching_sugar_disabled pos)
 
 let nullary_guard pss pos =

--- a/core/desugarSwitchFuns.ml
+++ b/core/desugarSwitchFuns.ml
@@ -28,7 +28,7 @@ open SourceCode
 
 let with_pos = SourceCode.WithPos.make
 
-let enabled =
+let switch_functions =
   Settings.(
     flag ~default:false "switch_functions"
     |> synopsis "Toggles whether to enable the switch function syntax"
@@ -39,7 +39,7 @@ let pattern_matching_sugar_guard pos =
   let pattern_matching_sugar_disabled pos =
     Errors.disabled_extension ~pos ~setting:("switch_functions", true) "Switch functions"
   in
-  if not (Settings.get enabled)
+  if not (Settings.get switch_functions)
   then raise (pattern_matching_sugar_disabled pos)
 
 let nullary_guard pss pos =

--- a/tests/functions.config
+++ b/tests/functions.config
@@ -1,1 +1,0 @@
-pattern_matching_sugar=true

--- a/tests/functions.tests
+++ b/tests/functions.tests
@@ -1,7 +1,3 @@
----
-config: tests/functions.config
----
-
 Function typing bug (see jdy's blog, 2005-10-24)
 (fun (x,y) { [x] ++ [y] }) ([1],"a")
 stderr : @..*
@@ -150,34 +146,3 @@ Linearity (9) - linear recursive functions should be disallowed
 linfun f(x) {f(x)} f
 stderr : @.*cannot be linear.*
 exit : 1
-
-Pattern Matching (1)
-fun foo(_) switch { case x -> x } foo
-stdout : fun : (a) ~> a
-
-Pattern Matching (2)
-fun ack(_,_) switch { case (0, n) -> n + 1 case (m, 0) -> ack(m - 1, 1) case (m, n) -> ack(m - 1, ack(m, n - 1)) } ack
-stdout : fun : (Int, Int) ~> Int
-
-Pattern Matching (3)
-fun ack(_,_) switch { case (0, n) -> n + 1 case (m, 0) -> ack(m - 1, 1) case (m, n) -> ack(m - 1, ack(m, n - 1)) } fun test() { print(intToString(ack(0,1))); print(intToString(ack(1,0))); print(intToString(ack(1,1))) } test()
-stdout : 223() : ()
-
-Pattern Matching (4) - multiple arg list function
-fun foo(_)(_) switch { case (x, y) -> x + y } foo
-stderr : @.*Curried switch functions are not yet supported.*
-exit : 1
-
-Pattern Matching (5) - runtime non-exhaustive error
-fun foo(_) switch { case 1 -> 1 } foo(0)
-stderr : @.*non-exhaustive pattern matching.*
-exit : 1
-
-Pattern Matching (6) - matching over nullary function
-fun f() switch { case n -> 1 }
-stderr : @.*Can't match over nullary function.*
-exit : 1
-
-Pattern Matching (7) - anonymous switch function
-fun(s) switch { case x -> x }
-stdout : fun : (a) ~> a

--- a/tests/switch_functions.config
+++ b/tests/switch_functions.config
@@ -1,0 +1,1 @@
+switch_functions=true

--- a/tests/switch_functions.tests
+++ b/tests/switch_functions.tests
@@ -1,0 +1,34 @@
+---
+config: tests/switch_functions.config
+---
+
+Switch fun (syntax check)
+fun foo(_) switch { case x -> x } foo
+stdout : fun : (a) ~> a
+
+Ackermann switch fun (1)
+fun ack(_,_) switch { case (0, n) -> n + 1 case (m, 0) -> ack(m - 1, 1) case (m, n) -> ack(m - 1, ack(m, n - 1)) } ack
+stdout : fun : (Int, Int) ~> Int
+
+Ackermann switch fun (2)
+fun ack(_,_) switch { case (0, n) -> n + 1 case (m, 0) -> ack(m - 1, 1) case (m, n) -> ack(m - 1, ack(m, n - 1)) } fun test() { print(intToString(ack(0,1))); print(intToString(ack(1,0))); print(intToString(ack(1,1))) } test()
+stdout : 223() : ()
+
+Curried switch fun
+fun foo(_)(_) switch { case (x, y) -> x + y } foo
+stderr : @.*Curried switch functions are not yet supported.*
+exit : 1
+
+Switch fun: runtime non-exhaustive error
+fun foo(_) switch { case 1 -> 1 } foo(0)
+stderr : @.*non-exhaustive pattern matching.*
+exit : 1
+
+Switch fun: matching over nullary function
+fun f() switch { case n -> 1 }
+stderr : @.*Can't match over nullary function.*
+exit : 1
+
+Anonymous switch fun
+fun(s) switch { case x -> x }
+stdout : fun : (a) ~> a


### PR DESCRIPTION
This commit renames the option `pattern_matching_sugar` to
`switch_functions` as the former is somewhat generic and the latter is
the name of the feature actually being enabled/disabled by toggling
the option.

In addition, this commit also cleans up the test suite for
functions. The non-experimental function features should not be kept
in the same test file as the experimental features -- in particular,
the non-experimental features should not **always** be tested under
the assumption that an experimental flag is enabled.