### PR TITLE
Allow table projection from within likeifyable SQL-compiled regular expressions

### DIFF
--- a/core/query/evalNestedQuery.ml
+++ b/core/query/evalNestedQuery.ml
@@ -397,7 +397,7 @@ struct
       | Apply (Primitive f, es) ->
         Apply (Primitive f, List.map li es)
       | Record fields ->
-        Record (StringMap.map (li) fields)
+        Record (StringMap.map li fields)
       | Primitive "out" ->
         (* z.2 *)
         Project (Var (z, z_fields), "2")

--- a/core/query/evalNestedQuery.ml
+++ b/core/query/evalNestedQuery.ml
@@ -375,7 +375,10 @@ struct
 
   let rec lins_inner (z, z_fields) ys : QL.t -> QL.t =
     let open QL in
+    let li () = lins_inner (z, z_fields) ys in
+    let liq = lins_inner_query (z, z_fields) ys in
     function
+      (* Need to make sure this happens on the regex, too. *)
       | Project (Var (x, fields), l) ->
         begin
           match position_of x ys with
@@ -386,20 +389,34 @@ struct
                 (Project
                     (Project (Var (z, z_fields), "1"), string_of_int i), l)
         end
-      | Apply (Primitive "Empty", [e]) -> Apply (Primitive "Empty", [lins_inner_query (z, z_fields) ys e])
-      | Apply (Primitive "length", [e]) -> Apply (Primitive "length", [lins_inner_query (z, z_fields) ys e])
+      | Apply (Primitive "Empty", [e]) -> Apply (Primitive "Empty", [liq e])
+      | Apply (Primitive "length", [e]) -> Apply (Primitive "length", [liq e])
       | Apply (Primitive "tilde", [s; r]) as e ->
           Debug.print ("Applying lins_inner to tilde expression: " ^ QL.show e);
-          Apply (Primitive "tilde", [lins_inner (z, z_fields) ys s; r])
+          Apply (Primitive "tilde", [li () s; li () r])
       | Apply (Primitive f, es) ->
-        Apply (Primitive f, List.map (lins_inner (z, z_fields) ys) es)
+        Apply (Primitive f, List.map (li ()) es)
       | Record fields ->
-        Record (StringMap.map (lins_inner (z, z_fields) ys) fields)
+        Record (StringMap.map (li ()) fields)
       | Primitive "out" ->
         (* z.2 *)
         Project (Var (z, z_fields), "2")
       | Primitive "in"  -> Primitive "index"
       | Constant c      -> Constant c
+      (* Regex variants. *)
+      | Variant ("Simply", x) ->
+          Variant ("Simply", li () x)
+      | Variant ("Seq", Singleton r) ->
+          Variant ("Seq", Singleton (li () r))
+      | Variant ("Seq", Concat rs) ->
+          Variant ("Seq",
+            Concat (List.map (
+              function | Singleton x -> Singleton (li () x) | _ -> assert false) rs))
+      | Variant ("Quote", Variant ("Simply", v)) ->
+          Variant ("Quote", Variant ("Simply", li () v))
+      (* Other regex variants which don't need to be traversed *)
+      | Variant (s, x) when s = "Repeat" || s = "StartAnchor" || s = "EndAnchor" ->
+          Variant (s, x)
       | e ->
         Debug.print ("Can't apply lins_inner to: " ^ QL.show e);
         assert false
@@ -499,7 +516,7 @@ struct
       | Apply (Primitive "length", [e]) -> Apply (Primitive "length", [flatten_inner_query e])
       | Apply (Primitive "tilde", [s; r]) as e ->
           Debug.print ("Applying flatten_inner to tilde expression: " ^ QL.show e);
-          Apply (Primitive "tilde", [flatten_inner s; r])
+          Apply (Primitive "tilde", [flatten_inner s; flatten_inner r])
       | Apply (Primitive f, es) -> Apply (Primitive f, List.map flatten_inner es)
       | If (c, t, e)  ->
         If (flatten_inner c, flatten_inner t, flatten_inner e)
@@ -523,6 +540,19 @@ struct
                    StringMap.add name body fields)
              fields
              StringMap.empty)
