### PR TITLE
Fix test-harness silently failing when config file provided in header

### DIFF
--- a/test-harness
+++ b/test-harness
@@ -216,18 +216,17 @@ def main():
         # enqueues execution of
         # evaluate(name, code, config_file, **opts)
         # in the thread pool
-        jobs.append(tp.submit(evaluate, name, code, config_file, **opts))
+        jobs.append((name, tp.submit(evaluate, name, code, config_file, **opts)))
 
     # Wait for all jobs to finish
     tp.shutdown(wait=True)
 
     # Check that none of the jobs raised an exception:
-    exceptions = [ j.exception() for j in jobs ]
-    if any(exceptions):
-      raise SystemExit(("Error: One of the test jobs failed to execute, producing"
-                        "the following exception:\n%s")
-                       % next(iter(exceptions)))
-
+    for (job_name, result) in jobs:
+        if result.exception():
+            raise SystemExit(("Error: Test \"%s\" failed to execute, producing "
+                              "the following exception:\n%s")
+                             % (job_name, result.exception()))
 
     print("%d failures (+%d ignored)\n%d successes\n" % (failures, ignored, successes))
     if failures > 0:

--- a/test-harness
+++ b/test-harness
@@ -201,7 +201,12 @@ def main():
     header = next(stream)
     if config_file == None and "config" in header:
         config_file = header["config"]
+        # Must remove the "config" key because we combine the header-provided
+        # options with the  per-file ones later on. However, the global config
+        # file must be provided via the config_file parameter of evaluate only.
+        del header["config"]
 
+    jobs = []
     # Process the body.
     for name, code, opts in stream:
         # Combines the options set in the header with the ones specific to this
@@ -211,10 +216,18 @@ def main():
         # enqueues execution of
         # evaluate(name, code, config_file, **opts)
         # in the thread pool
-        tp.submit(evaluate, name, code, config_file, **opts)
+        jobs.append(tp.submit(evaluate, name, code, config_file, **opts))
 
     # Wait for all jobs to finish
     tp.shutdown(wait=True)
+
+    # Check that none of the jobs raised an exception:
+    exceptions = [ j.exception() for j in jobs ]
+    if any(exceptions):
+      raise SystemExit(("Error: One of the test jobs failed to execute, producing"
+                        "the following exception:\n%s")
+                       % next(iter(exceptions)))
+
 
     print("%d failures (+%d ignored)\n%d successes\n" % (failures, ignored, successes))
     if failures > 0:

--- a/test-harness
+++ b/test-harness
@@ -202,7 +202,7 @@ def main():
     if config_file == None and "config" in header:
         config_file = header["config"]
         # Must remove the "config" key because we combine the header-provided
-        # options with the  per-file ones later on. However, the global config
+        # options with the per-file ones later on. However, the global config
         # file must be provided via the config_file parameter of evaluate only.
         del header["config"]
 


### PR DESCRIPTION
Commit bacc5e2e930ab7453f6d7ea6bcac48457e3e22c8 introduced a bug into `test-harness` that made all .tests files with a header containing a config file fail silently.

This PR fixes the concrete bug causing the exception in `test-harness` and adds logic for detecting such exceptions in the future (instead of the ignoring them and considering the test as passed).

