### PR TITLE
In DesugarInners, don't patch already frozen variables

### DIFF
--- a/core/desugarInners.ml
+++ b/core/desugarInners.ml
@@ -90,9 +90,8 @@ object (o : 'self_type)
 
   method! phrasenode = function
     | (Var name as e)
-    | (FreezeVar name as e)
     | (Section (Section.Name name) as e)
-    | (FreezeSection (Section.Name name) as e)
+
          when StringMap.mem name extra_env ->
        let tyargs = o#add_extras name [] in
        let o = o#unbind name in

--- a/tests/freezeml.tests
+++ b/tests/freezeml.tests
@@ -230,3 +230,29 @@ stderr : @.*Type error:.*
 Nested forall
 var x = auto(~id); x(42)
 stdout : 42 : Int
+
+Recursive functions have monomorphic inner types
+mutual { sig f : forall a. (a) {}-> () fun f(x) {()}    fun g(x) {g(~f)} }
+exit : 1
+stderr : @.*Type error:.*
+
+Generalization of recursive functions
+mutual { sig f : forall a. (a) {}-> () fun f(x) {()}    fun g(x) {x} } g(~f)
+exit : 0
+stdout : fun : forall a.(a) {}-> ()
+
+Freezing recursive function inside mutual block, with annotation
+mutual { sig f : forall a. (a) {}-> () fun f(x) {()}    fun g(x: (forall a. (a) {}-> ())) {g(~f)} }
+stdout : () : ()
+
+Freezing recursive function inside mutual block, without annotation
+mutual { fun f(x) {()}    fun g(x) {g(~f); ()} } ~g
+stdout : fun : forall a,b::Row,c::Row.((a) -b-> ()) ~c~> ()
+
+Freezing recursive function outside mutual block, with annotation
+mutual { sig f : forall a. (a) {}-> () fun f(x) {()} } ~f
+stdout : fun : forall a.(a) {}-> ()
+
+Freezing recursive function outside mutual block, without annotation
+mutual { fun f(x) {()} } ~f
+stdout : fun : forall a,b::Row.(a) -b-> ()


### PR DESCRIPTION
In DesugarInners, within a group of recursive functions, calls to such a polymorphic, recursive function `f` are modified to type applications of the form `~f [T1, ... , Tn]`, where the Ti are appropriate type arguments. This is to accommodate the fact that in `TypeSugar`, the functions are not considered polymorphic, yet.

However, the existing logic had a bug where already frozen usages of `f` (i.e., `~f`) were also transformed into type applications.