+      | Variant ("Simply", x) ->
+          Variant ("Simply", flatten_inner x)
+      | Variant ("Seq", Singleton r) ->
+          Variant ("Seq", Singleton (flatten_inner r))
+      | Variant ("Seq", Concat rs) ->
+          Variant ("Seq",
+            Concat (List.map (
+              function | Singleton x -> Singleton (flatten_inner x) | _ -> assert false) rs))
+      | Variant ("Quote", Variant ("Simply", v)) ->
+          Variant ("Quote", Variant ("Simply", flatten_inner v))
+      (* Other regex variants which don't need to be traversed *)
+      | Variant (s, x) when s = "Repeat" || s = "StartAnchor" || s = "EndAnchor" ->
+          Variant (s, x)
       | e ->
         Debug.print ("Can't apply flatten_inner to: " ^ QL.show e);
         assert false

--- a/core/query/evalNestedQuery.ml
+++ b/core/query/evalNestedQuery.ml
@@ -395,7 +395,7 @@ struct
           Debug.print ("Applying lins_inner to tilde expression: " ^ QL.show e);
           Apply (Primitive "tilde", [li s; li r])
       | Apply (Primitive f, es) ->
-        Apply (Primitive f, List.map (li) es)
+        Apply (Primitive f, List.map li es)
       | Record fields ->
         Record (StringMap.map (li) fields)
       | Primitive "out" ->
@@ -840,4 +840,3 @@ let compile_shredded : Value.env -> Ir.computation
           let t = Q.type_of_expression v in
           let p = unordered_query_package t v in
             Some (db, p)
-

--- a/core/query/evalNestedQuery.ml
+++ b/core/query/evalNestedQuery.ml
@@ -375,7 +375,7 @@ struct
 
   let rec lins_inner (z, z_fields) ys : QL.t -> QL.t =
     let open QL in
-    let li () = lins_inner (z, z_fields) ys in
+    let li x = lins_inner (z, z_fields) ys x in
     let liq = lins_inner_query (z, z_fields) ys in
     function
       (* Need to make sure this happens on the regex, too. *)
@@ -393,11 +393,11 @@ struct
       | Apply (Primitive "length", [e]) -> Apply (Primitive "length", [liq e])
       | Apply (Primitive "tilde", [s; r]) as e ->
           Debug.print ("Applying lins_inner to tilde expression: " ^ QL.show e);
-          Apply (Primitive "tilde", [li () s; li () r])
+          Apply (Primitive "tilde", [li s; li r])
       | Apply (Primitive f, es) ->
-        Apply (Primitive f, List.map (li ()) es)
+        Apply (Primitive f, List.map (li) es)
       | Record fields ->
-        Record (StringMap.map (li ()) fields)
+        Record (StringMap.map (li) fields)
       | Primitive "out" ->
         (* z.2 *)
         Project (Var (z, z_fields), "2")
@@ -405,15 +405,15 @@ struct
       | Constant c      -> Constant c
       (* Regex variants. *)
       | Variant ("Simply", x) ->
-          Variant ("Simply", li () x)
+          Variant ("Simply", li x)
       | Variant ("Seq", Singleton r) ->
-          Variant ("Seq", Singleton (li () r))
+          Variant ("Seq", Singleton (li r))
       | Variant ("Seq", Concat rs) ->
           Variant ("Seq",
             Concat (List.map (
-              function | Singleton x -> Singleton (li () x) | _ -> assert false) rs))
+              function | Singleton x -> Singleton (li x) | _ -> assert false) rs))
       | Variant ("Quote", Variant ("Simply", v)) ->
