### PR TITLE
Fixes #1067

### DIFF
--- a/core/query/evalMixingQuery.ml
+++ b/core/query/evalMixingQuery.ml
@@ -36,14 +36,14 @@ and disjunct is_set = function
 | QL.Prom p -> sql_of_query S.Distinct p
 | QL.Singleton _ as j -> S.Select (body is_set [] [] j)
 | QL.For (_, gs, os, j) -> S.Select (body is_set gs os j)
-| _arg -> Debug.print ("error in SimpleSqlGen.disjunct: unexpected arg = " ^ QL.show _arg); failwith "disjunct"
+| _arg -> Debug.print ("error in EvalMixingQuery.disjunct: unexpected arg = " ^ QL.show _arg); failwith "disjunct"
 
 and generator locvars = function
 | (v, QL.Prom p) -> (S.Subquery (dependency_of_contains_free (E.contains_free locvars p), sql_of_query S.Distinct p, v))
 | (v, QL.Table (_, tname, _, _)) -> (S.TableRef (tname, v))
 | (v, QL.Dedup (QL.Table (_, tname, _, _))) ->
     S.Subquery (S.Standard, S.Select (S.Distinct, S.Star, [S.TableRef (tname, v)], S.Constant (Constant.Bool true), []), v)
-| (_, _arg) -> Debug.print ("error in SimpleSqlGen.disjunct: unexpected arg = " ^ QL.show _arg); failwith "generator"
+| (_, _arg) -> Debug.print ("error in EvalMixingQuery.disjunct: unexpected arg = " ^ QL.show _arg); failwith "generator"
 
 and body is_set gs os j =
     let selquery body where =

--- a/core/query/mixingQuery.ml
+++ b/core/query/mixingQuery.ml
@@ -56,8 +56,8 @@ let rec freshen_for_bindings : Var.var Env.Int.t -> Q.t -> Q.t =
     | Q.Singleton v -> Q.Singleton (ffb v)
     | Q.Database db -> Q.Database db
     | Q.Concat vs -> Q.Concat (List.map ffb vs)
-    | Q.Dedup q -> ffb q
-    | Q.Prom q -> ffb q
+    | Q.Dedup q -> Q.Dedup (ffb q)
+    | Q.Prom q -> Q.Prom (ffb q)
     | Q.Record fields -> Q.Record (StringMap.map ffb fields)
     | Q.Variant (name, v) -> Q.Variant (name, ffb v)
     | Q.XML xmlitem -> Q.XML xmlitem

--- a/core/query/queryLang.ml
+++ b/core/query/queryLang.ml
@@ -373,6 +373,7 @@ let used_database v : Value.database option =
         end
   and used =
     function
+      | Prom q | Dedup q -> used q
       | Table ((db, _), _, _, _) -> Some db
       | For (_, gs, _, _body) -> List.map snd gs |> traverse
       | Singleton v -> used v
@@ -439,8 +440,7 @@ let lookup_fun env (f, fvs) =
         (* TODO(dhil): This is a bit of a round-about way to obtain
             the binder name. *)
       match Var.(name_of_binder (make_binder f finfo)) with
-      | "dedup"
-      | "distinct" ->
+      | "dedup" ->
         Primitive "Distinct"
       | "concatMap" ->
         Primitive "ConcatMap"

--- a/core/query/queryLang.ml
+++ b/core/query/queryLang.ml
@@ -393,21 +393,10 @@ let used_database : t -> Value.database option =
       | Erase (x, _) -> used x
       | Variant (_, x) -> used x
       | _ -> None
-  and used = 
+  and used =
     function
       | Concat vs -> traverse vs
       | v -> used_item v
-(* just use traverse! 
-  let rec comprehensions =
-    function
-      | [] -> None
-      | v::vs ->
-          begin
-            match used v with
-              | None -> comprehensions vs
-              | Some db -> Some db
-          end
-*)
   in used
 
 let string_of_t = string_of_t

--- a/lib/js/jslib.js
+++ b/lib/js/jslib.js
@@ -451,7 +451,10 @@ const WEBSOCKET = {
           case "MESSAGE_DELIVERY":
             DEBUG.debug("In message delivery case");
             var local_pid = js_parsed.dest_pid;
-            var msg = js_parsed.val;
+             // TODO(dhil): We should probably pass the parsed JSON
+             // state here, but it is not available in this scope. A
+             // refactoring of this code is warranted.
+            var msg = LINKS.resolveServerValue(null, js_parsed.val);
             LINKS.deliverMessage(local_pid, msg);
             break;
           case "AP_RESPONSE":
@@ -463,7 +466,10 @@ const WEBSOCKET = {
             break;
           case "SESSION_MESSAGE_DELIVERY":
             var ep_id = js_parsed.ep_id;
-            var message = LINKS.resolveServerValue(null, js_parsed.msg); // TODO(dhil): We should probably pass the parsed JSON state here, but it is not available in this scope. A refactoring of this code is warranted.
+            // TODO(dhil): We should probably pass the parsed JSON
+            // state here, but it is not available in this scope. A
+            // refactoring of this code is warranted.
+            var message = LINKS.resolveServerValue(null, js_parsed.msg);
             var delegated_chans = js_parsed.deleg_chans;
             var requires_lost_messages = js_parsed.requires_lost_messages;
             migrateDelegatedSessions(delegated_chans, requires_lost_messages);

--- a/tests/database/mixing.links
+++ b/tests/database/mixing.links
@@ -1,0 +1,10 @@
+var db = database "links";
+var bagtable = table "bagtable" with (i : Int) from db;
+
+fun test() {
+    assertEq(query mixing { distinct(bagtable) }, [(i=0)]);
+    assertEq(query mixing { dedup(for (x <-- bagtable) [x]) }, [(i=0)]);
+    assertEq(query mixing { for (x <- distinct(bagtable)) [x] }, [(i=0)])
+}
+
+test()

--- a/tests/database/mixing.sql
+++ b/tests/database/mixing.sql
@@ -1,0 +1,8 @@
+DROP TABLE IF EXISTS bagtable;
+
+CREATE TABLE bagtable (
+    i integer
+);
+
+
+INSERT INTO bagtable VALUES (0) , (0);

--- a/tests/database/testsuite.json
+++ b/tests/database/testsuite.json
@@ -5,6 +5,7 @@
  "setups" :
  [ "factorials",
    "null",
+   "mixing",
    "regexes",
    "xpath-reduced",
    "xpath" ],
@@ -14,6 +15,7 @@
    "empty",
    "emptyfun",
    "null",
+   "mixing",
    "regexes",
    "unit",
    "xpath",


### PR DESCRIPTION
This PR fixes issue #1067 with queries using deduplication:

The fix consists of three small changes:

- the function `QueryLang.used_database`, which incorrectly ignored deduplicated subexpressions, now performs recursion under deduplication: this corrects the "unoptimized query" problem (which was caused by Links incrrectly determining that deduplicated subexpressions didn't require the database)

- the function `MixingQuery.freshen_for_bindings` was incorrectly throwing away `Q.Prom` and `Q.Dedup` constructors when performing recursion. This was at the basis of the problem that caused certain uses of distinct/dedup to be ineffective and has been fixed

- the function `QueryLang.lookup_fun` does NOT hardcode `distinct` as a `Primitive` operation any more, letting Links unfold it to a composition of `asList` and `dedup` (`dedup`, however, will still be hardcoded as a `Primitive`); this ensures that normalized queries have the expected normal form and fixes a "fatal error: disjunct" problem that was not detected in the issue, but still occurred when evaluating queries in the form `query { distinct(factorials) }`.