### PR TITLE
Add option to save the output of the JavaScript compiler

### DIFF
--- a/bin/repl.ml
+++ b/bin/repl.ml
@@ -348,7 +348,7 @@ let interact : Context.t -> unit
   let print_error exn =
     Printf.fprintf stderr "%s\n%!" (Errors.format_exception exn)
   in
-  Settings.set BS.interactive_mode true;
+  Settings.set BS.System.interactive_mode true;
   Printf.printf "%s%!" (val_of (Settings.get welcome_note));
   let rec loop context =
     Parse.Readline.prepare_prompt ps1;

--- a/core/PP.ml
+++ b/core/PP.ml
@@ -45,6 +45,17 @@ let sdocToString d =
     sdocToString buf d;
     Buffer.contents buf
 
+let rec output : out_channel -> sdoc -> unit
+  = fun oc doc ->
+    match doc with
+    | SNil -> ()
+    | SText(s,d) -> output_string oc s; output oc d
+    | SLine(i,d) ->
+      let prefix = String.make i ' ' in
+      output_string oc nl;
+      output_string oc prefix;
+      output oc d
+
 type mode =
   | Flat
   | Break
@@ -152,3 +163,8 @@ let pretty w doc =
   let sdoc = format w 0 [0,Flat, DocGroup doc] (fun d -> d) in
   let str = sdocToString sdoc in
   str
+
+let out_pretty : out_channel -> int -> doc -> unit
+  = fun oc w doc ->
+    let sdoc = format w 0 [0, Flat, DocGroup doc] (fun d -> d) in
+    output oc sdoc; flush oc

