### PR TITLE
Bump Links version to 0.9.4

### DIFF
--- a/core/basicsettings.ml
+++ b/core/basicsettings.ml
@@ -7,7 +7,7 @@ let interactive_mode =
             |> sync)
 
 (** The banner *)
-let version = "0.9.3 (Burghmuirhead)"
+let version = "0.9.4 (Burghmuirhead)"
 let version = Settings.(option ~default:(Some version) ~readonly:true "version"
                         |> privilege `System
                         |> synopsis "Print version and exit"

--- a/links.opam
+++ b/links.opam
@@ -7,7 +7,7 @@ homepage: "https://github.com/links-lang/links"
 dev-repo: "git+https://github.com/links-lang/links.git"
 bug-reports: "https://github.com/links-lang/links/issues"
 license: "GPL-2"
-version: "0.9.3"
+version: "0.9.4"
 
 
 build: [


### PR DESCRIPTION
Links 0.9.3 has been released. This commit bumps the development version of Links to 0.9.4.