### PR TITLE
Fix nested effect rows printing incorrectly

### DIFF
--- a/core/types.ml
+++ b/core/types.ml
@@ -3065,7 +3065,8 @@ module RoundtripPrinter : PRETTY_PRINTER = struct
           in
           Printer (fun ctx r buf ->
               let is_lolli = Context.is_ambient_linfun ctx in
-              (* flatten here in case there are nested row variables *)
+              (* flatten here in case there are nested row variables,
+                 e.g. {  | { wild:() } } *)
               let (fields, rvar, _) as r' = extract_row_parts (flatten_row r) in
               let is_wild = is_field_present fields wild in
               let visible_fields = (FieldEnv.size fields) - (if is_wild then 1 else 0) in
@@ -3080,7 +3081,7 @@ module RoundtripPrinter : PRETTY_PRINTER = struct
                    else (* empty open row use the abbreviated notation
                            -a- or ~a~ unless it's anonymous in which
                            case we skip it entirely *)
-                     match Unionfind.find (snd3 (extract_row_parts r)) with
+                     match Unionfind.find rvar with
                      | Var (vid, knd, _) ->
                         if is_var_anonymous ctx vid
                         then () (* skip printing it entirely *)

--- a/tests/roundtrippable_types.tests
+++ b/tests/roundtrippable_types.tests
@@ -15,3 +15,7 @@ Recursive effect
 fun w(g) { handle(g()) { case Return(()) -> () case F(h, res) -> w(h) }} w
 args : --enable-handlers
 stdout : fun : (() { |(mu a.F:(() { |a}-> ()) {}-> _::Any,wild:()|c)}-> ()) {F{_}|c}~> ()
+
+Row with no fields, but with nested wild row in its row variable
+fun f() { error("") } f
+stdout : fun : () ~> _


### PR DESCRIPTION
Fixes #1024.

The issue was that the original code did not use the already flattened version of the row for printing the row variable in function arrows.

The problem was caused by the internal structure like this (in the particular example from #1024):
```links
fun() { error("") } : () { | {wild:()} }-> _
```
note the nested internal row within the variable of the external row, which reduces to `() {wild:()}-> _` and hence to `() ~> _`.