### PR TITLE
Implement System F-style general-purpose type abstractions

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,10 @@
+# 0.9.6
+
+* Links now supports System F-style explicit type abstractions:
+  For instance, writing `/\ [a, e::Row] { foo }` abstracts the expression `foo`
+  over type variable `a` and row variable `e`. Here, `foo` must have a unique
+  type and must be pure (to satisfy the value restriction).
+
 # 0.9.5
 
 This is a minor hotfix release.

--- a/core/desugarTypeVariables.ml
+++ b/core/desugarTypeVariables.ml
@@ -1,5 +1,5 @@
 (*
-  aThis pass resolves type variables and reports errors w.r.t. their
+  This pass resolves type variables and reports errors w.r.t. their
   scoping. Specifically, this means that the pass replaces all TUnresolved from
   {Sugartypes.SugarTypeVar.t} by appropriate TResolved*. The latter contain
   Unionfind points and the pass guarantees that syntactic/unresolved variables

--- a/core/desugarTypeVariables.ml
+++ b/core/desugarTypeVariables.ml
@@ -1,5 +1,5 @@
 (*
-  This pass resolves type variables and reports errors w.r.t. their
+  aThis pass resolves type variables and reports errors w.r.t. their
   scoping. Specifically, this means that the pass replaces all TUnresolved from
   {Sugartypes.SugarTypeVar.t} by appropriate TResolved*. The latter contain
   Unionfind points and the pass guarantees that syntactic/unresolved variables

--- a/core/lexer.mll
+++ b/core/lexer.mll
@@ -225,6 +225,7 @@ rule lex ctxt nl = parse
   | '@'                                 { AT }
   | "%" def_id as var                   { PERCENTVAR var }
   | '%'                                 { PERCENT }
+  | "/\\"                               { CAPITAL_LAMBDA }
   | initopchar opchar * as op           { OPERATOR op }
   | '`' (def_id as var) '`'             { if List.mem_assoc var keywords || Char.isUpper var.[0] then
                                               raise (LexicalError (lexeme lexbuf, lexeme_end_p lexbuf))

--- a/core/parser.mly
+++ b/core/parser.mly
@@ -486,7 +486,7 @@ signature:
 typedecl:
 | TYPENAME CONSTRUCTOR typeargs_opt EQ datatype                { with_pos $loc (Typenames [with_pos $loc ($2, $3, datatype $5)]) }
 
-/* Lists of type parameters in square brackets denote type abstractions */
+(* Lists of quantifiers in square brackets denote type abstractions *)
 type_abstracion_vars:
 | LBRACKET varlist RBRACKET                                    { $2 }
 

--- a/core/parser.mly
+++ b/core/parser.mly
@@ -322,6 +322,7 @@ let parse_foreign_language pos lang =
 %token MU FORALL ALIEN SIG UNSAFE
 %token MODULE MUTUAL OPEN IMPORT
 %token BANG QUESTION
+%token CAPITAL_LAMBDA
 %token PERCENT EQUALSTILDE PLUS STAR ALTERNATE SLASH SSLASH CARET DOLLAR AT
 %token <char*char> RANGE
 %token <string> QUOTEDMETA
@@ -484,6 +485,10 @@ signature:
 
 typedecl:
 | TYPENAME CONSTRUCTOR typeargs_opt EQ datatype                { with_pos $loc (Typenames [with_pos $loc ($2, $3, datatype $5)]) }
+
+/* Lists of type parameters in square brackets denote type abstractions */
+type_abstracion_vars:
+| LBRACKET varlist RBRACKET                                    { $2 }
 
 typeargs_opt:
 | /* empty */                                                  { [] }
@@ -665,6 +670,7 @@ typed_expression:
 | logical_expression                                           { $1 }
 | typed_expression COLON datatype                              { with_pos $loc (TypeAnnotation ($1, datatype $3)) }
 | typed_expression COLON datatype LARROW datatype              { with_pos $loc (Upcast ($1, datatype $3, datatype $5)) }
+| CAPITAL_LAMBDA type_abstracion_vars DOT block                { type_abstraction ~ppos:$loc $2 $4 }
 
 db_expression:
 | DELETE LPAREN table_generator RPAREN perhaps_where           { let pat, phrase = $3 in with_pos $loc (DBDelete (pat, phrase, $5)) }

--- a/core/sugarConstructors.ml
+++ b/core/sugarConstructors.ml
@@ -207,6 +207,9 @@ module SugarConstructors (Position : Pos)
   let module_binding ?(ppos=dp) binder members =
     with_pos ppos (Module { binder; members })
 
+  let type_abstraction ?(ppos=dp) tyvars phrase =
+    with_pos ppos (TAbstr (tyvars, phrase))
+
   (** Database queries *)
 
   (* Create a list of labeled database expressions. *)

--- a/core/sugarConstructorsIntf.ml
+++ b/core/sugarConstructorsIntf.ml
@@ -63,6 +63,8 @@ module type SugarConstructorsSig = sig
     ?ppos:t -> ?ty:Types.datatype -> phrase list -> phrase
   val constructor :
     ?ppos:t -> ?body:phrase -> ?ty:Types.datatype -> Name.t -> phrase
+  val type_abstraction : ?ppos:t -> SugarQuantifier.t list -> phrase -> phrase
+
 
   (* Constants *)
   val constant      : ?ppos:t -> Constant.t -> phrase

--- a/core/typeSugar.ml
+++ b/core/typeSugar.ml
@@ -404,6 +404,8 @@ sig
   val inconsistent_quantifiers :
     pos:Position.t -> t1:Types.datatype -> t2:Types.datatype -> unit
 
+  val tabstr_ambiguos_type : pos:Position.t -> Types.datatype -> unit
+
   val escaped_quantifier :
     pos:Position.t ->
     var:string ->
@@ -1541,6 +1543,13 @@ end
                 typ l                                  ^ nl ()  ^
                 "actual: "                             ^ nli () ^
                 typ r                                  ^ nl ())
+
+    let tabstr_ambiguos_type ~pos t =
+      let policy () = Types.Policy.set_quantifiers true (Types.Policy.default_policy ()) in
+      let typ = Types.string_of_datatype ~policy t in
+      die pos ("The phrase under a type abstraction must have a unique type."     ^ nl ()  ^
+               "We cannot guarantee this for the phrase under this /\\ with type" ^ nli () ^
+                typ                                                      )
 
     let recursive_usage ~pos ~t1:(_, lt) ~t2:(v, rt) ~error:_ =
       build_tyvar_names [lt; rt];
@@ -3323,8 +3332,23 @@ let rec type_check : context -> phrase -> phrase * Types.datatype * Usage.t =
                       FnAppl (erase f, List.map erase ps), rettyp, Usage.combine_many (usages f :: List.map usages ps)
               end
         | TAbstr (sugar_qs, e) ->
-            let e, t, u = tc e in
             let qs = List.map SugarQuantifier.get_resolved_exn sugar_qs in
+
+            (* Links being Links, the only way to ensure that we don't
+               generalize any of the qs while type-checking e is to add
+               a term variable to the environment that contains all variables
+               from qs *)
+            let dummy_var = Utils.dummy_source_name () in
+            let type_of_quantifier q = Types.type_arg_of_quantifier q |> snd in
+            let dummy_type = List.map type_of_quantifier qs |> Types. make_tuple_type in
+            let context' = {context
+                            with var_env = Env.bind dummy_var dummy_type context.var_env } in
+            let e, t, u = type_check context' e in
+
+            let free_flexible_vars = Types.free_flexible_type_vars t in
+            if not (Types.TypeVarSet.is_empty free_flexible_vars) then
+              Gripers.tabstr_ambiguos_type ~pos t;
+
             let t = Types.for_all(qs, t) in
               tabstr (sugar_qs, e.node), t, u
         | TAppl (e, tyargs) ->

--- a/core/typeSugar.ml
+++ b/core/typeSugar.ml
@@ -404,7 +404,7 @@ sig
   val inconsistent_quantifiers :
     pos:Position.t -> t1:Types.datatype -> t2:Types.datatype -> unit
 
-  val tabstr_ambiguos_type : pos:Position.t -> Types.datatype -> unit
+  val tabstr_ambiguous_type : pos:Position.t -> Types.datatype -> unit
 
   val escaped_quantifier :
     pos:Position.t ->
@@ -1544,7 +1544,7 @@ end
                 "actual: "                             ^ nli () ^
                 typ r                                  ^ nl ())
 
