### PR TITLE
[Experiment] Run interpreter testsuite on ubuntu-latest and macos-latest

### DIFF
--- a/.github/workflows/default.yml
+++ b/.github/workflows/default.yml
@@ -145,17 +145,11 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v2
 
-      - name: Install system dependencies
-        if: matrix.os == 'ubuntu-latest'
-        run: sudo apt-get install -y libev-dev
-        shell: bash
-
       - name: Use OCaml ${{ matrix.ocaml-compiler }}
         uses: ocaml/setup-ocaml@v2
         with:
           ocaml-compiler: ${{ matrix.ocaml-compiler }}
 
-      - run: opam install -y conf-libev
       - run: opam install -y ounit2
 
       - name: Install Links dependencies

--- a/.github/workflows/default.yml
+++ b/.github/workflows/default.yml
@@ -69,7 +69,8 @@ jobs:
       fail-fast: false
       matrix:
         os:
-          - ubuntu-20.04
+          - ubuntu-latest
+          - macos-latest
         ocaml-compiler:
           - 4.08.0
 
@@ -145,6 +146,7 @@ jobs:
         uses: actions/checkout@v2
 
       - name: Install system dependencies
+        if: matrix.os == 'ubuntu-latest'
         run: sudo apt-get install -y libev-dev
         shell: bash
 


### PR DESCRIPTION
This patch extends the operating system matrix for the interpreter job with `macos-latest`. In addition it changes `ubuntu-20.04` to `ubuntu-latest` since the interpreter should not be sensitive to system dependencies.