### PR TITLE
Resolve arguments inside call packages.

### DIFF
--- a/lib/js/jslib.js
+++ b/lib/js/jslib.js
@@ -941,17 +941,30 @@ const LINKS = new (function() {
         // or continuing with a final result.
         // TBD: Would be more elegant to use JS constructors instead of
         // using a signal member like __continuation.
-        const unresolvedServerValue = serverResponse.content.value;
+        const callPackageOrServerValue = serverResponse.content.value;
 
-        if ((unresolvedServerValue instanceof Object) && ('__continuation' in unresolvedServerValue)) {
+        if ((callPackageOrServerValue instanceof Object) && ('__continuation' in callPackageOrServerValue)) {
+          // callPackageOrServerValue is a call package.
           // Bouncing the trampoline
 
-          DEBUG.debug("Client function name, before evaluation, is ", unresolvedServerValue.__name);
+          DEBUG.debug("Client function name, before evaluation, is ", callPackageOrServerValue.__name);
 
           _current_pid = request.pid;
-          return _invokeClientCall(kappa, unresolvedServerValue);
+          // TODO(dhil): The call package should probably be tagged
+          // such that we can supply it to resolveServerValue.
+          // Resolve arguments.
+          let args = callPackageOrServerValue.__args;
+          for (let i = 0; i < args.length; i++) {
+            args[i] = resolveServerValue(state, args[i]);
+          }
+          // TODO(dhil): The following is redundant at the moment, but
+          // this is subject to change if/when we make
+          // resolveServerValue purely functional.
+          callPackageOrServerValue.__args = args;
+          return _invokeClientCall(kappa, callPackageOrServerValue);
         } else {
-          const serverValue = resolveServerValue(state, unresolvedServerValue);
+          // callPackageOrServerValue is a server value
+          const serverValue = resolveServerValue(state, callPackageOrServerValue);
           DEBUG.debug("Client continuing after remote server call, value ", serverValue);
           // it's the final result: return it.
           DEBUG.debug("Server response decoded: ", serverValue);


### PR DESCRIPTION
This patch fixes #1021. The problem was that the arguments inside call
packages received from the server were unresolved.

A unified approach to handling of values received from the server is
warranted.