### PR TITLE
Robust resolution of deeply nested server values.

### DIFF
--- a/core/irtojs.ml
+++ b/core/irtojs.ml
@@ -1230,7 +1230,7 @@ end = functor (K : CONTINUATION) -> struct
          (state,
           varenv,
           Some x_name,
-          fun code -> Bind (x_name, Lit jsonized_val, code))
+          fun code -> Bind (x_name, Call (Var "JSON.parse", [strlit jsonized_val]), code))
       | Fun def ->
          let {fn_binder = fb; _} = def
          in

--- a/lib/js/jslib.js
+++ b/lib/js/jslib.js
@@ -941,17 +941,30 @@ const LINKS = new (function() {
         // or continuing with a final result.
         // TBD: Would be more elegant to use JS constructors instead of
         // using a signal member like __continuation.
-        const unresolvedServerValue = serverResponse.content.value;
+        const callPackageOrServerValue = serverResponse.content.value;
 
-        if ((unresolvedServerValue instanceof Object) && ('__continuation' in unresolvedServerValue)) {
+        if ((callPackageOrServerValue instanceof Object) && ('__continuation' in callPackageOrServerValue)) {
+          // callPackageOrServerValue is a call package.
           // Bouncing the trampoline
 
-          DEBUG.debug("Client function name, before evaluation, is ", unresolvedServerValue.__name);
+          DEBUG.debug("Client function name, before evaluation, is ", callPackageOrServerValue.__name);
 
           _current_pid = request.pid;
-          return _invokeClientCall(kappa, unresolvedServerValue);
+          // TODO(dhil): The call package should probably be tagged
+          // such that we can supply it to resolveServerValue.
+          // Resolve arguments.
+          let args = callPackageOrServerValue.__args;
+          for (let i = 0; i < args.length; i++) {
+            args[i] = resolveServerValue(state, args[i]);
+          }
+          // TODO(dhil): The following is redundant at the moment, but
+          // this is subject to change if/when we make
+          // resolveServerValue purely functional.
+          callPackageOrServerValue.__args = args;
+          return _invokeClientCall(kappa, callPackageOrServerValue);
         } else {
-          const serverValue = resolveServerValue(state, unresolvedServerValue);
+          // callPackageOrServerValue is a server value
+          const serverValue = resolveServerValue(state, callPackageOrServerValue);
           DEBUG.debug("Client continuing after remote server call, value ", serverValue);
           // it's the final result: return it.
           DEBUG.debug("Server response decoded: ", serverValue);

--- a/lib/js/jslib.js
+++ b/lib/js/jslib.js
@@ -772,6 +772,17 @@ const LINKS = new (function() {
   }
 
 
+   // Server value resolution
+   class ServerValueResolutionYield extends Error {
+     constructor(k) {
+       super("resolveServerValueCPS yielding");
+       this.k = k;
+     }
+   }
+
+   let _resolveDepth = 0;
+   let _resolveDepthMax = 1000;
+
   /**
    * Resolve function references in the object `obj` and return the
    * updated `obj`. The `obj` is specified as records { function:f,
@@ -782,77 +793,199 @@ const LINKS = new (function() {
    * standard CPS compiled Links function. This is recursive, so each
    * object in `obj` also has its functions resolved.
    *
-   * NOTE due to the use of recursion, this function fails to resolve
-   * deeply nested server values properly.
-   *
    * @param {any} state
    * @param {any} obj
    * @return {any} obj
    */
-  function resolveServerValue(state, obj) {
-    if (obj._tag == null && obj.key != null) {
-      obj.key = _lookupMobileKey(state, obj.key);
-      return obj;
-    }
+   // TODO(dhil): This function internally calls a CPS function inside
+   // a trampoline in order to not cause a stack overflow on deeply
+   // nested objects. Preferably, we should defunctionalise the CPS
+   // function in order to obtain a iterative version that is more in
+   // line with the rest of jslib. Another point worth making is that
+   // the function mutates the given object and returns
+   // it. Ultimately, I think we should return a new object.
+   function resolveServerValue(state, obj) {
+     let k = function() { return resolveServerValueCPS(state, obj, function(x) { return x; }) };
+     while (true) {
+       try {
+         return k();
+       } catch (e) {
+         if (e instanceof ServerValueResolutionYield) {
+           k = e.k;
+         } else {
+           throw e;
+         }
+       }
+     }
+   }
 
-    let tag = obj._tag;
-    delete obj._tag;
+   function resolveServerValueCPS(state, obj, k) {
+     // Applies a continuation, bounces on the trampoline if necessary.
+     function applyK(k, arg) {
+       _resolveDepth++;
+       if (_resolveDepth >= _resolveDepthMax) {
+         _resolveDepth = 0;
+         throw new ServerValueResolutionYield(function() { return k(arg) });
+       }
+       return k(arg);
+     }
+     // Applies a function, bounces on the trampoline if necessary.
+     function _yield(f) {
+       _resolveDepth++;
+       if (_resolveDepth >= _resolveDepthMax) {
+         _resolveDepth = 0;
+         throw new ServerValueResolutionYield(f);
+       }
+       return f();
+     }
 
-    switch (tag) {
-    case "Bool":
-    case "Float":
-    case "Int":
-    case "String":
-    case "Database":
-    case "Table":
-        return obj._value;
-    case "Char":
-    case "ClientDomRef":
-    case "ClientAccessPoint":
-    case "ServerAccessPoint":
-    case "ClientPid":
-    case "ServerPid":
-    case "SessionChannel":
-    case "ServerSpawnLoc":
-    case "ClientSpawnLoc":
-        return obj;
-    case "XML":
-        return resolveServerValue(state, obj._value);
-    case "Text":
-        return obj;
-    case "NsNode":
-        obj.children = resolveServerValue(state, obj.children);
-        return obj;
-    case "List":
-        if (obj._head == null && obj._tail == null) return LINKEDLIST.Nil;
+     if (obj._tag == null && obj.key != null) {
+       obj.key = _lookupMobileKey(state, obj.key)
+       return applyK(k, obj);
+      }
 
-        obj._head = resolveServerValue(state, obj._head);
-        obj._tail = resolveServerValue(state, obj._tail);
-        return obj;
-    case "Record":
-        for (let k in obj)
-            obj[k] = resolveServerValue(state, obj[k]);
-        return obj;
-    case "Variant":
-        return {'_label': obj._label, '_value': resolveServerValue(state, obj._value)};
-    case "FunctionPtr":
-    case "ClientFunction":
-        const f = (!TYPES.isObject(obj.environment)) ?
-            eval(obj.func) :
-            partialApply(eval(obj.func), resolveServerValue(state, obj.environment));
-        f.location = obj.location; // This may be set to 'server' by the server serializer.
-        f.func = obj.func;
-        return f;
-    case "Process":
-        obj.process = resolveServerValue(state, obj.process);
-        for (let k in obj.messages) {
-            obj.messages[k] = resolveServerValue(state, obj.messages[k]);
-        }
-        return obj;
-    default:
-        throw "Unrecognised tag " + tag + " for object \"" + JSON.stringify(obj) + "\"";
-    }
-  }
+      let tag = obj._tag;
+      delete obj._tag;
+
+      switch (tag) {
+      case "Bool":
+      case "Float":
+      case "Int":
+      case "String":
+      case "Database":
+      case "Table":
+          return applyK(k, obj._value);
+      case "XML":
+          return _yield(function() {
+              return resolveServerValueCPS(state, obj._value, function(xml) {
+                  return applyK(k, xml);
+              });
+          });
+      case "Text":
+          return applyK(k, obj);
+      case "NsNode":
+          return _yield(function() {
+              return resolveServerValueCPS(state, obj.children, function(children) {
+                  obj.children = children;
+                  return applyK(k, obj);
+              });
+          });
+      case "Char":
+      case "ClientDomRef":
+      case "ClientAccessPoint":
+      case "ServerAccessPoint":
+      case "ClientPid":
+      case "ServerPid":
+      case "SessionChannel":
+      case "ServerSpawnLoc":
+      case "ClientSpawnLoc":
+          return k(obj);
+      case "List":
+          if (obj._head == null && obj._tail == null) return applyK(k, LINKEDLIST.Nil);
+          return _yield(function() {
+              return resolveServerValueCPS(state, obj._head, function(head) {
+                  obj._head = head;
+                  return _yield(function () {
+                      return resolveServerValueCPS(state, obj._tail, function(tail) {
+                          obj._tail = tail;
+                          return applyK(k, obj);
+                      })
+                  });
+              });
+          });
+      case "Record": {
+          var chain0 = function(obj) {
+              return applyK(k, obj);
+          };
+          function resolveComponent(i, k) {
+              return function(obj) {
+                  return _yield(function() {
+                      return resolveServerValueCPS(state, obj[i], function(ith) {
+                          obj[i] = ith;
+                          return applyK(k, obj);
+                      });
+                  });
+              };
+          };
+
+          // resolveComponent builds the continuation in bottom-up
+          // fashion, so in order to resolve the object in-order at
+          // runtime construct the continuation from the keys in reverse
+          // order.
+          let keys = [];
+          for (let key in obj) {
+              keys.push(key);
+          }
+          var g = function(obj) {
+              return applyK(k, obj);
+          };
+          while (keys.length > 0) {
+              g = resolveComponent(keys.pop(), g);
+          }
+          return g(obj);
+      }
+      case "Variant":
+          return _yield(function () {
+              return resolveServerValueCPS(state, obj._value, function(value) {
+                  return applyK(k, {'_label': obj._label, '_value': value});
+              });
+          });
+      case "FunctionPtr":
+      case "ClientFunction":
+          if (obj.environment == null) {
+              let f = eval(obj.func);
+              f.location = obj.location;
+              f.func = obj.func;
+              return applyK(k, f);
+          } else {
+              return _yield(function() {
+                  return resolveServerValueCPS(state, obj.environment, function(env) {
+                      let f = partialApply(eval(obj.func),env);
+                      f.location = obj.location;
+                      f.func = obj.func;
+                      return applyK(k, f);
+                  });
+              });
+          }
+      case "Process": {
+          function resolveMessage(i, k) {
+              return function(obj) {
+                  return _yield(function() {
+                      return resolveServerValueCPS(state, obj.messages[i], function(ith) {
+                          obj.messages[i] = ith;
+                          return applyK(k, obj);
+                      });
+                  });
+              };
+          }
+
+          // resolveMessage builds the continuation in bottom-up
+          // fashion, so in order to resolve the object in-order at
+          // runtime construct the continuation from the indices in
+          // reverse order.
+          let indices = [];
+          for (let index in obj.messages) {
+              indices.push(index);
+          }
+          let g = function(obj) {
+              return applyK(k, obj);
+          };
+          while (indices.length > 0) {
+              g = resolveMessage(indices.pop(), g);
+          }
+
+          return _yield(function() {
+              return resolveServerValueCPS(state, obj.process, function(process) {
+                  obj.process = process;
+                  obj.pid     = obj.pid;
+                  return g(obj);
+              });
+          });
+      }
+      default:
+          throw "Unrecognised tag " + tag + " for object \"" + JSON.stringify(obj) + "\"";
+      }
+   }
 
   /**
    * @param {any[]} xs

--- a/lib/js/jslib.js
+++ b/lib/js/jslib.js
@@ -434,6 +434,8 @@ const WEBSOCKET = {
     return;
   },
 
+  // TODO(dhil): I have a feeling that we may need to call
+  // `resolveServerValue` on more "messages" below.
   onMessage : function(evt) {
     const js_parsed = JSON.parse(evt.data);
     DEBUG.debug("Received message ", js_parsed || evt.data);
@@ -455,7 +457,7 @@ const WEBSOCKET = {
             break;
           case "SESSION_MESSAGE_DELIVERY":
             var ep_id = js_parsed.ep_id;
-            var message = js_parsed.msg;
+            var message = LINKS.resolveServerValue(null, js_parsed.msg); // TODO(dhil): We should probably pass the parsed JSON state here, but it is not available in this scope. A refactoring of this code is warranted.
             var delegated_chans = js_parsed.deleg_chans;
             var requires_lost_messages = js_parsed.requires_lost_messages;
             migrateDelegatedSessions(delegated_chans, requires_lost_messages);
@@ -1593,6 +1595,8 @@ const LINKS = new (function() {
     }
     return false;
   };
+
+  LINKS.resolveServerValue = resolveServerValue;
 
   return LINKS;
 })();


### PR DESCRIPTION
This patch converts the function `resolveServerValue` into CPS with a
trampoline such that resolution of deeply nested server values no
longer causes a stack overflow.

Resolves #1013.