### PR TITLE
Address warnings emitted by OCaml 4.13.

### DIFF
--- a/core/proc.ml
+++ b/core/proc.ml
@@ -435,8 +435,11 @@ end
 module rec Websockets : WEBSOCKETS =
 struct
 
+  (* TODO(dhil): The field `_client_id` is never read. It seems that
+     the client ID is manually threaded through every function. This
+     module possibly warrants a refactor/redesign at some point. *)
   type links_websocket = {
-    client_id : client_id;
+    _client_id : client_id;
     send_fn : Websocket.Frame.t option -> unit
   }
 
@@ -464,7 +467,7 @@ struct
       | _ -> None
 
   let make_links_websocket cid send_fn = {
-    client_id = cid;
+    _client_id = cid;
     send_fn = send_fn
   }
 

--- a/database/mysql-driver/dune
+++ b/database/mysql-driver/dune
@@ -3,7 +3,6 @@
   (public_name links-mysql)
   (synopsis "MySQL database backend for Links")
   (optional)
-  (flags (:standard -safe-string -dtypes -w Ae-44-45-60 -g -cclib -lunix -thread))
   (libraries mysql links.core))
 
 

--- a/database/mysql8-driver/dune
+++ b/database/mysql8-driver/dune
@@ -3,7 +3,6 @@
   (public_name links-mysql8)
   (synopsis "MySQL8 database backend for Links")
   (optional)
-  (flags (:standard -safe-string -dtypes -w Ae-42-44-45-60 -g -cclib -lunix -thread))
   (libraries mysql8 links.core))
 
 

--- a/dune
+++ b/dune
@@ -6,14 +6,14 @@
           -safe-string        ;; Immutable strings.
           -bin-annot          ;; Dumps information per (file) module about types, bindings, tail-calls, etc. Used by some tools.
           -warn-error -a      ;; Do not treat warnings as errors.
-          -w A-4-42-44-45-48-60-67  ;; Ignores warnings 4, 42, 44, 45, 48, 60, and 67.
+          -w +A-4-42-44-45-48-60-67-70  ;; Ignores warnings 4, 42, 44, 45, 48, 60, 67, and 70.
           -g                  ;; Adds debugging information to the resulting executable / library.
  )))
  (release
   (flags (:standard
           ;; The following flags are the same as for the "dev" profile.
           -strict-formats -strict-sequence -safe-string -bin-annot
-          -w A-4-42-44-45-48-60-67  ;; Ignores warnings 4, 42, 44, 45, 48, 60, and 67.
+          -w +A-4-42-44-45-48-60-67-70  ;; Ignores warnings 4, 42, 44, 45, 48, 60, 67, and 70.
   ))
   (ocamlopt_flags (:standard
                    -O3 ;; Applies (aggressive) optimisations to the resulting executable.
@@ -22,7 +22,7 @@
   (flags (:standard
           -strict-formats -strict-sequence -safe-string -bin-annot
           -warn-error @A      ;; Treat warnings as errors...
-          -w A-4-42-44-45-48-60-67  ;; ... except for warnings 4, 42, 44, 45, 48, 60, and 67 which are ignored.
+          -w A-4-42-44-45-48-60-67-70  ;; ... except for warnings 4, 42, 44, 45, 48, 60, 67, and 70 which are ignored.
   ))
   (ocamlopt_flags (:standard -O3))
 ))


### PR DESCRIPTION
This commit addresses the warnings emitted by OCaml 4.13. In
particular, I have decided to silence/ignore warning 70, which is
produced whenever a source file does not have a corresponding
interface file. I removed the redundant flags from
`database/{mysql-driver,mysql8-driver}/dune`. They are now inherited
from the profile flags specified in the root `dune` file. OCaml 4.13
also warned about an unused field in `core/proc.ml`, which I have just
silenced by adding an underscore prefix to the field name. In the
future we should probably refactor this particular module.

Resolves #1054.