### PR TITLE
Update CHANGES.md with recursive rows, roundtrip printer and effect sugar

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,19 @@
 # 0.9.4
 
+## Queries mixing set and bag semantics
+Links now provides experimental support for SQL queries mixing set and bag semantics. 
+
+When the `mixing_norm=on` flag is added to the configuration file, or when a query is defined in a `query mixing { ... }` block, Links will use a new query evaluator, allowing the programmer to call deduplication functions (`dedup` and `distinct`) within database queries. These are handled with set-based SQL statements `select distinct / union`, in addition to the usual bag-based `select / union all`.
+
+    # will run on the DB as "select distinct e.dept as dept from employees"
+    query mixing {
+      dedup(for (e <-- employees) [(dept = e.dept)])
+    }
+
+Queries mixing set and bag semantics may, in some cases, require the use of the SQL:1999 keyword `lateral`; Links implements an optional query transformation to produce queries that do not use `lateral` (allowing the use of older DBMSs): this behaviour is enabled by using `query delat` in place of `query mixing`.
+
+Further information on this feature is provided in the [Links GitHub wiki](https://github.com/links-lang/links/wiki/Deduplication-in-database-queries).
+
 ## DateTime type
 Links now includes a primitive type, `DateTime`, for dates and times.
 This is a *breaking change* from previous versions, where `dateToInt`

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -43,6 +43,23 @@ You can also print out the `DateTime` using `show` (which is an alias of
 
 Due to limitations of the underlying library, the minimum timezone granularity is one hour. Unfortunately, this means we can't handle Indian timezones, for example.
 
+## Surface syntax for presence type argument
+
+**Breaking change**: New syntax has been added to support type arguments of kind `Presence`. Here are some example of the syntax:
+
+```links
+typename T(p::Presence) = (foo{p});
+
+(foo=4200) : T({:Int})         # Present with type Int
+()         : T({-})            # Absent
+(foo=4200) : T({%})            # Unnamed flexible variable
+(foo=true) : T({%p})           # Named flexible variable
+fun(r : T({_})) { () }         # Anonymous presence variable
+fun(r : T({p})) { r : T({p}) } # Named presence variable
+```
+
+The syntactic sugar for effect and record fields which lets one omit the `()` has been removed in order to resolve the otherwise ambiguity between the presence type argument `{wild}` from the row type argument `{wild}`. Note however that it is still possible to omit the `()` for variant fields.
+
 # 0.9.3
 
 This minor release fixes a few bugs.

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -68,11 +68,9 @@ It is now possible to annotate type variables with `Mono` restriction, e.g. `sig
 
 ### Recursive rows
 
-* We can now enter a recursive row effect type, such as `{ |(mu a.F:(() { |a}-> ()) {}-> b|c)}`.
-* **Breaking change**: recursive rows of different types cannot mix anymore - a variant can only contain fields with variant syntax (i.e. uppercase and separated by `|`) in its recursive row variable, and the same goes for others (e.g. records - lowecase, separated by `,`);
-  * these are correct: `[|(mu a. Foo:()|Bar:()|d)|]`, `(|(mu a. foo:(),bar:()|d))`
-  * these are not: `[|(mu a. foo:()|bar:()|d)|]`, `(|(mu a. foo:()|bar:()|d))`
-* **Breaking change**: Recursive variants with no directly exposed fields no longer require (nor allow) the vertical bar separating fields from the row variable: the following is no longer correct: `[| |(mu a . Foo:()|Bar:()|d)|]` (note the bar before `mu`)
+* Effect variables can be recursive, e.g. `{ |(mu a.F:(() { |a}-> ()) {}-> b|c)}`.
+* **Breaking change**: Recursive rows are no longer restricted to variant syntax, i.e. separating fields using `|`. Recursive record and effects rows separate fields using `,` now. 
+* Recursive variants with no directly exposed fields no longer require the vertical bar separating fields from the row variable, e.g. `[|(mu a. Foo)|]` is equivalent to `[| |(mu a . Foo)|]`.
 
 ## Roundtrip: New pretty printer for types
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -43,7 +43,9 @@ You can also print out the `DateTime` using `show` (which is an alias of
 
 Due to limitations of the underlying library, the minimum timezone granularity is one hour. Unfortunately, this means we can't handle Indian timezones, for example.
 
-## Surface syntax for presence type argument
+## New surface syntax
+
+### Presence type arguments
 
 **Breaking change**: New syntax has been added to support type arguments of kind `Presence`. Here are some example of the syntax:
 
@@ -59,6 +61,19 @@ fun(r : T({p})) { r : T({p}) } # Named presence variable
 ```
 
 The syntactic sugar for effect and record fields which lets one omit the `()` has been removed in order to resolve the otherwise ambiguity between the presence type argument `{wild}` from the row type argument `{wild}`. Note however that it is still possible to omit the `()` for variant fields.
+
+### Mono restriction
+
+It is now possible to annotate type variables with `Mono` restriction, e.g. `sig id : (a::(Any,Mono)) -> a::(Any,Mono)`.
+
+## Other fixes
+
+* Fixed a bug where the REPL would unconditionally print a stacktrace for unknown directives.
+* Fixed a bug where deeply nested JSON literals would cause the client to stack overflow.
+* Fixed a bug where big server side values would cause the client to stack overflow.
+* Fixed JavaScript compilation of top-level anonymous functions.
+* Fixed a bug where the server would inadvertently respond with response `500` following the (successful) termination of a server side process.
+* The body of an escape expression has been made more permissive (grammatically) as it can now be any expression.
 
 # 0.9.3
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -92,7 +92,7 @@ Note that one can select multiple printers at once, for comparison; this is done
 
 ## Effect Syntactic Sugar
 
-**Breaking change** (for code using effect sugar): This version implements enhanced syntactic sugar for effects. The changes influence both the Roundtrip printer (see above) and the desugaring passes (between parsing and typechecking).
+This version implements enhanced syntactic sugar for effects. The changes influence both the Roundtrip printer (see above) and the desugaring passes (between parsing and typechecking).
 
 (*Note: Most of effect sugar, and in particular the changes introduced in this version, requires the `effect_sugar` setting to be `true`.*)
 


### PR DESCRIPTION
Update to CHANGES.md, see #1042. It seems I cannot push it directly without a PR.