### PR TITLE
Restore row variable syntax for variants

### DIFF
--- a/core/parser.mly
+++ b/core/parser.mly
@@ -1038,15 +1038,15 @@ row:
 | fields                                                       { $1                    }
 | /* empty */                                                  { ([], Datatype.Closed) }
 
-fields_def(field_prod, row_var_prod, kinded_row_var_prod):
+fields_def(field_prod, sep, row_var_prod, kinded_row_var_prod):
 | field_prod                                                   { ([$1], Datatype.Closed) }
 | soption(field_prod) VBAR row_var_prod                        { ( $1 , $3             ) }
 | soption(field_prod) VBAR kinded_row_var_prod                 { ( $1 , $3             ) }
-| field_prod COMMA
-    fields_def(field_prod, row_var_prod, kinded_row_var_prod)  { ( $1::fst $3, snd $3 ) }
+| field_prod sep
+    fields_def(field_prod, sep, row_var_prod, kinded_row_var_prod) { ( $1::fst $3, snd $3 ) }
 
 fields:
-| fields_def(field, row_var, kinded_row_var)                   { $1 }
+| fields_def(field, COMMA, row_var, kinded_row_var)                   { $1 }
 
 field:
 | CONSTRUCTOR /* allows nullary variant labels */              { ($1, present) }
@@ -1059,7 +1059,7 @@ field_label:
 | UINTEGER                                                     { string_of_int $1 }
 
 rfields:
-| fields_def(rfield, row_var, kinded_row_var)                  { $1 }
+| fields_def(rfield, COMMA, row_var, kinded_row_var)                  { $1 }
 
 rfield:
 /* The following sugar is tempting, but it leads to a conflict. Is
@@ -1072,10 +1072,9 @@ record_label:
 | field_label                                                  { $1 }
 
 vfields:
-| vfield                                                       { ([$1], Datatype.Closed) }
+| fields_def(vfield, VBAR, vrow_var, kinded_vrow_var)          { $1 }
 | vrow_var                                                     { ([]  , $1             ) }
 | kinded_vrow_var                                              { ([]  , $1             ) }
-| vfield VBAR vfields                                          { ($1::fst $3, snd $3   ) }
 
 vfield:
 | CONSTRUCTOR                                                  { ($1, present) }


### PR DESCRIPTION
This commit restores the `[| |p|]` syntax for variants, whilst keeping
the sugar `[|p|]`.