### PR TITLE
Constrain Links version in links-{mysql,mysql8,postgresql}.opam

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -43,10 +43,7 @@ before_install:
   - mysql -e "GRANT ALL ON $DBNAME.* TO $DBUSER;"
   - mysql -e "FLUSH PRIVILEGES;"
 script:
-  - opam install ./links.opam --deps-only
-  - opam install ./links-postgresql --deps-only
-  - opam install ./links-sqlite3 --deps-only
-  - opam install ./links-mysql8 --deps-only
+  - opam install ./links.opam ./links-postgresql.opam ./links-sqlite3.opam ./links-mysql8.opam --deps-only --ignore-constraints-on=links
   - make doc
   - make all-ci
   - make tests

--- a/.travis.yml
+++ b/.travis.yml
@@ -43,10 +43,10 @@ before_install:
   - mysql -e "GRANT ALL ON $DBNAME.* TO $DBUSER;"
   - mysql -e "FLUSH PRIVILEGES;"
 script:
-  - opam pin add links . -y
-  - opam pin add links-postgresql . -y
-  - opam pin add links-sqlite3 . -y
-  - opam pin add links-mysql8 . -y
+  - opam install ./links.opam --deps-only
+  - opam install ./links-postgresql --deps-only
+  - opam install ./links-sqlite3 --deps-only
+  - opam install ./links-mysql8 --deps-only
   - make doc
   - make all-ci
   - make tests

--- a/.travis.yml
+++ b/.travis.yml
@@ -43,7 +43,7 @@ before_install:
   - mysql -e "GRANT ALL ON $DBNAME.* TO $DBUSER;"
   - mysql -e "FLUSH PRIVILEGES;"
 script:
-  - opam install ./links.opam ./links-postgresql.opam ./links-sqlite3.opam ./links-mysql8.opam --deps-only --ignore-constraints-on=links
+  - opam install ./links.opam ./links-postgresql.opam ./links-sqlite3.opam ./links-mysql8.opam -y --deps-only --ignore-constraints-on=links
   - make doc
   - make all-ci
   - make tests

--- a/links-mysql.opam
+++ b/links-mysql.opam
@@ -18,5 +18,5 @@ depends: [
   "dune" {>= "1.10.0"}
   "conf-mysql"
   "mysql"
-  "links"
+  "links" {= version}
 ]

--- a/links-mysql8.opam
+++ b/links-mysql8.opam
@@ -1,8 +1,8 @@
 opam-version: "2.0"
 maintainer: "James Cheney <jcheney@inf.ed.ac.uk>"
 authors: "The Links Team <links-dev@inf.ed.ac.uk>"
-synopsis: "MySQL database driver for the Links Programming Language"
-description: "MySQL database driver for the Links Programming Language"
+synopsis: "MySQL8 database driver for the Links Programming Language"
+description: "MySQL8 database driver for the Links Programming Language"
 homepage: "https://github.com/links-lang/links"
 dev-repo: "git+https://github.com/links-lang/links.git"
 bug-reports: "https://github.com/links-lang/links/issues"
@@ -18,5 +18,5 @@ depends: [
   "dune" {>= "1.10.0"}
   "conf-mysql"
   "mysql8"
-  "links"
+  "links" {= version}
 ]

--- a/links-postgresql.opam
+++ b/links-postgresql.opam
@@ -18,5 +18,5 @@ depends: [
   "ocaml" {>= "4.08.0"}
   "dune" {>= "1.10.0"}
   "postgresql"
-  "links"
+  "links" {= version}
 ]


### PR DESCRIPTION
Required to release `links` and `links-{mysql,postgresql,sqlite3}` (and also `links-mysql8`) simultaneously. C.f. ocaml/opam-repository#18781.