### PR TITLE
Default HTTP response when process throws `Aborted`.

### DIFF
--- a/core/webif.ml
+++ b/core/webif.ml
@@ -182,7 +182,9 @@ struct
           Lwt.return (mime_type, error_page (Errors.format_exception_html exc)) in
 
     let handle_exception = function
-      | Aborted r -> Lwt.return r (* Aborts are not "real" errors. *)
+      | Aborted r -> Lwt.return r (* Aborts are not "real" errors, as
+                                     every client call throws a
+                                     Proc.Abort. *)
       | e ->
          let req_data = Value.Env.request_data valenv in
          RequestData.set_http_response_code req_data 500;

--- a/core/webif.ml
+++ b/core/webif.ml
@@ -166,31 +166,30 @@ struct
      * a ServerCont or EvalMain, that is fine -- but we need to construct a b64-encoded
      * JSON object if we're responding to a ClientReturn or RemoteCall. *)
 
-    let handle_ajax_error = function
-      | Aborted r -> Lwt.return r
-      | e ->
-          let json =
-            `Assoc [("error", `String (Errors.format_exception e))] in
-         Lwt.return
-           ("text/plain", Utility.base64encode (Yojson.Basic.to_string json)) in
+    let handle_ajax_error e =
+      let json =
+        `Assoc [("error", `String (Errors.format_exception e))] in
+      Lwt.return
+        ("text/plain", Utility.base64encode (Yojson.Basic.to_string json)) in
 
     let handle_html_error e =
       let mime_type = "text/html; charset=utf-8" in
       match e with
-       | Aborted r -> Lwt.return r
        | Failure msg as e ->
           prerr_endline msg;
           Lwt.return (mime_type, error_page (Errors.format_exception_html e))
        | exc ->
-           Lwt.return (mime_type, error_page (Errors.format_exception_html exc)) in
+          Lwt.return (mime_type, error_page (Errors.format_exception_html exc)) in
 
-    let handle_error e =
-      let req_data = Value.Env.request_data valenv in
-      RequestData.set_http_response_code req_data 500;
-      if (RequestData.is_ajax_call cgi_args) then
-        handle_ajax_error e
-      else
-        handle_html_error e in
+    let handle_error = function
+      | Aborted r -> Lwt.return r (* Aborts are not "real" errors. *)
+      | e ->
+         let req_data = Value.Env.request_data valenv in
+         RequestData.set_http_response_code req_data 500;
+         if (RequestData.is_ajax_call cgi_args) then
+           handle_ajax_error e
+         else
+           handle_html_error e in
 
     Lwt.catch
       (fun () -> perform_request valenv run render_cont render_servercont_cont request )

--- a/core/webif.ml
+++ b/core/webif.ml
@@ -176,12 +176,12 @@ struct
       let mime_type = "text/html; charset=utf-8" in
       match e with
        | Failure msg as e ->
-          prerr_endline msg;
+          Debug.print (Printf.sprintf "Failure(%s)" msg);
           Lwt.return (mime_type, error_page (Errors.format_exception_html e))
        | exc ->
           Lwt.return (mime_type, error_page (Errors.format_exception_html exc)) in
 
-    let handle_error = function
+    let handle_exception = function
       | Aborted r -> Lwt.return r (* Aborts are not "real" errors. *)
       | e ->
          let req_data = Value.Env.request_data valenv in
@@ -193,7 +193,7 @@ struct
 
     Lwt.catch
       (fun () -> perform_request valenv run render_cont render_servercont_cont request )
-      (handle_error) >>=
-    fun (content_type, content) ->
+      handle_exception >>=
+      fun (content_type, content) ->
       response_printer [("Content-type", content_type)] content
 end

--- a/core/webif.ml
+++ b/core/webif.ml
@@ -184,7 +184,7 @@ struct
     let handle_exception = function
       | Aborted r -> Lwt.return r (* Aborts are not "real" errors, as
                                      every client call throws a
-                                     Proc.Abort. *)
+                                     Proc.Aborted. *)
       | e ->
          let req_data = Value.Env.request_data valenv in
          RequestData.set_http_response_code req_data 500;


### PR DESCRIPTION
This patch fixes issue #1011. Patch #947 modified the response code
for error messages to be 500. Every client call aborts its server
process, and when a process aborts it throws the exception `Aborted`,
meaning it would inadvertently set the response code to 500. In the
long term we should probably reconsider the design of processes,
remote calls, etc.