### PR TITLE
Fix #1088

### DIFF
--- a/core/types.ml
+++ b/core/types.ml
@@ -3990,6 +3990,7 @@ module RoundtripPrinter : PRETTY_PRINTER = struct
 
             | Meta pt            -> meta ctx pt
             | Present t          -> with_value presence t
+            | Absent             -> constant "-"
             | Primitive t        -> with_value primitive t
 
             | Function f         -> let ambient = if Context.is_ambient_effect ctx


### PR DESCRIPTION
This commit is a quick fix for #1088. It appears that the roundtrip
pretty printer cannot handle `Absent` appearing as a type argument
(which has been possible since #1000).

Resolves #1088.