-          Variant ("Quote", Variant ("Simply", li () v))
+          Variant ("Quote", Variant ("Simply", li v))
       (* Other regex variants which don't need to be traversed *)
       | Variant (s, x) when s = "Repeat" || s = "StartAnchor" || s = "EndAnchor" ->
           Variant (s, x)

--- a/core/query/query.ml
+++ b/core/query/query.ml
@@ -1016,7 +1016,6 @@ let rec likeify v =
               | _ -> None
           in
             string v
-            (* opt_map quote (string v) *)
       | Variant ("Seq", rs) ->
           let rec seq =
             function

--- a/core/query/query.ml
+++ b/core/query/query.ml
@@ -1124,7 +1124,7 @@ and base : Sql.index -> Q.t -> Sql.base = fun index ->
       begin
         match likeify r with
           | Some r ->
-            Sql.Apply ("ILIKE", [base index s; Sql.Like r])
+            Sql.Apply ("LIKE", [base index s; Sql.Like r])
           | None ->
               begin
                 let r =

--- a/core/query/sql.ml
+++ b/core/query/sql.ml
@@ -305,8 +305,8 @@ and pr_base quote one_table ppf b =
         Format.pp_print_string ppf
           ("'" ^ CommonTypes.Constant.escape_string s ^ "'")
     | LikeProject (v, f) ->
-        Format.fprintf ppf "%a.\"%a\""
-          Format.pp_print_string (string_of_table_var v)
+        Format.fprintf ppf "%a.%a"
+          Format.pp_print_string (quote (string_of_table_var v))
           Format.pp_print_string f
     (* Special case appends with the empty string *)
     | LikeAppend (LikeString "", l) ->

--- a/core/query/sql.ml
+++ b/core/query/sql.ml
@@ -26,7 +26,9 @@ and select_clause = (base * string) list * from_clause list * base * base list
 and from_clause =
   | TableRef of table_name * Var.var
   | Subquery of query * Var.var
-and sql_like = (* Used to implement 'LIKE' in SQL. Monoidal. *)
+and sql_like =
+  (* Used to implement 'LIKE' in SQL. Monoidal
+   * (with unit `LikeString ""`) . *)
   | LikeString of string
   | LikeProject of Var.var * string
   | LikeAppend of (sql_like * sql_like)
@@ -303,7 +305,7 @@ and pr_base quote one_table ppf b =
         Format.pp_print_string ppf
           ("'" ^ CommonTypes.Constant.escape_string s ^ "'")
     | LikeProject (v, f) ->
-        Format.fprintf ppf "%a.%a"
+        Format.fprintf ppf "%a.\"%a\""
           Format.pp_print_string (string_of_table_var v)
           Format.pp_print_string f
     (* Special case appends with the empty string *)

--- a/database/mysql-driver/mysql_database.ml
+++ b/database/mysql-driver/mysql_database.ml
@@ -246,7 +246,7 @@ let mysql_printer = object (self)
   method quote_field x =
     "`" ^ Str.global_replace (Str.regexp "`") "``" x ^ "`"
 
-  method! pp_sql_like ppf x =
+  method! pp_sql_like one_table ppf x =
     let open Sql in
     (* Flattens monoidal representation into a list of (non-append)
      * SqlLike nodes. *)
@@ -259,7 +259,7 @@ let mysql_printer = object (self)
       | LikeAppend (x, y) -> flatten x @ flatten y
     in
     Format.fprintf ppf "concat(%a)"
-      (self#pp_comma_separated super#pp_sql_like)
+      (self#pp_comma_separated (super#pp_sql_like one_table))
       (flatten x)
 
   (* Infix concatenation is not supported in MySQL; ensure that Links ^^

--- a/database/mysql-driver/mysql_database.ml
+++ b/database/mysql-driver/mysql_database.ml
@@ -246,22 +246,6 @@ let mysql_printer = object (self)
   method quote_field x =
     "`" ^ Str.global_replace (Str.regexp "`") "``" x ^ "`"
 
-  method! pp_sql_like one_table ppf x =
-    let open Sql in
-    (* Flattens monoidal representation into a list of (non-append)
-     * SqlLike nodes. *)
-    let rec flatten = function
-      | LikeString x
-      | LikeAppend (LikeString "", LikeString x)
-      | LikeAppend (LikeString x, LikeString "") -> [LikeString x]
-      | LikeProject (v, f) -> [LikeProject (v, f)]
-      | LikeAppend (LikeString x, LikeString y) -> [LikeString (x ^ y)]
-      | LikeAppend (x, y) -> flatten x @ flatten y
-    in
-    Format.fprintf ppf "concat(%a)"
-      (self#pp_comma_separated (super#pp_sql_like one_table))
-      (flatten x)
-
   (* Infix concatenation is not supported in MySQL; ensure that Links ^^
    * is translated to MySQL concat(-, -) *)
   method! pp_sql_arithmetic ppf one_table (l, op, r) =

--- a/tests/database/regexes.links
+++ b/tests/database/regexes.links
@@ -22,12 +22,23 @@ fun queryBudgets() {
   }
 }
 
+# Tests concatenation
+fun concatDepts() {
+  query flat {
+    for (d <-- depts)
+      [(dept = (d.name ^^ "foo"))]
+  }
+}
+
 fun main() {
   setup();
-  print("Results: " ^^ show(queryBudgets()));
   assertEq(sortBy(fun(x) { x.name }, queryBudgets()),
     [(name = "Alice", dept = "mathematics", coffee_budget = 10000),
      (name = "Bob", dept = "computer science", coffee_budget = 20000),
-     (name = "Carol", dept = "dentistry", coffee_budget = 30000)])
+     (name = "Carol", dept = "dentistry", coffee_budget = 30000)]);
+  assertEq(sortBy(fun(x) { x.dept }, concatDepts()),
+    [(dept = "computer sciencefoo"),
+     (dept ="dentistryfoo"),
+     (dept = "mathematicsfoo")])
 }
 main()

--- a/tests/database/regexes.links
+++ b/tests/database/regexes.links
@@ -1,0 +1,33 @@
+var db = database "links";
+var staff = table "staff" with (name: String, dept: String) from db;
+var depts = table "depts" with (name: String, coffee_budget: Int) from db;
+
+fun setup() {
+  insert staff values (name, dept)
+    [(name = "Alice", dept = "mathematics"),
+     (name = "Bob", dept = "computer science"),
+     (name = "Carol", dept = "dentistry")];
+  insert depts values (name, coffee_budget)
+    [(name = "mathematics", coffee_budget = 10000),
+     (name = "computer science", coffee_budget = 20000),
+     (name = "dentistry", coffee_budget = 30000)]
+}
+
+fun queryBudgets() {
+  query flat {
+    for (s <-- staff)
+      for (d <-- depts)
+      where (d.name =~ /.*{s.dept}.*/)
+      [(name = s.name, dept = d.name, coffee_budget = d.coffee_budget)]
+  }
+}
+
+fun main() {
+  setup();
+  print("Results: " ^^ show(queryBudgets()));
+  assertEq(sortBy(fun(x) { x.name }, queryBudgets()),
+    [(name = "Alice", dept = "mathematics", coffee_budget = 10000),
+     (name = "Bob", dept = "computer science", coffee_budget = 20000),
+     (name = "Carol", dept = "dentistry", coffee_budget = 30000)])
+}
+main()

--- a/tests/database/regexes.sql
+++ b/tests/database/regexes.sql
@@ -1,0 +1,12 @@
+DROP TABLE IF EXISTS staff;
+DROP TABLE IF EXISTS depts;
+
+CREATE TABLE staff (
+    name text,
+    dept text
+);
+
+CREATE TABLE depts (
+    name text,
+    coffee_budget int
+);

--- a/tests/database/testsuite.json
+++ b/tests/database/testsuite.json
@@ -5,6 +5,7 @@
  "setups" :
  [ "factorials",
    "null",
+   "regexes",
    "xpath-reduced",
    "xpath" ],
  "tests" :
@@ -13,6 +14,7 @@
    "empty",
    "emptyfun",
    "null",
+   "regexes",
    "unit",
    "xpath",
    "xpath-reduced" ]

--- a/tests/shredding/jrules.links
+++ b/tests/shredding/jrules.links
@@ -61,10 +61,19 @@ fun marketers2 () {
   }
 }
 
