### PR TITLE
Fix #1090

### DIFF
--- a/core/query/sql.ml
+++ b/core/query/sql.ml
@@ -274,13 +274,14 @@ class virtual printer =
             Format.pp_print_string (order_by_clause n)
       | Union (mult, qs, n) ->
         let pp_sep_union ppf () = Format.fprintf ppf "\nunion %a\n" pp_all mult in
-        let pp_value ppf x =
+        let pp_union_term ppf x =
           match x with  (* parenthesize safely wrt SQL standard *)
           | Select _ -> pr_q ppf x
           | _ -> Format.fprintf ppf "select * from (%a)" pr_q x
-        in
-        Format.fprintf ppf "%a%a"
-          (Format.pp_print_list ~pp_sep:pp_sep_union pp_value) qs
+        in 
+          (* defensively add a select in case there is an order by clause *)
+        Format.fprintf ppf "select * from (%a)%a"
+          (Format.pp_print_list ~pp_sep:pp_sep_union pp_union_term) qs
           Format.pp_print_string (order_by_clause n)
       | Select (_, fields, [], Constant (Constant.Bool true), _os) ->
         Format.fprintf ppf "select %a" pp_fields fields

--- a/core/query/sql.ml
+++ b/core/query/sql.ml
@@ -274,11 +274,11 @@ class virtual printer =
             Format.pp_print_string (order_by_clause n)
       | Union (mult, qs, n) ->
         let pp_sep_union ppf () = Format.fprintf ppf "\nunion %a\n" pp_all mult in
-        let pp_value ppf x = 
+        let pp_value ppf x =
           match q with  (* parenthesize safely wrt SQL standard *)
           | Select _ -> Format.fprintf ppf "%a" pr_q x
           | _ -> Format.fprintf ppf "select * from (%a)" pr_q x
-        in 
+        in
         Format.fprintf ppf "%a%a"
           (Format.pp_print_list ~pp_sep:pp_sep_union pp_value) qs
           Format.pp_print_string (order_by_clause n)

--- a/core/query/sql.ml
+++ b/core/query/sql.ml
@@ -276,7 +276,7 @@ class virtual printer =
         let pp_sep_union ppf () = Format.fprintf ppf "\nunion %a\n" pp_all mult in
         let pp_value ppf x =
           match x with  (* parenthesize safely wrt SQL standard *)
-          | Select _ -> Format.fprintf ppf "%a" pr_q x
+          | Select _ -> pr_q ppf x
           | _ -> Format.fprintf ppf "select * from (%a)" pr_q x
         in
         Format.fprintf ppf "%a%a"

--- a/core/query/sql.ml
+++ b/core/query/sql.ml
@@ -277,7 +277,7 @@ class virtual printer =
         let pp_value ppf x =
           match q with  (* parenthesize safely wrt SQL standard *)
           | Select _ -> Format.fprintf ppf "%a" pr_q x
-          | _ -> Format.fprintf ppf "select * from (%a)" pr_q x
+          | _ -> Format.fprintf ppf "select * from (%a) where 1=1" pr_q x
         in
         Format.fprintf ppf "%a%a"
           (Format.pp_print_list ~pp_sep:pp_sep_union pp_value) qs

--- a/core/query/sql.ml
+++ b/core/query/sql.ml
@@ -275,9 +275,9 @@ class virtual printer =
       | Union (mult, qs, n) ->
         let pp_sep_union ppf () = Format.fprintf ppf "\nunion %a\n" pp_all mult in
         let pp_value ppf x =
-          match q with  (* parenthesize safely wrt SQL standard *)
+          match x with  (* parenthesize safely wrt SQL standard *)
           | Select _ -> Format.fprintf ppf "%a" pr_q x
-          | _ -> Format.fprintf ppf "select * from (%a) where 1=1" pr_q x
+          | _ -> Format.fprintf ppf "select * from (%a)" pr_q x
         in
         Format.fprintf ppf "%a%a"
           (Format.pp_print_list ~pp_sep:pp_sep_union pp_value) qs

--- a/core/query/sql.ml
+++ b/core/query/sql.ml
@@ -279,8 +279,7 @@ class virtual printer =
           | Select _ -> pr_q ppf x
           | _ -> Format.fprintf ppf "select * from (%a)" pr_q x
         in 
-          (* defensively add a select in case there is an order by clause *)
-        Format.fprintf ppf "select * from (%a)%a"
+        Format.fprintf ppf "%a%a"
           (Format.pp_print_list ~pp_sep:pp_sep_union pp_union_term) qs
           Format.pp_print_string (order_by_clause n)
       | Select (_, fields, [], Constant (Constant.Bool true), _os) ->

--- a/core/query/sql.ml
+++ b/core/query/sql.ml
@@ -274,7 +274,11 @@ class virtual printer =
             Format.pp_print_string (order_by_clause n)
       | Union (mult, qs, n) ->
         let pp_sep_union ppf () = Format.fprintf ppf "\nunion %a\n" pp_all mult in
-        let pp_value ppf x = Format.fprintf ppf "(%a)" pr_q x in
+        let pp_value ppf x = 
+          match q with  (* parenthesize safely wrt SQL standard *)
+          | Select _ -> Format.fprintf ppf "%a" pr_q x
+          | _ -> Format.fprintf ppf "select * from (%a)" pr_q x
+        in 
         Format.fprintf ppf "%a%a"
           (Format.pp_print_list ~pp_sep:pp_sep_union pp_value) qs
           Format.pp_print_string (order_by_clause n)

--- a/core/query/sql.ml
+++ b/core/query/sql.ml
@@ -278,7 +278,7 @@ class virtual printer =
           match x with  (* parenthesize safely wrt SQL standard *)
           | Select _ -> pr_q ppf x
           | _ -> Format.fprintf ppf "select * from (%a)" pr_q x
-        in 
+        in
         Format.fprintf ppf "%a%a"
           (Format.pp_print_list ~pp_sep:pp_sep_union pp_union_term) qs
           Format.pp_print_string (order_by_clause n)

--- a/tests/database/factorials.links
+++ b/tests/database/factorials.links
@@ -97,7 +97,9 @@ fun test() {
   assertEq(tableLength(), 3);
   assertEq(lookupFactorials(3), [(i=1, f=1), (i=2, f=2), (f=6,i=3)]);
   assertEq(trivialNested1(),[(a=0),(a=0),(a=0)]);
-  assertEq(trivialNested2(),[(a=0),(a=0),(a=0)])
+  assertEq(trivialNested2(),[(a=0),(a=0),(a=0)]);
+  assertEq(query  { for (x <-- factorials) where (x.i == 1) [(a=x.i),(a=x.i)] },
+           [(a = 1), (a = 1)])
 }
 
 test()


### PR DESCRIPTION
This uses SQL-safe parentheses conditionally: if a query appearing under a UNION/UNION ALL is a SELECT then we just print it, otherwise we wrap the subquery in a silly "SELECT * FROM (...)" that seems to be the only fully SQL-standardized way to do this.

Let's see what the CI thinks of this.