### PR TITLE
Coping with deeply nested literal JSON objects.

### DIFF
--- a/core/irtojs.ml
+++ b/core/irtojs.ml
@@ -1230,7 +1230,7 @@ end = functor (K : CONTINUATION) -> struct
          (state,
           varenv,
           Some x_name,
-          fun code -> Bind (x_name, Lit jsonized_val, code))
+          fun code -> Bind (x_name, Call (Var "JSON.parse", [strlit jsonized_val]), code))
       | Fun def ->
          let {fn_binder = fb; _} = def
          in


### PR DESCRIPTION
Literal JSON objects must be passed to the client as string literals,
which are supplied to `JSON.parse` in order to avoid crashing the V8
parser for JavaScript literal JSON objects (it is a recursive descent
parser, which `JSON.parse` apparently isn't).

Technically, we need to do this trick for all literal objects that the
JavaScript compiler produces, including records, lists, and
variants. This patch only does it for top-level let bindings.

Partial fix for #1013. I will merge this patch after #1015.