### PR TITLE
Move the function `tt` to typeUtils.ml

### DIFF
--- a/core/desugarFormlets.ml
+++ b/core/desugarFormlets.ml
@@ -19,11 +19,6 @@ let rec is_raw phrase =
         ~stage:DesugarFormlets
         ~message:"Invalid element in formlet literal")
 
-let tt =
-  function
-    | [t] -> t
-    | ts -> Types.make_tuple_type ts
-
 let xml_str           = "xml"
 let pure_str          = "pure"
 let plug_str          = "plug"
@@ -98,7 +93,7 @@ object (o : 'self_type)
               in
               let vs, ts = List.rev vs', List.rev ts' in
 
-              (* Given (f1 -> v1 : t1) ... (fn -> vn : tt), we generate a term of the form
+              (* Given (f1 -> v1 : t1) ... (fn -> vn : tn), we generate a term of the form
                  (@@@)(f1, ... (@@@)(fn)(pure (fun(pn : tn)...(p1 : t1) { (p1, ..., pn) }))).
 
                  Thus we generate a function with the arguments in reverse, but the variables
@@ -107,7 +102,7 @@ object (o : 'self_type)
               let ft =
                 List.fold_right
                   (fun t ft -> Types.Function (Types.make_tuple_type [t], closed_wild, ft))
-                  ts' (tt ts) in
+                  ts' (TypeUtils.pack_types ts) in
               let open PrimaryKind in
               begin
                   match vs with
@@ -173,7 +168,7 @@ object (o : 'self_type)
             | [p] -> [[p]]
             | _ -> [[tuple_pat ps]] in
 
-        let arg_type = tt ts in
+        let arg_type = TypeUtils.pack_types ts in
         let open PrimaryKind in
         let e =
           fn_appl_node atatat_str

--- a/core/desugarFors.ml
+++ b/core/desugarFors.ml
@@ -45,10 +45,6 @@ open SugarConstructors.DummyPositions
     (q; qs)_v = (q_v, qs_v)
 *)
 
-let tt = function
-  | [t] -> t
-  | ts -> Types.make_tuple_type ts
-
 (**
   This function generates the code to extract the results.
   It roughly corresponds to [[qs]].
@@ -64,7 +60,7 @@ let results :  Types.row ->
         | (e::es, x::xs, t::ts) ->
             let r = results (es, xs, ts) in
             let qt = t in
-            let qst = tt ts in
+            let qst = TypeUtils.pack_types ts in
 
             let ((qsb, qs) : Sugartypes.Pattern.with_pos list * Sugartypes.phrase list) =
               List.split
@@ -77,7 +73,7 @@ let results :  Types.row ->
                 match qsb with
                   | [p] -> [p]
                   | _ -> [tuple_pat qsb] in
-              let a = Types.make_tuple_type [tt ts] in
+              let a = Types.make_tuple_type [TypeUtils.pack_types ts] in
               fun_lit ~args:[a, eff] dl_unl [ps] (tuple (q::qs)) in
             let outer : Sugartypes.phrase =
               let a = Types.make_tuple_type (t :: ts) in
@@ -162,7 +158,7 @@ object (o : 'self_type)
             | [p] -> [p]
             | ps -> [tuple_pat ps] in
 
-        let arg_type = tt ts in
+        let arg_type = TypeUtils.pack_types ts in
 
         let f : phrase = fun_lit ~args:[Types.make_tuple_type [arg_type], eff]
                                  dl_unl [arg] body in

--- a/core/typeUtils.ml
+++ b/core/typeUtils.ml
@@ -441,3 +441,7 @@ let row_present_types t =
         match v with
           | Present t -> Some t
           | _ -> None)
+
+let pack_types : Types.datatype list -> Types.datatype = function
+  | [t] -> t
+  | ts -> Types.make_tuple_type ts

--- a/core/typeUtils.mli
+++ b/core/typeUtils.mli
@@ -45,3 +45,5 @@ val primary_kind_of_type : Types.datatype -> PrimaryKind.t
 val check_type_wellformedness : PrimaryKind.t option -> Types.datatype -> unit
 
 val row_present_types : Types.datatype -> Types.datatype Utility.StringMap.t
+
+val pack_types : Types.datatype list -> Types.datatype


### PR DESCRIPTION
The function `tt` is duplicated in `desugarFormlets.ml` and `desugarFors.ml`. This patch moves the definition of `tt` to `typeUtils.ml` and renames it to `pack_types`.