-    let tabstr_ambiguos_type ~pos t =
+    let tabstr_ambiguous_type ~pos t =
       let policy () = Types.Policy.set_quantifiers true (Types.Policy.default_policy ()) in
       let typ = Types.string_of_datatype ~policy t in
       die pos ("The phrase under a type abstraction must have a unique type."     ^ nl ()  ^
@@ -3347,7 +3347,7 @@ let rec type_check : context -> phrase -> phrase * Types.datatype * Usage.t =
 
             let free_flexible_vars = Types.free_flexible_type_vars t in
             if not (Types.TypeVarSet.is_empty free_flexible_vars) then
-              Gripers.tabstr_ambiguos_type ~pos t;
+              Gripers.tabstr_ambiguous_type ~pos t;
 
             let t = Types.for_all(qs, t) in
               tabstr (sugar_qs, e.node), t, u

--- a/core/typeSugar.ml
+++ b/core/typeSugar.ml
@@ -3332,6 +3332,8 @@ let rec type_check : context -> phrase -> phrase * Types.datatype * Usage.t =
                       FnAppl (erase f, List.map erase ps), rettyp, Usage.combine_many (usages f :: List.map usages ps)
               end
         | TAbstr (sugar_qs, e) ->
+          if Utils.is_generalisable e then
+
             let qs = List.map SugarQuantifier.get_resolved_exn sugar_qs in
 
             (* Links being Links, the only way to ensure that we don't
@@ -3350,7 +3352,9 @@ let rec type_check : context -> phrase -> phrase * Types.datatype * Usage.t =
               Gripers.tabstr_ambiguous_type ~pos t;
 
             let t = Types.for_all(qs, t) in
-              tabstr (sugar_qs, e.node), t, u
+            tabstr (sugar_qs, e.node), t, u
+          else
+            Gripers.generalise_value_restriction pos (uexp_pos e)
         | TAppl (e, tyargs) ->
            let e, t, u = tc e in
 

--- a/core/types.ml
+++ b/core/types.ml
@@ -1962,6 +1962,17 @@ struct
   let find_spec var tbl =      Hashtbl.find tbl var
 end
 
+let free_flexible_type_vars t =
+  let free_vars = Vars.free_bound_type_vars TypeVarSet.empty t in
+  let add_if_flexible set var_entry =
+    let (id, (flavour, _kind, _scope)) = var_entry in
+    if flavour = `Flexible then
+      TypeVarSet.add id set
+    else
+      set
+  in
+  List.fold_left add_if_flexible TypeVarSet.empty free_vars
+
 (** Type printers *)
 
 module Policy = struct

--- a/core/types.mli
+++ b/core/types.mli
@@ -251,6 +251,7 @@ val is_builtin_effect : string -> bool
 
 (** get type variables *)
 val free_type_vars : datatype -> TypeVarSet.t
+val free_flexible_type_vars : datatype -> TypeVarSet.t
 val free_row_type_vars : row -> TypeVarSet.t
 val free_tyarg_vars : type_arg -> TypeVarSet.t
 val free_bound_type_vars          : typ      -> Vars.vars_list

--- a/tests/polymorphism.tests
+++ b/tests/polymorphism.tests
@@ -258,3 +258,8 @@ Type abstraction: correct, shadowing (3)
 exit : 0
 stdout : fun : forall a::Row.(Int) -a-> Int
 args : --set=show_quantifiers=true
+
+Type abstraction: incorrect, violates value restriction
+/\ [e::Row]. {  id(id : ( (Int) -e-> Int )) }
+exit : 1
+stderr : @.*Type error:.*Because of the value restriction, the expression .*cannot be generalised.*

--- a/tests/polymorphism.tests
+++ b/tests/polymorphism.tests
@@ -193,3 +193,68 @@ Signatures (var): free variable in body, quantified sig (7)
 fun f(x) {x}     sig x : forall a. (a) -> a var x = f : ((a) -> a); x
 exit : 1
 stderr : @.*Type error:.*
+
+# Tests for type abstractions /\ [...]. { ... }
+
+Type abstraction: correct, non-polymorphic body
+/\ [a]. { 123 }
+exit : 0
+stdout : 123 : forall a.Int
+args : --set=show_quantifiers=true
+
+Type abstraction: correct, polymorphic body
+/\ [a]. { $(fun(x){x}) }
+exit : 0
+stdout : fun : forall a,b::(Any,Any),c::Row.(b::Any) -c-> b::Any
+args : --set=show_quantifiers=true
+
+Type abstraction: correct, use type variable in signature
+/\ [a]. { sig f : (a) {}-> a fun f(x){x : a} f }
+exit : 0
+stdout : fun : forall a.(a) {}-> a
+args : --set=show_quantifiers=true
+
+Type abstraction: correct, use type variable in body
+# Note that we need the signature to enforce a function without effects
+/\ [a]. { sig f : (%b) {}-> %b fun f (x) {x : a} ~f }
+exit : 0
+stdout : fun : forall a.(a) {}-> a
+args : --set=show_quantifiers=true
+
+Type abstraction: Ambigous type (1)
+# The lambda has type (%b) -%e-> %b, so we must fail
+/\ [a]. { fun(x) { x } }
+exit : 1
+stderr : @.*Type error:.*The phrase under a type abstraction must have a unique type.*
+
+Type abstraction: Ambigous type (2)
+# This example is somewhat tricky.
+# One may assume that calling g from the toplevel fixes its effect and we can therefore accept this program.
+# However, If we did allow this, then g wouldn't have a most general type before the call g(): Both
+# forall e :: Row. (Int) -e-> (Int) and
+# forall e :: Row. (Int) -R-> (Int) for any effect row R would be an option.
+# We would like our terms to have most general types at any point, not just at the end of type-checking.
+# Therefore, we require that the body of the /\ must have unqiue type immediately after checking
+# it. Unifying away the flexible variables afterwards doesn't save us.
+var g = /\ [e::Row]. { fun(x) { x + 1 } }; g()
+exit : 1
+stderr : @.*Type error:.*The phrase under a type abstraction must have a unique type.*
+
+Type abstraction: correct, shadowing (1)
+sig f : () -a-> (forall b.()) fun f() {  /\ [a]. {  sig g : (a) {}-> a fun g(x){x} ()   } } f
+exit : 0
+stdout : fun : forall a::Row.() -a-> forall b.()
+args : --set=show_quantifiers=true
+
+Type abstraction: correct, shadowing (2)
+# Like previous version, but this time with an explicit forall on the outer variable a!
+sig f : forall a::Row. () -a-> (forall b.()) fun f() {  /\ [a]. {  sig g : (a) {}-> a fun g(x){x} ()   } } f
+exit : 0
+stdout : fun : forall a::Row.() -a-> forall b.()
+args : --set=show_quantifiers=true
+
+Type abstraction: correct, shadowing (3)
+/\ [e::Row]. { sig f : forall e. (e) {}-> e fun f(x){x}  id : ( (Int) -e-> Int ) }
+exit : 0
+stdout : fun : forall a::Row.(Int) -a-> Int
+args : --set=show_quantifiers=true


### PR DESCRIPTION
This PR enables writing expression of the form `/\ [Q]. { E }`, where Q is a list of quantifiers and E is an expression with the quantifiers Q in scope. Assuming that E has type T, the overall type is `forall Q.T`.

 For example, we may write
```
  /\ [a, e :: Row] { sig f : (a) -e-> a fun f(x) {x} ~f }
```
of type `forall a, e::Row. (a) -e-> a`.

One important restriction to ensure that such /\ expressions have most general types is that the type T of E must be unambiguous/unique.
As an example why this is important, consider the following function:
```
fun outer() {
  var inner = /\ [e::Row] { fun f(x) {x + 1} };
  ~inner
}
```
What should `outer`'s type be? If the inner function uses `e` as its effect variable, we have 
```
outer : forall e::Row. (Int) -e-> (Int)
```

However, if the inner function uses some arbitrary effect %f as its effect variable, the binding of `inner` could generalize this independently, and we would get
```
outer : forall f::Row, e::Row. (Int) -f-> (Int)
``` 

We avoid all these problems with a simple rule: After type-checking any type abstraction of the form mentioned initially, we require that the type T of E does not contain any flexible type variable. This is sufficient to ensure that E has a unique type.

My plan is to integrate similar syntax using quantifiers in square brackets into `fun` and `rec` bindings in a follow-up PR.
