### PR TITLE
WIP: attempt to fix issue 773

### DIFF
--- a/core/frontend.ml
+++ b/core/frontend.ml
@@ -200,8 +200,8 @@ module Typeability_preserving = struct
 
   (* Collection of transformers. *)
   let transformers : transformer array
-    = [| (module DesugarCP)
-       ; (module DesugarInners)
+    = [| (module DesugarInners) (* this must always be done first after type inference *)
+       ; (module DesugarCP)
        ; only_if
            Basicsettings.Sessions.exceptions_enabled
            (module DesugarSessionExceptions)


### PR DESCRIPTION
Not to be merged, we should have tests exercising `desugarCP` and any interactions with `desugarInners` first.  Would close #773.