### PR TITLE
Do not print backtrace on "unknown directive"

### DIFF
--- a/bin/repl.ml
+++ b/bin/repl.ml
@@ -258,7 +258,6 @@ let execute_directive context (name, args) =
       let f = fst (assoc name (Lazy.force directives)) in
       f context args
     with NotFound _ ->
-      Printexc.print_backtrace stdout;
       Printf.fprintf stderr "unknown directive : %s\n" name;
       context
   in


### PR DESCRIPTION
Prior to this patch the REPL would unconditionally print a backtrace
whenever a user would input an unsupported directive. Due to
buffering, the backtrace would only be printed next time the buffers
were flushed, e.g. by quitting the REPL.

```
links> @show abc;
unknown directive : show
(CTRL+D)
Raised at Links_core__Notfound.not_found in file "core/notfound.ml", line 20, characters 4-159
Called from Repl.execute_directive in file "bin/repl.ml", line 258, characters 18-54
```

This patch removes the unconditional backtrace print.