### PR TITLE
Add support for OCaml 4.12

### DIFF
--- a/core/graph.ml
+++ b/core/graph.ml
@@ -4,7 +4,6 @@
 *)
 
 open Utility
-open List
 
 (* Utility function for hashtables *)
 let hashfind_dflt table elem def =
@@ -56,7 +55,7 @@ let hashtbl_as_alist tbl =
     the same type, return a list of all the pairs (u, v) where
     v \in nbhd(u) *)
 let unroll_edges l = concat_map (fun (f, callers) ->
-                                 map (fun caller -> (f, caller))
+                                 List.map (fun caller -> (f, caller))
                                    callers) l
 
 let edge_to_str (u, v) = u ^ "->" ^ v
@@ -97,12 +96,12 @@ let topological_sort' nodes edges =
     List.sort (fun (_,y1) (_,y2) -> - (compare y1 y2)) (hashtbl_as_alist f)
 
 let topological_sort nodes edges =
-  map fst (topological_sort' nodes edges)
+  List.map fst (topological_sort' nodes edges)
 
 
 (* CLR Ex 23.1-3 *)
 let transpose_edges : ('a * 'b) list -> ('b * 'a) list =
-  fun list -> map (fun (x,y) -> (y,x)) list
+  fun list -> List.map (fun (x,y) -> (y,x)) list
 
 let string_of_parent_tree =
   mapstrcat "\n" (function a, None -> a ^ " root"
@@ -142,7 +141,7 @@ let cmp_snd_desc (_,y1) (_,y2) = (- compare y1 y2)
 let strongly_connected_components (nodes : 'a list) (edges : ('a * 'a) list) : 'a list list =
   let f, _, _ = dfs nodes edges in
   let edges_reversed = transpose_edges edges in
-  let nodes_sorted = (map fst (List.sort cmp_snd_desc (hashtbl_as_alist f))) in
+  let nodes_sorted = (List.map fst (List.sort cmp_snd_desc (hashtbl_as_alist f))) in
   let _, _, p = (dfs nodes_sorted edges_reversed) in
     flatten_forest (hashtbl_as_alist p)
 
@@ -159,7 +158,7 @@ let topo_sort_sccs (adj_list : ('a * 'a list) list) : 'a list list =
   (* [scc_of sccs]: lookup (in [sccs]) the scc that [v] belongs to *)
   let scc_of sccs v = List.find (List.mem v) sccs in
 
-  let nodes = map fst adj_list in
+  let nodes = List.map fst adj_list in
     (*  unfold adj_list: let `edges' be the list of all
         (u, v) where (u, v) is an edge in the graph *)
   let edges = unroll_edges adj_list in
@@ -171,7 +170,7 @@ let topo_sort_sccs (adj_list : ('a * 'a list) list) : 'a list list =
     (* Map each such node to its scc, so that we have, for each
        scc, the list of sccs that it points to: *)
   let scc_innodes =
-    alistmap (fun calls -> map (scc_of sccs) calls) scc_innodes in
+    alistmap (fun calls -> List.map (scc_of sccs) calls) scc_innodes in
     (* Now unroll that to get a list of pairs (U, V) where U and V are
        sccs and there is an edge from U to V *)
   let scc_edges = unroll_edges scc_innodes in

--- a/core/lib.ml
+++ b/core/lib.ml
@@ -1,5 +1,4 @@
 open CommonTypes
-open List
 
 open Utility
 open Proc
@@ -142,14 +141,14 @@ let rec less l r =
     | `String l, `String r -> l < r
       (* Compare fields in lexicographic order of labels *)
     | `Record lf, `Record rf ->
-        let order = sort (fun x y -> compare (fst x) (fst y)) in
-        let lv, rv = map snd (order lf), map snd (order rf) in
+        let order = List.sort (fun x y -> compare (fst x) (fst y)) in
+        let lv, rv = List.map snd (order lf), List.map snd (order rf) in
         let rec compare_list = function
           | [] -> false
           | (l,r)::_ when less l r -> true
           | (l,r)::_ when less r l -> false
           | _::rest                -> compare_list rest in
-          compare_list (combine lv rv)
+          compare_list (List.combine lv rv)
     | `List (l), `List (r) -> less_lists (l,r)
     | l, r ->  runtime_error ("Cannot yet compare "^ Value.string_of_value l ^" with "^ Value.string_of_value r)
 and less_lists = function
@@ -585,13 +584,13 @@ let env : (string * (located_primitive * Types.datatype * pure)) list = [
              | (Value.Node _) -> true
              | (Value.NsNode _) -> true
              | _ -> false) children in
-           `List (map (fun x -> `XML x) children)
+           `List (List.map (fun x -> `XML x) children)
          | `List [ `XML (Value.NsNode (_, _, children)) ] ->
            let children = List.filter (function
              | (Value.Node _) -> true
              | (Value.NsNode _) -> true
              | _ -> false) children in
-           `List (map (fun x -> `XML x) children)
+           `List (List.map (fun x -> `XML x) children)
          | _ -> raise (runtime_type_error "non-XML given to childNodes")),
    datatype "(Xml) -> Xml",
   IMPURE);
@@ -819,8 +818,8 @@ let env : (string * (located_primitive * Types.datatype * pure)) list = [
       | Value.NsAttr _ -> true
       | _ -> false
     in match v with
-      | `List [ `XML (Value.Node (_, children)) ]      -> `List (map attr_to_record (filter is_attr children))
-      | `List [ `XML (Value.NsNode (_, _, children)) ] -> `List (map attr_to_record (filter is_attr children))
+      | `List [ `XML (Value.Node (_, children)) ]      -> `List (List.map attr_to_record (List.filter is_attr children))
+      | `List [ `XML (Value.NsNode (_, _, children)) ] -> `List (List.map attr_to_record (List.filter is_attr children))
       | _ -> raise (runtime_type_error "non-element given to getAttributes")),
   datatype "(Xml) ~> [(String,String)]",
   IMPURE);
@@ -838,9 +837,9 @@ let env : (string * (located_primitive * Types.datatype * pure)) list = [
   (p1 (fun v ->
          match v with
            | `List [`XML(Value.Node(_, children))] ->
-               `List (map (fun x -> `XML(x)) (filter (function (Value.Node _) -> true | (Value.NsNode _) -> true | _ -> false) children))
+               `List (List.map (fun x -> `XML(x)) (List.filter (function (Value.Node _) -> true | (Value.NsNode _) -> true | _ -> false) children))
            | `List [`XML(Value.NsNode(_, _, children))] ->
-               `List (map (fun x -> `XML(x)) (filter (function (Value.Node _) -> true | (Value.NsNode _) -> true | _ -> false) children))
+               `List (List.map (fun x -> `XML(x)) (List.filter (function (Value.Node _) -> true | (Value.NsNode _) -> true | _ -> false) children))
            | _ -> raise (runtime_type_error "non-element given to getChildNodes")),
    datatype "(Xml) ~> Xml",
   IMPURE);
@@ -1626,7 +1625,7 @@ let rec function_arity =
     | _ -> None
 
 let primitive_arity (name : string) =
-  let _, t, _ = assoc name env in
+  let _, t, _ = List.assoc name env in
     function_arity t
 
 (*let primitive_by_code var = Env.Int.lookup value_env var*)


### PR DESCRIPTION
OCaml 4.12 added `List.compare` which conflicts with the use of `compare` in those modules where the `List` module is opened.