### PR TITLE
Consolidate primitive row labels and type information

### DIFF
--- a/core/commonTypes.ml
+++ b/core/commonTypes.ml
@@ -209,6 +209,11 @@ module Name = struct
     [@@deriving show]
 end
 
+module Label = struct
+  type t = string
+    [@@deriving show]
+end
+
 module ForeignLanguage = struct
   type t =
     | JavaScript

--- a/core/desugarFormlets.ml
+++ b/core/desugarFormlets.ml
@@ -29,8 +29,6 @@ let pure_str          = "pure"
 let plug_str          = "plug"
 let atatat_str        = "@@@"
 
-let closed_wild = Types.row_with ("wild", Types.Present Types.unit_type) (Types.make_empty_closed_row ())
-
 class desugar_formlets env =
 object (o : 'self_type)
   inherit (TransformSugar.transform env) as super
@@ -106,7 +104,7 @@ object (o : 'self_type)
                *)
               let ft =
                 List.fold_right
-                  (fun t ft -> Types.Function (Types.make_tuple_type [t], closed_wild, ft))
+                  (fun t ft -> Types.Function (Types.make_tuple_type [t], Types.closed_wild_row, ft))
                   ts' (tt ts) in
               let open PrimaryKind in
               begin
@@ -117,7 +115,7 @@ object (o : 'self_type)
                          fn_appl ~ppos xml_str [Row, o#lookup_effects] [with_dummy_pos e],
                          Types.unit_type)
                     | _ ->
-                        let args = List.map (fun t -> (Types.make_tuple_type [t], closed_wild)) ts' in
+                        let args = List.map (fun t -> (Types.make_tuple_type [t], Types.closed_wild_row)) ts' in
                         let (o, es, _) = TransformSugar.list o (fun o -> o#formlet_body) contents in
                         let eff = o#lookup_effects in
                         let base : phrase =
@@ -146,7 +144,7 @@ object (o : 'self_type)
               let context : phrase =
                 let name = Utility.gensym ~prefix:"_formlet_" () in
                 fun_lit ~ppos
-                        ~args:[Types.make_tuple_type [Types.xml_type], closed_wild]
+                        ~args:[Types.make_tuple_type [Types.xml_type], Types.closed_wild_row]
                         dl_unl
                         [[variable_pat ~ty:(Types.xml_type) name]]
                         (xml tag attrs attrexp [block ([], var name)]) in
@@ -164,7 +162,7 @@ object (o : 'self_type)
         let (ps, _, ts) = o#formlet_patterns body in
         let (o, body, _body_type) = o#formlet_body body in
         let (o, ps) = TransformSugar.listu o (fun o -> o#pattern) ps in
-        let o = o#with_effects closed_wild in
+        let o = o#with_effects Types.closed_wild_row in
         let (o, yields, yields_type) = o#phrase yields in
         let o = o#with_effects eff in
 
@@ -179,9 +177,9 @@ object (o : 'self_type)
           fn_appl_node atatat_str
              [(Type, arg_type); (Type, yields_type); (Row, eff)]
              [body; fn_appl pure_str
-                      [(Type, Types.Function (Types.make_tuple_type [arg_type], closed_wild, yields_type));
+                      [(Type, Types.Function (Types.make_tuple_type [arg_type], Types.closed_wild_row, yields_type));
                        (Row, eff)]
-                    [fun_lit ~args:[Types.make_tuple_type [arg_type], closed_wild] dl_unl pss yields]] in
+                    [fun_lit ~args:[Types.make_tuple_type [arg_type], Types.closed_wild_row] dl_unl pss yields]] in
         (o, e, Instantiate.alias "Formlet" [(Type, yields_type)] tycon_env)
     | e -> super#phrasenode e
 end

--- a/core/desugarPages.ml
+++ b/core/desugarPages.ml
@@ -9,8 +9,6 @@ let raise_invalid_element pos =
   raise (desugaring_error ~pos ~stage:DesugarPages
     ~message:"Invalid element in page literal")
 
-let closed_wild = Types.make_singleton_closed_row ("wild", Types.Present Types.unit_type)
-
 let rec is_raw phrase =
   match phrase.node with
   | TextNode _ -> true
@@ -60,7 +58,7 @@ let rec desugar_page (o, page_type) =
         | Xml (name, attrs, dynattrs, children) ->
             let x = Utility.gensym ~prefix:"xml" () in
             fn_appl "plugP" [(PrimaryKind.Row, o#lookup_effects)]
-               [fun_lit ~args:[Types.make_tuple_type [Types.xml_type], closed_wild]
+               [fun_lit ~args:[Types.make_tuple_type [Types.xml_type], Types.closed_wild_row]
                         dl_unl [[variable_pat ~ty:Types.xml_type x]]
                         (xml name attrs dynattrs [block ([], var x)]);
                 desugar_nodes children]

--- a/core/lib.ml
+++ b/core/lib.ml
@@ -1600,7 +1600,7 @@ let type_env : Types.environment =
 let typing_env = {Types.var_env = type_env;
                   Types.rec_vars = StringSet.empty;
                   tycon_env = alias_env;
-                  Types.effect_row = Types.make_singleton_closed_row ("wild", Types.(Present unit_type));
+                  Types.effect_row = Types.closed_wild_row;
                   Types.desugared = false }
 
 let primitive_names = StringSet.elements (Env.String.domain type_env)

--- a/core/sugarConstructors.ml
+++ b/core/sugarConstructors.ml
@@ -118,8 +118,8 @@ module SugarConstructors (Position : Pos)
   (** Fieldspec *)
 
   let present        = Datatype.Present (WithPos.dummy Datatype.Unit)
-  let wild_present   = ("wild", present)
-  let hear_present p = ("hear", Datatype.Present p)
+  let wild_present   = (Types.wild, present)
+  let hear_present p = (Types.hear, Datatype.Present p)
 
 
   (** Rows *)

--- a/core/typeSugar.ml
+++ b/core/typeSugar.ml
@@ -2539,7 +2539,7 @@ let rec type_check : context -> phrase -> phrase * Types.datatype * Usage.t =
       (* register wildness if this is a recursive variable instance *)
       if StringSet.mem v context.rec_vars then
         begin
-          let wild_open = Types.make_singleton_open_row ("wild", Types.Present Types.unit_type) default_effect_subkind in
+          let wild_open = Types.(open_row default_effect_subkind closed_wild_row) in
           unify ~handle:Gripers.recursive_usage (no_pos (Types.Effect wild_open), (uexp_pos e, Types.Effect context.effect_row));
         end;
     in
@@ -2910,7 +2910,7 @@ let rec type_check : context -> phrase -> phrase * Types.datatype * Usage.t =
             (* delete is wild *)
             let () =
               let outer_effects =
-                Types.make_singleton_open_row ("wild", T.Present Types.unit_type) default_effect_subkind
+                Types.(open_row default_effect_subkind closed_wild_row)
               in
                 unify ~handle:Gripers.delete_outer
                   (no_pos (T.Record context.effect_row), no_pos (T.Record outer_effects))
@@ -2988,7 +2988,7 @@ let rec type_check : context -> phrase -> phrase * Types.datatype * Usage.t =
             (* insert is wild *)
             let () =
               let outer_effects =
-                Types.make_singleton_open_row ("wild", T.Present Types.unit_type) default_effect_subkind
+                Types.(open_row default_effect_subkind closed_wild_row)
               in
                 unify ~handle:Gripers.insert_outer
                   (no_pos (T.Record context.effect_row), no_pos (T.Record outer_effects))
@@ -3052,7 +3052,7 @@ let rec type_check : context -> phrase -> phrase * Types.datatype * Usage.t =
             (* update is wild *)
             let () =
               let outer_effects =
-                Types.make_singleton_open_row ("wild", T.Present Types.unit_type) default_effect_subkind
+                Types.(open_row default_effect_subkind closed_wild_row)
               in
                 unify ~handle:Gripers.update_outer
                   (no_pos (T.Record context.effect_row), no_pos (T.Record outer_effects))
@@ -3071,7 +3071,7 @@ let rec type_check : context -> phrase -> phrase * Types.datatype * Usage.t =
                     let offset = tc offset in
                     let () = unify ~handle:Gripers.range_bound (pos_and_typ offset, no_pos Types.int_type) in
                     let outer_effects =
-                      Types.make_singleton_open_row ("wild", T.Present Types.unit_type) default_effect_subkind
+                      Types.(open_row default_effect_subkind closed_wild_row)
                     in
                     Some (erase limit, erase offset), outer_effects, Usage.combine (usages limit) (usages offset)
             in
@@ -3099,7 +3099,7 @@ let rec type_check : context -> phrase -> phrase * Types.datatype * Usage.t =
             (* let pid_type = Application (Types.process, [Row inner_effects]) in *)
             let () =
               let outer_effects =
-                Types.make_singleton_open_row ("wild", T.Present Types.unit_type) default_effect_subkind
+                Types.(open_row default_effect_subkind closed_wild_row)
               in
                 unify ~handle:Gripers.spawn_wait_outer
                   (no_pos (T.Record context.effect_row), no_pos (T.Record outer_effects)) in
@@ -3133,7 +3133,7 @@ let rec type_check : context -> phrase -> phrase * Types.datatype * Usage.t =
                wild | e }] (and maybe SessionFail) (call this "inner_effects"), and
                then use e (pid_effects) as the type argument to the process.
              *)
-            let inner_effects = Types.row_with ("wild", T.Present Types.unit_type) pid_effects in
+            let inner_effects = Types.row_with Types.wild_present pid_effects in
             let inner_effects =
               if Settings.get  Basicsettings.Sessions.exceptions_enabled then
                 let ty = Types.make_pure_function_type [] (Types.empty_type) in
@@ -3143,7 +3143,7 @@ let rec type_check : context -> phrase -> phrase * Types.datatype * Usage.t =
             let pid_type = T.Application (Types.process, [PrimaryKind.Row, pid_effects]) in
             let () =
               let outer_effects =
-                Types.make_singleton_open_row ("wild", T.Present Types.unit_type) default_effect_subkind
+                Types.(open_row default_effect_subkind closed_wild_row)
               in
                 unify ~handle:Gripers.spawn_outer
                   (no_pos (T.Record context.effect_row), no_pos (T.Record outer_effects)) in
@@ -3166,9 +3166,8 @@ let rec type_check : context -> phrase -> phrase * Types.datatype * Usage.t =
         | Receive (binders, _) ->
             let mb_type = Types.fresh_type_variable (lin_any, res_any) in
             let effects =
-              Types.row_with ("wild", T.Present Types.unit_type)
-                (Types.make_singleton_open_row ("hear", T.Present mb_type) default_effect_subkind) in
-
+              Types.(open_row default_effect_subkind (row_with (hear_present mb_type) closed_wild_row))
+            in
             let () = unify ~handle:Gripers.receive_mailbox
               (no_pos (T.Record context.effect_row), no_pos (T.Record effects)) in
 
@@ -3222,8 +3221,8 @@ let rec type_check : context -> phrase -> phrase * Types.datatype * Usage.t =
         | RangeLit (l, r) ->
             let l, r = tc l, tc r in
             let outer_effects =
-              Types.make_singleton_open_row ("wild", T.Present Types.unit_type)
-                                            default_effect_subkind in
+              Types.(open_row default_effect_subkind closed_wild_row)
+            in
             let () = unify ~handle:Gripers.range_bound  (pos_and_typ l,
                                                          no_pos Types.int_type)
             and () = unify ~handle:Gripers.range_bound  (pos_and_typ r,
@@ -3392,8 +3391,7 @@ let rec type_check : context -> phrase -> phrase * Types.datatype * Usage.t =
            let body = type_check context body in
            let env = extract_formlet_bindings (erase body) in
            let vs = Env.domain env in
-           let closed_wild = Types.make_singleton_closed_row ("wild", T.Present Types.unit_type) in
-           let context' = { context with effect_row = closed_wild } ++ env in
+           let context' = { context with effect_row = Types.closed_wild_row } ++ env in
            let yields = type_check context' yields in
            unify ~handle:Gripers.formlet_body (pos_and_typ body, no_pos Types.xml_type);
            (Formlet (erase body, erase yields),
@@ -3525,7 +3523,7 @@ let rec type_check : context -> phrase -> phrase * Types.datatype * Usage.t =
             let f = Types.fresh_type_variable (lin_any, res_any) in
             let t = Types.fresh_type_variable (lin_any, res_any) in
 
-            let eff = Types.make_singleton_open_row ("wild", T.Present Types.unit_type) default_effect_subkind in
+            let eff = Types.(open_row default_effect_subkind closed_wild_row) in
 
             let cont_type = T.Function (Types.make_tuple_type [f], eff, t) in
             let context' = {context
@@ -3534,7 +3532,7 @@ let rec type_check : context -> phrase -> phrase * Types.datatype * Usage.t =
 
             let () =
               let outer_effects =
-                Types.make_singleton_open_row ("wild", T.Present Types.unit_type) default_effect_subkind
+                Types.(open_row default_effect_subkind closed_wild_row)
               in
                 unify ~handle:Gripers.escape_outer
                   (no_pos (T.Record context.effect_row), no_pos (T.Record outer_effects)) in
@@ -3684,9 +3682,8 @@ let rec type_check : context -> phrase -> phrase * Types.datatype * Usage.t =
            in
            (* allow_wild adds wild : () to the given effect row *)
            let allow_wild : Types.row -> Types.row
-         = fun row ->
-           let fields = StringMap.add "wild" Types.unit_type StringMap.empty in
-           Types.extend_row fields row
+             = fun row ->
+             Types.(row_with wild_present row)
            in
            (* returns a pair of lists whose first component is the
                value clauses, while the second component is the
@@ -4670,7 +4667,7 @@ and type_cp (context : context) = fun {node = p; pos} ->
 
   let unify ~pos ~handle (t, u) = unify_or_raise ~pos:pos ~handle:handle (("<unknown>", t), ("<unknown>", u)) in
 
-  let wild_open = Types.make_singleton_open_row ("wild", Types.Present Types.unit_type) default_effect_subkind in
+  let wild_open = Types.(open_row default_effect_subkind closed_wild_row) in
   unify ~pos ~handle:Gripers.cp_wild (Types.Effect wild_open, Types.Effect context.effect_row);
 
   let module T = Types in

--- a/core/typeUtils.ml
+++ b/core/typeUtils.ml
@@ -208,9 +208,8 @@ let is_function_type t = match concrete_type t with
 let is_thunk_type t =
   is_function_type t && arg_types t = []
 
-let is_builtin_effect = function
-  | "wild" | "hear" -> true
-  | _ -> false
+let is_builtin_effect lbl =
+  lbl = Types.wild || lbl = Types.hear
 
 let rec element_type ?(overstep_quantifiers=true) t = match (concrete_type t, overstep_quantifiers) with
   | (ForAll (_, t), true) -> element_type t
@@ -441,3 +440,7 @@ let row_present_types t =
         match v with
           | Present t -> Some t
           | _ -> None)
+
+let from_present : Types.field_spec -> Types.datatype = function
+  | Present t -> t
+  | _ -> raise Types.tag_expectation_mismatch

--- a/core/typeUtils.mli
+++ b/core/typeUtils.mli
@@ -45,3 +45,5 @@ val primary_kind_of_type : Types.datatype -> PrimaryKind.t
 val check_type_wellformedness : PrimaryKind.t option -> Types.datatype -> unit
 
 val row_present_types : Types.datatype -> Types.datatype Utility.StringMap.t
+
+val from_present : Types.field_spec -> Types.datatype

--- a/core/types.ml
+++ b/core/types.ml
@@ -2806,13 +2806,15 @@ let extend_row fields row =
   fst (extend_row_check_duplicates fields row)
 
 let open_row subkind = function
-  | Row (fieldenv, _, dual) ->
+  | Row (fieldenv, rho, dual) when rho = closed_row_var ->
      Row (fieldenv, fresh_row_variable subkind, dual)
+  | Row _ -> raise (internal_error "attempt to open an already open row")
   | _ -> raise tag_expectation_mismatch
 
 let close_row = function
-  | Row (fieldenv, _, dual) ->
+  | Row (fieldenv, rho, dual) when rho <> closed_row_var ->
      Row (fieldenv, closed_row_var, dual)
+  | Row _ -> raise (internal_error "attempt to close an already closed row")
   | _ -> raise tag_expectation_mismatch
 
 let closed_wild_row = make_singleton_closed_row wild_present

--- a/core/types.mli
+++ b/core/types.mli
@@ -201,6 +201,10 @@ val float_type : datatype
 val database_type : datatype
 val xml_type : datatype
 val empty_type : datatype
+val wild : Label.t
+val hear : Label.t
+val wild_present : Label.t * datatype
+val hear_present : datatype -> (Label.t * datatype)
 
 (** get type variables *)
 val free_type_vars : datatype -> TypeVarSet.t
@@ -269,6 +273,10 @@ val make_closed_row : datatype field_env -> row
 val row_with : (string * field_spec) -> row -> row
 val extend_row : datatype field_env -> row -> row
 val extend_row_safe : datatype field_env -> row -> row option
+val open_row : Subkind.t -> row -> row
+val close_row : row -> row
+val closed_wild_row : row
+val remove_field : ?idempotent:bool -> Label.t -> row -> row
 
 (** constants *)
 val empty_field_env : field_spec_map


### PR DESCRIPTION
 Consolidate primitive row labels and type information.
    
 This patch removes every handcrafted row with wild and hear labels in
 favour of using a more structured approach based on a set of new
 primitives for working with rows and labels. Specifically, this patch
 extends the interface of `Types` with the following operations.
    
  * `hear`: primitive label hear
  * `wild`: primitive label wild
  * `hear_present`: constructs a present hear field spec.
  * `wild_present`: constructs a present wild field spec.
  * `closed_wild_row`: a closed row with the primitive wild label present.
  * `open_row`: opens a closed row.
  * `close_row`: closes an open row.
  * `remove_field`: removes a field from a row.