### PR TITLE
Secure connections

### DIFF
--- a/core/errors.ml
+++ b/core/errors.ml
@@ -54,6 +54,7 @@ exception DisabledExtension of Position.t option * (string * bool) option * stri
 exception PrimeAlien of Position.t
 exception ForbiddenClientCall of string * string
 exception MissingBuiltinType of string
+exception MissingSSLCertificate
 
 exception LocateFailure of string
 let driver_locate_failure driver = LocateFailure driver
@@ -189,6 +190,7 @@ let format_exception =
   | ForbiddenClientCall (fn, reason) ->
      pos_prefix (Printf.sprintf "Error: Cannot call client side function '%s' because of %s\n" fn reason)
   | MissingBuiltinType alias -> Printf.sprintf "Error: Missing builtin type with alias '%s'. Is it defined in the prelude?" alias
+  | MissingSSLCertificate -> "Error: SSL mode requires both a valid certificate and key\n"
   | Sys.Break -> "Caught interrupt"
   | exn -> pos_prefix ("Error: " ^ Printexc.to_string exn)
 

--- a/core/errors.mli
+++ b/core/errors.mli
@@ -38,6 +38,7 @@ exception SettingsError of string
 exception DynlinkError of string
 exception ModuleError of string * Position.t option
 exception MissingBuiltinType of string
+exception MissingSSLCertificate
 
 val format_exception : exn -> string
 val format_exception_html : exn -> string

--- a/core/page.ml
+++ b/core/page.ml
@@ -160,8 +160,10 @@ module Make_RealPage (C : JS_PAGE_COMPILER) (G : JS_CODEGEN) = struct
       ~cgi_env
       ~body:printed_code
       ~html:(Value.string_of_xml ~close_tags:true bs)
-      ~head:(script_tag welcome_msg ^ "\n" ^ script_tag (C.primitive_bindings) ^ "\n" ^ script_tag("  var _jsonState = " ^ escaped_state_string ^ "\n" ^ init_vars)
-             ^ Value.string_of_xml ~close_tags:true hs)
+      ~head:(script_tag welcome_msg ^ "\n"
+              ^ script_tag (C.primitive_bindings) ^ "\n"
+              ^ script_tag("  var _jsonState = " ^ escaped_state_string ^ "\n" ^ init_vars)
+              ^ Value.string_of_xml ~close_tags:true hs)
       ~onload:"_isRuntimeReady() && _startRealPage()"
       ~external_files:deps
       []

--- a/core/webserver.ml
+++ b/core/webserver.ml
@@ -25,6 +25,29 @@ let port =
             |> convert (fun n -> Some (int_of_string n))
             |> sync)
 
+(* SSL settings *)
+let ssl_cert_file =
+  Settings.(option "ssl_cert_file"
+            |> privilege `System
+            |> synopsis "The SSL certificate"
+            |> convert Utility.(Sys.expand ->- some)
+            |> to_string from_string_option
+            |> sync)
+
+let ssl_key_file =
+  Settings.(option "ssl_key_file"
+            |> privilege `System
+            |> synopsis "The SSL key file"
+            |> convert Utility.(Sys.expand ->- some)
+            |> to_string from_string_option
+            |> sync)
+
+let ssl =
+  Settings.(flag ~default:false "ssl"
+            |> synopsis "Toggles secure mode for all connections"
+            |> convert parse_bool
+            |> sync)
+
 (* Base URL for websocket connections *)
 let websocket_url
   = let parse_ws_url url =
@@ -352,7 +375,15 @@ struct
       Conduit_lwt_unix.init ~src:host () >>= fun ctx ->
       let ctx = Cohttp_lwt_unix.Net.init ~ctx () in
       Debug.print ("Starting server (2)?\n");
-      Cohttp_lwt_unix.Server.create ~ctx ~mode:(`TCP (`Port port))
+      let mode =
+        if Settings.get ssl
+        then match Settings.get ssl_cert_file, Settings.get ssl_key_file with
+          | Some cert, Some key ->
+                `TLS ((`Crt_file_path cert), (`Key_file_path key), `No_password, (`Port port))
+          | _, _ -> raise Errors.MissingSSLCertificate
+        else `TCP (`Port port)
+      in
+      Cohttp_lwt_unix.Server.create ~ctx ~mode
         (Cohttp_lwt_unix.Server.make_response_action ~callback:(callback rt render_cont) ()) in
 
     Debug.print ("Starting server?\n");

--- a/core/webserver_types.mli
+++ b/core/webserver_types.mli
@@ -6,7 +6,6 @@ val jslib_url : string option Settings.setting
 val internal_base_url : string option Settings.setting
 val external_base_url : string option Settings.setting
 
-
 module type WEBSERVER =
 sig
   type request_handler_fn = { request_handler: Value.env * Value.t; error_handler: Value.env * Value.t }

--- a/lib/js/jslib.js
+++ b/lib/js/jslib.js
@@ -378,8 +378,8 @@ const WEBSOCKET = {
         path = "";
       }
     }
-    let protocol = location.protocol === "https" ? "wss" : "ws";
-    return protocol + "://" + loc.host + "/" + path + "/" + _client_id;
+    let protocol = location.protocol === "https:" ? "wss:" : "ws:";
+    return protocol + "//" + loc.host + "/" + path + "/" + _client_id;
   },
 
   connect_if_required: function (state) {

--- a/lib/js/jslib.js
+++ b/lib/js/jslib.js
@@ -378,8 +378,8 @@ const WEBSOCKET = {
         path = "";
       }
     }
-
-    return "ws://" + loc.host + "/" + path + "/" + _client_id;
+    let protocol = location.protocol === "https" ? "wss" : "ws";
+    return protocol + "://" + loc.host + "/" + path + "/" + _client_id;
   },
 
   connect_if_required: function (state) {

--- a/links.opam
+++ b/links.opam
@@ -30,6 +30,7 @@ depends: [
   "cohttp-lwt-unix"
   "conduit-lwt-unix"
   "uri"
+  "tls"
   "websocket"
   "websocket-lwt-unix"
   "safepass"


### PR DESCRIPTION
This patch makes it possible for the built-in webserver to serve
requests via https.

To enable secure connections, you must first obtain an adequate
certificate and key, e.g. via Let's Encrypt or a self-signed
certificate. The latter can be useful for testing, e.g. the following
command starts an interactive process to create a self-signed
certificate (that uses 4096 bits RSA encryption and is valid for 365 days):

```shell
openssl req -x509 -newkey rsa:4096 -keyout server.key -out server.crt -days 365 -nodes
```

After obtaining a valid certificate, you must tell Links to run in SSL
mode and you must also tell it how to locate the `key` and `crt` file. This can be done via a configuration file, e.g.

```
# ssl.config
ssl=true
ssl_cert_file=server.crt
ssl_key_file=server.key
```

Then running `./links --config=ssl.config <file.links>` will cause the
built-in webserver to only serve requests via https.

When a webpage is served via https, then the websocket layer will
automatically communicate via the wss protocol.

Note the error handling around certificates is fairly minimal. For
example, if a certificate file or key file is not found it dumps a
stack trace.