### PR TITLE
Fixes #1075

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,6 +4,8 @@
   For instance, writing `/\ [a, e::Row] { foo }` abstracts the expression `foo`
   over type variable `a` and row variable `e`. Here, `foo` must have a unique
   type and must be pure (to satisfy the value restriction).
+* Fixed a bug in "mixing" query normalisation, which prevented certain queries using 
+  concatenation inside `for` statements from being correctly converted to SQL.
 
 # 0.9.5
 

--- a/core/query/mixingQuery.ml
+++ b/core/query/mixingQuery.ml
@@ -211,7 +211,6 @@ let rec reduce_where_then (c, t) =
 let rec reduce_for_body (gs, os, body) =
   let rb = reduce_for_body in
   match body with
-    (* | Concat []                 -> body *)
     | Q.For (_, gs', os', body') -> rb (gs @ gs', os @ os', body')
     (* | Prom _ as u               ->
           let z = Var.fresh_raw_var () in

--- a/core/query/mixingQuery.ml
+++ b/core/query/mixingQuery.ml
@@ -208,10 +208,11 @@ let rec reduce_where_then (c, t) =
   | _ ->
     Q.If (c, t, Q.Concat [])
 
-let reduce_for_body (gs, os, body) =
+let rec reduce_for_body (gs, os, body) =
+  let rb = reduce_for_body in
   match body with
     (* | Concat []                 -> body *)
-    | Q.For (_, gs', os', body') -> Q.For (None, gs @ gs', os @ os', body')
+    | Q.For (_, gs', os', body') -> rb (gs @ gs', os @ os', body')
     (* | Prom _ as u               ->
           let z = Var.fresh_raw_var () in
           let tyz = type_of_expression u in
@@ -220,6 +221,7 @@ let reduce_for_body (gs, os, body) =
           For (None, gs @ [(z, u)], [] (* os *), (Singleton vz)) *)
     (* make sure when we reach this place, gs can NEVER be empty
       | _ when gs = [] (* && _os = [] *) -> body *)
+    | Q.Concat vs -> reduce_concat (List.map (fun v -> rb (gs, os, v)) vs)
     | _                         -> Q.For (None, gs, os, body)
 
 let rec reduce_for_source : Q.env -> var * Q.t * Types.datatype -> (Q.env -> (Q.t list -> Q.t list) -> Q.t) -> Q.t =

--- a/tests/database/mixing.links
+++ b/tests/database/mixing.links
@@ -4,7 +4,8 @@ var bagtable = table "bagtable" with (i : Int) from db;
 fun test() {
     assertEq(query mixing { distinct(bagtable) }, [(i=0)]);
     assertEq(query mixing { dedup(for (x <-- bagtable) [x]) }, [(i=0)]);
-    assertEq(query mixing { for (x <- distinct(bagtable)) [x] }, [(i=0)])
+    assertEq(query mixing { for (x <- distinct(bagtable)) [x] }, [(i=0)]);
+    assertEq(query mixing { for (x <-- bagtable) [(i=0,j=x.i)] }, [(i=0,j=0),(i=0,j=0)])
 }
 
 test()

--- a/tests/database/mixing.links
+++ b/tests/database/mixing.links
@@ -5,7 +5,7 @@ fun test() {
     assertEq(query mixing { distinct(bagtable) }, [(i=0)]);
     assertEq(query mixing { dedup(for (x <-- bagtable) [x]) }, [(i=0)]);
     assertEq(query mixing { for (x <- distinct(bagtable)) [x] }, [(i=0)]);
-    assertEq(query mixing { for (x <-- bagtable) [(i=0,j=x.i)] }, [(i=0,j=0),(i=0,j=0)])
+    assertEq(query mixing { for (x <-- bagtable) [(a=x.i),(a=x.i)] }, [(a=0),(a=0),(a=0),(a=0)])
 }
 
 test()


### PR DESCRIPTION
This is straightforward: the mixing normaliser (`mixingQuery.ml`) has an issue with `For` when its body is a `Concat`: the comprehension would normally be split along concatenation, but this does not happen. 

The issue is caused by the changes made to normalisation to allow it to consider normal forms where comprehension generators can be complex queries: in order for these changes to work, we must add a recursive call to `MixingQuery.reduce_for_body` (which until now was non-recursive).

The old normaliser doesn't show this bug, for reasons not entirely clear (but related to the simpler structure of homogeneous bag normal forms). However it's now advisable that the code responsible for normalising comprehensions should be refactored to make its rationale more understandable (without a clear rationale, every further change is at risk of creating new bugs).