### PR TITLE
Surface syntax for Mono restriction.

### DIFF
--- a/core/parser.mly
+++ b/core/parser.mly
@@ -75,6 +75,7 @@ let restriction_of_string p =
   | "Any"     -> res_any
   | "Base"    -> res_base
   | "Session" -> res_session
+  | "Mono"    -> res_mono
   | rest      ->
      raise (ConcreteSyntaxError (pos p, "Invalid kind restriction: " ^ rest))
 
@@ -1092,10 +1093,6 @@ nonrec_row_var:
 | UNDERSCORE                                                   { Datatype.Open (fresh_typevar `Rigid)    }
 | PERCENT                                                      { Datatype.Open (fresh_typevar `Flexible) }
 
-/* FIXME:
- *
- * recursive row vars shouldn't be restricted to vfields.
- */
 row_var:
 | nonrec_row_var                                               { $1 }
 | LPAREN MU VARIABLE DOT fields RPAREN                         { Datatype.Recursive (named_typevar $3 `Rigid, $5) }

--- a/test-harness
+++ b/test-harness
@@ -110,7 +110,7 @@ def evaluate(name, code, config_file, stdout='', stderr='', exit = '0', env = No
                 failures += 1
                 return
 
-        arg_array += ["--config=" + config_file]
+        arg_array = ["--config=" + config_file] + arg_array
 
     if not filemode.startswith('true'):
         arg_array += ["-e"]

--- a/tests/parser.tests
+++ b/tests/parser.tests
@@ -40,3 +40,8 @@ stdout : fun : () { |(mu a.Op:(() ~> ()) -> ())}~> ()
 Recursive type variable in codomain
 sig f : (() ~a~> mu b . [|Op:() ~a~> b|]) ~a~> c fun f(m) { switch(m()) { case Op(g) -> f(g) } } f
 stdout : fun : (() ~a~> mu b.[|Op:() ~a~> b|]) ~a~> _
+
+Mono restriction
+id : (a::(Any,Mono)) -> a::(Any,Mono)
+stdout : fun : (a::(Any,Mono)) -> a::(Any,Mono)
+args : --set=show_kinds=full


### PR DESCRIPTION
This patch adds surface syntax for `Mono` restriction.

This patch also fixes a small subtlety in the `test-harness` script
which would make settings in global config files take precedence over
test-local `args`.

Resolves #987.