+sig marketers3 : () -> [(name:String, clients:[Int])]
+fun marketers3 () {
+  query nested {
+    for (m <-- marketers_names)
+      [(name=m.name, clients = for (x <-- mc) where (x.m =~ /.*{m.name}.*/ && x.m == "a") [x.c])]
+  }
+}
+
 fun test() {
   assertEq(u(), [((id=1), ["a", "c"]), ((id=2), ["c"]), ((id=3), ["c"]), ((id=42), [])]);
   assertEq(v(), [(name = "a")]);
-  assertEq(marketers2(), [(clients = [1], name = "a"), (clients = [], name = "b"), (clients = [], name = "c")])
+  assertEq(marketers2(), [(clients = [1], name = "a"), (clients = [], name = "b"), (clients = [], name = "c")]);
+  assertEq(marketers3(), [(clients = [1], name = "a"), (clients = [], name = "b"), (clients = [], name = "c")])
 }
 
 test()


### PR DESCRIPTION
# Issue

(Related in part to #754).

Previously, compiled regular expressions failed at runtime. As an example from GtoPdb:

```
for (strI <-- Tables.structural_info)
  where (strI.object_id == objectId && strI.species_id == 2)
  for (al <-- Tables.allele)
    where (strI.official_gene_id <> "" && al.accessions =~ /.*{strI.official_gene_id}.*/)
```

would fail due to the clause

```
al.accessions =~ /.*{strI.official_gene_id}.*/
```

within the `where` clause, since we're including a regular expression which projects from the `strI` table.

# Scope

This patch rectifies the above problem for `LIKE`-translatable queries (but not yet for arbitrary `RLIKE` queries).

# Proposal

To fix this, we need to do two things: generalise the return type of `likeify` to include SQL which allows strings, concatenation, and projection operators; and ensure the nested query translations occur inside regular expressions.