### PR TITLE
Permissive escape bodies

### DIFF
--- a/core/parser.mly
+++ b/core/parser.mly
@@ -746,7 +746,7 @@ perhaps_orderby:
 | ORDERBY LPAREN exps RPAREN                                   { Some (orderby_tuple ~ppos:$loc($3) $3) }
 
 escape_expression:
-| ESCAPE VARIABLE IN postfix_expression                        { with_pos $loc (Escape (binder ~ppos:$loc($2) $2, $4)) }
+| ESCAPE VARIABLE IN exp                        { with_pos $loc (Escape (binder ~ppos:$loc($2) $2, $4)) }
 
 formlet_expression:
 | FORMLET xml YIELDS exp                                       { with_pos $loc (Formlet ($2, $4)) }

--- a/tests/continuations.tests
+++ b/tests/continuations.tests
@@ -35,5 +35,29 @@ stdout : 1 : Int
 
 continuation mailbox typing (see r321)
 fun () {(escape e in {spawn { e(self()) }}) ! ""; 1 + recv(); }
-stderr : @..*
 exit : 1
+stderr : @..*
+
+Escape body [1]
+escape k in A
+stdout : A : [|A|_::Any|]
+
+Escape body [2]
+escape k in A(k)
+stdout : A(Continuationpure_continuation) : [|A:(mu a . [|A:(a) ~b~> c::Any|d::Any|]) ~b~> c::Any|d::Any|]
+
+Escape body [3]
+escape k in switch (A) { case A -> 0 case B -> 1 }
+stdout : 0 : Int
+
+Escape body [4]
+escape k in ()
+stdout : () : ()
+
+Escape body [5]
+escape k in (foo="bar",quux=Just(k((foo="baz",quux=Nothing))))
+stdout : (foo = "baz", quux = Nothing) : (foo:String,quux:[|Just:_::Any|Nothing|_::Any|])
+
+Escape body [6]
+escape k in 2 + 40
+stdout : 42 : Int


### PR DESCRIPTION
This patch allows the body of an escape expression to be any syntactic
expression.

Resolves #921.