### PR TITLE
Distribute MVU JavaScript source files.

### DIFF
--- a/lib/js/dune
+++ b/lib/js/dune
@@ -1,4 +1,6 @@
 (install
   (section lib)
-  (files (jslib.js as js/jslib.js))
+  (files (jslib.js as js/jslib.js)
+         (vdom.js as js/vdom.js)
+         (virtual-dom.js as js/virtual-dom.js))
   (package links))

--- a/lib/stdlib/mvu.links
+++ b/lib/stdlib/mvu.links
@@ -7,14 +7,14 @@ open import MvuCommands;
 
 # Needed to ensure that virtual-dom is open
 module VirtualDom {
-  alien javascript "/lib/virtual-dom.js" {
+  alien javascript "/lib/js/virtual-dom.js" {
     dummy : ();
   }
 }
 
 # Loads the "vdom.js" file, exposes runDom and updateDom.
 module VDom {
-  alien javascript "/lib/vdom.js" {
+  alien javascript "/lib/js/vdom.js" {
     runDom : forall a :: Type(Any, Any), e :: Row .
       (String, HTML(a), AP(?a.End), Sub(a)) ~e~> ();
     updateDom : forall a :: Type(Any, Any), e :: Row . (HTML(a), Sub(a)) ~e~> ();

--- a/preinstall/preinstall.ml
+++ b/preinstall/preinstall.ml
@@ -44,6 +44,7 @@ let write_content filename =
 let config libdir = [
   "jsliburl=/lib/js";
   Printf.sprintf "jslibdir=%s/js" libdir;
+  Printf.sprintf "stdlib_path=%s/stdlib" libdir;
   "#database_driver=postgresql";
   "#database_args=localhost:5432:user:pass" ]
 


### PR DESCRIPTION
This commit modifies the install script such that the MVU dependencies
`vdom.js` and `virtual-dom.js` are installed along with the MVU
examples.

To make the MVU examples work out of the box I have chosen to piggyback
on hardcoded resolution for `jslib.js`. This is a horrible hack. I
also had to change the default configuration file to set the stdlib
path in order for the system to find the MVU Links source files.

I was able to run the MVU todo example application on a fresh
installation of Links with the following command.

```
$ linx $OPAM_SWITCH_PREFIX/share/links/examples/mvu/todomvc/todoMVC.links
```

Resolves #930. Resolves #931.