--- a/core/basicsettings.ml
+++ b/core/basicsettings.ml
@@ -1,11 +1,3 @@
-(** [true] if we're in interactive mode *)
-let interactive_mode =
-  Settings.(flag "interactive_mode"
-            |> synopsis "Signifies whether Links is running in REPL mode"
-            |> privilege `System
-            |> convert parse_bool
-            |> sync)
-
 (** The banner *)
 let version = "0.9.5 (Burghmuirhead)"
 let version = Settings.(option ~default:(Some version) ~readonly:true "version"
@@ -49,4 +41,68 @@ module Sessions = struct
               |> convert parse_bool
               |> CLI.(add (long "session-exceptions"))
               |> sync)
+end
+
+module System = struct
+  type mode = Interactive
+            | Compile
+            | Web
+  let mode =
+    let parse_mode s =
+      match String.lowercase_ascii s with
+      | "interact"    -> Some Interactive
+      | "compile"     -> Some Compile
+      | "web"         -> Some Web
+      | _ -> raise (Invalid_argument (Printf.sprintf "Unrecognised mode '%s'" s))
+    in
+    let string_of_mode = function
+      | Some Interactive -> "interact"
+      | Some Compile -> "compile"
+      | Some Web -> "web"
+      | None -> "<none>"
+    in
+    Settings.(option "mode"
+              |> privilege `System
+              |> synopsis "Instructs Links to run in interactive, compilation, or web mode"
+              |> convert parse_mode
+              |> hidden
+              |> to_string string_of_mode
+              |> hint "<compile|interact|web>"
+              |> CLI.(add (long "mode"))
+              |> sync)
+
+  let compile_mode =
+    Settings.(flag "compile" ~default:false
+              |> privilege `System
+              |> synopsis "Toggles compilation mode"
+              |> action (fun _ -> set mode (Some Compile))
+              |> hidden
+              |> CLI.(add (long "compile" <&> short 'c'))
+              |> sync)
+
+  (* TODO(dhil): The notion of output file might need to be
+     generalised as we add more backends to Links or decide to add
+     support for dumping other compilation artefacts. *)
+  let output_file =
+    Settings.(option "output_file" ~default:(Some "a.js")
+              |> privilege `User
+              |> synopsis "Set output file name to <file>"
+              |> hint "<file>"
+              |> to_string from_string_option
+              |> CLI.(add (long "output" <&> short 'o'))
+              |> sync)
+
+  let interactive_mode =
+    Settings.(flag "interactive_mode"
+              |> synopsis "Toggles interactive mode"
+              |> privilege `System
+              |> action (fun _ -> set mode (Some Interactive))
+              |> hidden
+              |> sync)
+
+  let is_interacting () =
+    match Settings.get mode with
+    | Some Interactive -> true
+    | _ -> false
+
 end

--- a/core/desugarModules.ml
+++ b/core/desugarModules.ml
@@ -534,7 +534,7 @@ let renamer : Epithet.t ref = ref Epithet.empty
 
 let desugar_program : Sugartypes.program -> Sugartypes.program
   = fun program ->
-  let interacting = Settings.get Basicsettings.interactive_mode in
+  let interacting = Basicsettings.System.is_interacting () in
   (* TODO move to this logic to the loader. *)
   let program = Chaser.add_dependencies program in
   let program = DesugarAlienBlocks.transform_alien_blocks program in

--- a/core/errors.ml
+++ b/core/errors.ml
@@ -54,6 +54,8 @@ exception DisabledExtension of Position.t option * (string * bool) option * stri
 exception PrimeAlien of Position.t
 exception ForbiddenClientCall of string * string
 exception MissingBuiltinType of string
+exception CannotOpenFile of string * string
+exception ObjectFileWriteError of string * string
 
 exception LocateFailure of string
 let driver_locate_failure driver = LocateFailure driver
@@ -189,6 +191,10 @@ let format_exception =
   | ForbiddenClientCall (fn, reason) ->
      pos_prefix (Printf.sprintf "Error: Cannot call client side function '%s' because of %s\n" fn reason)
   | MissingBuiltinType alias -> Printf.sprintf "Error: Missing builtin type with alias '%s'. Is it defined in the prelude?" alias
+  | CannotOpenFile (filename, reason) ->
+     Printf.sprintf "Error: Cannot open file '%s' (%s)\n" filename reason
+  | ObjectFileWriteError (filename, reason) ->
+    Printf.sprintf "Error: Cannot write to file '%s' (%s)\n" filename reason
   | Sys.Break -> "Caught interrupt"
   | exn -> pos_prefix ("Error: " ^ Printexc.to_string exn)
 
@@ -236,3 +242,5 @@ let disabled_extension ?pos ?setting ?flag name =
   DisabledExtension (pos, setting, flag, name)
 let prime_alien pos = PrimeAlien pos
 let forbidden_client_call fn reason = ForbiddenClientCall (fn, reason)
+let cannot_open_file filename reason = CannotOpenFile (filename, reason)
+let object_file_write_error filename reason = ObjectFileWriteError (filename, reason)

--- a/core/errors.mli
+++ b/core/errors.mli
@@ -38,6 +38,8 @@ exception SettingsError of string
 exception DynlinkError of string
 exception ModuleError of string * Position.t option
 exception MissingBuiltinType of string
+exception CannotOpenFile of string * string
+exception ObjectFileWriteError of string * string
 
 val format_exception : exn -> string
 val format_exception_html : exn -> string
@@ -58,3 +60,5 @@ val dependency_load_failure : string -> Dynlink.error -> exn
 val load_failure : string -> Dynlink.error -> exn
 val forbidden_client_call : string -> string -> exn
 val rethrow_errors_if_better_position : Position.t -> ('a -> 'b) -> 'a -> 'b
+val cannot_open_file : string -> string -> exn
+val object_file_write_error : string -> string -> exn

--- a/core/irtojs.ml
+++ b/core/irtojs.ml
@@ -126,6 +126,7 @@ let __kappa = "__kappa"
 
 module type JS_CODEGEN = sig
   val string_of_js : code -> string
+  val output : out_channel -> code -> unit
 end
 
 module Js_CodeGen : JS_CODEGEN = struct
@@ -133,6 +134,7 @@ module Js_CodeGen : JS_CODEGEN = struct
   module PP :
   sig
     val show : code -> string
+    val output : out_channel -> code -> unit
   end =
     struct
       open PP
@@ -222,10 +224,12 @@ module Js_CodeGen : JS_CODEGEN = struct
         | Return expr ->
            PP.text "return " ^^ (show expr) ^^ PP.text ";"
 
+      let output oc = show ->- PP.out_pretty oc 144
       let show = show ->- PP.pretty 144
     end
 
   let string_of_js x = PP.show x
+  let output oc code = PP.output oc code
 end
 
 (** Create a JS string literal, quoting special characters *)

--- a/core/irtojs.mli
+++ b/core/irtojs.mli
@@ -41,5 +41,6 @@ module Compiler : JS_PAGE_COMPILER
 
 module type JS_CODEGEN = sig
   val string_of_js : code -> string
+  val output : out_channel -> code -> unit
 end
 module Js_CodeGen : JS_CODEGEN

--- a/tests/shredding/config.pgsql
+++ b/tests/shredding/config.pgsql
@@ -1,3 +1,3 @@
 database_driver=postgresql
-database_args=localhost:5433:links:links
+database_args=$LINKS_POSTGRES_HOST:$LINKS_POSTGRES_PORT:$LINKS_POSTGRES_USER:$LINKS_POSTGRES_PASSWORD
 show_pre_sugar_typing=off


### PR DESCRIPTION
This patch makes it possible to run Links in a "compile only mode"
which will store the output of `Irtojs.generate_program` in a
file. Note that the generated file may not be directly runnable
without linking the runtime system first. As of writing, the runtime
system must be linked manually, if required.