### PR TITLE
Fix warning 16

### DIFF
--- a/core/parse.ml
+++ b/core/parse.ml
@@ -75,12 +75,12 @@ let parse_string ?(pp=default_preprocessor ()) ?in_context:context grammar strin
   let pp = normalize_pp pp
   and context = LinksParser.normalize_context context in
     LinksParser.read ?nlhook:None ~parse:grammar
-      ~infun:(reader_of_string ?pp string) ~name:"<string>" ~context
+      ~infun:(reader_of_string ?pp string) ~name:"<string>" ~context ()
 
 let parse_channel ?interactive ?in_context:context grammar (channel, name) =
   let context = LinksParser.normalize_context context in
     LinksParser.read ?nlhook:interactive ~parse:grammar
-      ~infun:(reader_of_channel channel) ~name:name ~context
+      ~infun:(reader_of_channel channel) ~name:name ~context ()
 
 let parse_file ?(pp=default_preprocessor ()) ?in_context:context grammar filename =
   match normalize_pp pp with
@@ -93,7 +93,7 @@ let parse_file ?(pp=default_preprocessor ()) ?in_context:context grammar filenam
                ~parse:grammar
                ~infun:(reader_of_string ~pp (String.concat "\n" (lines channel)))
                ~name:filename
-               ~context)
+               ~context ())
 
 module Readline = struct
   (** Readline settings. **)
@@ -162,7 +162,7 @@ module Readline = struct
     let context = LinksParser.normalize_context context in
     let (accessor_fun, populate_fun) = reader_of_readline ps1 in
     LinksParser.read ?nlhook:(Some populate_fun) ~parse:grammar
-      ~infun:accessor_fun ~name:"<stdin>" ~context
+      ~infun:accessor_fun ~name:"<stdin>" ~context ()
 
   let prepare_prompt : string -> unit
     = fun ps1 ->

--- a/core/parseXml.ml
+++ b/core/parseXml.ml
@@ -38,6 +38,6 @@ let normalize_context = function
 let parse_string ?in_context:context grammar string =
   let context = normalize_context context in
     XmlParse.read ?nlhook:None ~parse:grammar ~infun:(reader_of_string string)
-      ~name:"<string>" ~context
+      ~name:"<string>" ~context ()
 
 let parse_xml s = fst (Errors.display (lazy (parse_string xml s)))

--- a/core/scanner.ml
+++ b/core/scanner.ml
@@ -21,8 +21,9 @@ module Scanner (Lex : LexerSig) = struct
           -> parse:('result Lex.grammar)
           -> infun:(bytes -> int -> int)
           -> name:string
+          -> unit
           -> 'result * source_code =
-  fun ~context ?nlhook ~parse ~infun ~name ->
+  fun ~context ?nlhook ~parse ~infun ~name () ->
     let code = new source_code in
     let lexbuf = {(from_function (code#parse_into infun))
                  with lex_curr_p={pos_fname=name; pos_lnum=1; pos_bol=0; pos_cnum=0}} in

--- a/core/scanner.mli
+++ b/core/scanner.mli
@@ -18,6 +18,7 @@ module Scanner (Lex : LexerSig) : sig
           -> parse:('result Lex.grammar)
           -> infun:(bytes -> int -> int)
           -> name:string
+          -> unit
           -> 'result * position_context
 
   val normalize_context : Lex.lexer_context option -> Lex.lexer_context


### PR DESCRIPTION
OCaml 4.12.0 emits warning 16 on our code base, because the
parameterlist of function `read` in `core/scanner.ml` contains a
unerasable optional parameter. This patch extends the signature of
`read` with a trivial unlabelled parameter in order to fix this
warning.

Resolves #1046