### PR TITLE
Wrap `@load` in an error handler.

### DIFF
--- a/bin/repl.ml
+++ b/bin/repl.ml
@@ -194,10 +194,13 @@ let rec directives : (string * ((Context.t -> string list -> Context.t) * string
         ((fun context args ->
           match args with
           | [filename] ->
-             let (context', datatype, value) =
-               Driver.Phases.whole_program context filename
-             in
-             print_value datatype value; context'
+             Errors.display
+               ~default:(fun _ -> context)
+               (lazy
+                  (let (context', datatype, value) =
+                     Driver.Phases.whole_program context filename
+                   in
+                   print_value datatype value; context'))
           | _ -> prerr_endline "syntax: @load \"filename\""; context),
          "load in a Links source file, extending the current environment");
 
@@ -255,6 +258,7 @@ let execute_directive context (name, args) =
       let f = fst (assoc name (Lazy.force directives)) in
       f context args
     with NotFound _ ->
+      Printexc.print_backtrace stdout;
       Printf.fprintf stderr "unknown directive : %s\n" name;
       context
   in

--- a/core/desugarEffects.ml
+++ b/core/desugarEffects.ml
@@ -229,10 +229,14 @@ let may_have_shared_eff (tycon_env : simple_tycon_env) dt =
   | Lolli _ ->
       true
   | TypeApplication (tycon, _) -> (
-      let param_kinds, _has_implicit_effect = SEnv.find tycon tycon_env in
-      match ListUtils.last_opt param_kinds with
-      | Some (PrimaryKind.Row, (_, Restriction.Effect)) -> true
-      | _ -> false )
+    let param_kinds, _has_implicit_effect =
+      try
+        SEnv.find tycon tycon_env
+      with NotFound _ -> raise (Errors.UnboundTyCon (SourceCode.WithPos.pos dt, tycon))
+    in
+    match ListUtils.last_opt param_kinds with
+    | Some (PrimaryKind.Row, (_, Restriction.Effect)) -> true
+    | _ -> false )
   (* TODO: in the original version, this was true for every tycon with a Row var with restriction effect as the last param *)
   | _ -> false
 
@@ -272,8 +276,12 @@ let cleanup_effects tycon_env =
              let a, e, r = do_fun a e r in
              Lolli (a, e, r)
          | TypeApplication (name, ts) ->
-             let tycon_info = SEnv.find_opt name tycon_env in
-             let rec go =
+            let tycon_info =
+              try
+                SEnv.find_opt name tycon_env
+              with NotFound _ -> raise (Errors.UnboundTyCon (pos, name))
+            in
+            let rec go =
                (* We don't know if the arities match up yet (nor the final arities
                   of the definitions), so we handle mismatches, assuming spare rows
                   are effects.


### PR DESCRIPTION
This patch fixes a couple of bugs w.r.t. to error printing/handling, which would be visible in the REPL, e.g.

```
# foo.links
sig f : () -> T
fun f() { Foo }

links> @load "foo.links";
unknown directive : @load
```

The directive `@load` is uncertainly not unknown. What has happened
here is that the type constructor `T` is unbound, which in
`desugarEffects` would raise `NotFound`, which in turn would propagate
all the way out to the REPL, which catches `NotFound`, however, it
excepts the `NotFound` exception to raised if the given directive is
not found in the association list `directives`.

This patch fixes the exception raising points in `desugarEffects` to
raise `UnboundTyCon` instead, and wraps `@load` in `Errors.display`.