### PR TITLE
Allow direct dispatch of messages to MVU event loop

### DIFF
--- a/examples/mvu/dispatch.links
+++ b/examples/mvu/dispatch.links
@@ -1,0 +1,51 @@
+open import Mvu;
+import MvuHTML;
+import MvuAttrs;
+
+typename Msg = [| Incr |];
+
+typename Model = Int;
+
+fun incrModel(hndl) {
+    Mvu.dispatch(Incr, hndl)
+}
+
+fun view(model) {
+    open MvuAttrs;
+    open MvuHTML;
+
+    var h0 = MvuHTML.empty;
+    var a0 = MvuAttrs.empty;
+
+    h1(a0, textNode(intToString(model)))
+}
+
+fun updt(msg, model) {
+    switch (msg) {
+        case Incr -> model + 1
+    }
+}
+
+fun mainPage() {
+    var hndl = runSimpleHandle("placeholder", 0, view, updt);
+    var _ = spawnClient {
+        dispatch(Incr, hndl);
+        dispatch(Incr, hndl);
+        dispatch(Incr, hndl)
+    };
+    page
+        <html>
+            <body>
+                <div id="placeholder"></div>
+            </body>
+        </html>
+}
+
+
+fun main() {
+    addRoute("/", fun(_) { mainPage() });
+    serveWebsockets();
+    servePages()
+}
+
+main()

--- a/lib/stdlib/mvu.links
+++ b/lib/stdlib/mvu.links
@@ -5,6 +5,15 @@ open import MvuHTML;
 open import MvuSubscriptions;
 open import MvuCommands;
 
+typename MvuHandle(msg) = AP(?msg.End);
+
+# Directly dispatches a message to the MVU event loop
+fun dispatch(msg, hndl) {
+  var s = request(hndl);
+  var s = send(msg, s);
+  close(s)
+}
+
 # Needed to ensure that virtual-dom is open
 module VirtualDom {
   alien javascript "/lib/js/virtual-dom.js" {
@@ -46,7 +55,25 @@ fun evtLoop(ap, model, view, updt, subscriptionsFn, prevSubscriptions) {
 }
 
 # User-facing function (assuming an unrestricted model)
-sig run:
+sig runHandle:
+  forall msg, model, e :: Row, f :: Row.
+  (String,
+    model,
+    (model) ~e~> HTML(msg),
+    (msg, model) ~e~> (model, Command(msg)),
+    (model) ~e~> Sub(msg),
+    Command(msg)) ~f~> MvuHandle(msg)
+fun runHandle(placeholder, model, view, updt, subscriptions, cmd) {
+  var ap = newClientAP();
+  var evtHandler = spawnClient {
+    processCommand(cmd, ap);
+    VDom.runDom(placeholder, view(model), ap, subscriptions(model));
+    evtLoop(ap, model, view, updt, subscriptions, subscriptions(model))
+  };
+  ap
+}
+
+sig run :
   forall msg, model, e :: Row, f :: Row.
   (String,
     model,
@@ -54,24 +81,39 @@ sig run:
     (msg, model) ~e~> (model, Command(msg)),
     (model) ~e~> Sub(msg),
     Command(msg)) ~f~> ()
-fun run(placeholder, model, view, updt, subscriptions, cmd) {
-  var evtHandler = spawnClient {
-    var ap = new();
-    processCommand(cmd, ap);
-    VDom.runDom(placeholder, view(model), ap, subscriptions(model));
-    evtLoop(ap, model, view, updt, subscriptions, subscriptions(model))
-  };
-  ()
+fun run(placeholder, model, view, updt, sub, cmd) {
+    ignore(runHandle(placeholder, model, view, updt, sub, cmd))
 }
 
-sig runCmd: forall msg, model, e :: Row, f :: Row.
+sig runCmdHandle: forall msg, model, e :: Row, f :: Row.
+  (String,
+    model,
+    (model) ~e~> HTML(msg),
+    (msg, model) ~e~> (model, Command(msg)),
+    Command(msg)) ~f~> MvuHandle(msg)
+fun runCmdHandle(placeholder, model, view, updt, cmd) {
+  runHandle(placeholder, model, view, updt, fun(_) { SubEmpty }, cmd )
+}
+
+sig runCmd : forall msg, model, e :: Row, f :: Row.
   (String,
     model,
     (model) ~e~> HTML(msg),
     (msg, model) ~e~> (model, Command(msg)),
     Command(msg)) ~f~> ()
 fun runCmd(placeholder, model, view, updt, cmd) {
-  run(placeholder, model, view, updt, fun(_) { SubEmpty }, cmd )
+  ignore(runCmdHandle(placeholder, model, view, updt, cmd))
+}
+
+sig runSimpleHandle : forall msg, model, e :: Row, f :: Row.
+  (String,
+    model,
+    (model) ~e~> HTML(msg),
+    (msg, model) ~e~> model) ~f~> MvuHandle(msg)
+fun runSimpleHandle(placeholder, model, view, updt) {
+  runHandle(placeholder, model, view,
+      fun(msg, model) { (updt(msg, model), MvuCommands.empty) },
+      fun(_) { SubEmpty }, MvuCommands.empty )
 }
 
 sig runSimple : forall msg, model, e :: Row, f :: Row.
@@ -80,9 +122,7 @@ sig runSimple : forall msg, model, e :: Row, f :: Row.
     (model) ~e~> HTML(msg),
     (msg, model) ~e~> model) ~f~> ()
 fun runSimple(placeholder, model, view, updt) {
-  run(placeholder, model, view,
-      fun(msg, model) { (updt(msg, model), MvuCommands.empty) },
-      fun(_) { SubEmpty }, MvuCommands.empty )
+  ignore(runSimpleHandle(placeholder, model, view, updt))
 }
 
 sig runStatic :

--- a/tests/typecheck_examples.tests
+++ b/tests/typecheck_examples.tests
@@ -755,3 +755,7 @@ filemode : true
 Typecheck example file examples/mvu/dates.links
 examples/mvu/dates.links
 filemode : true
+
+Typecheck example file examples/mvu/dispatch.links
+examples/mvu/dispatch.links
+filemode : true


### PR DESCRIPTION
# Overview
This fairly simple patch makes it possible to dispatch an MVU message from outside of the event loop. This is particularly useful, for example, when dealing with a persistent, stateful thread which is receiving messages from a server.

# Implementation
* Introduce type alias `MvuHandle(msg)`
* Introduce variants of the `run` functions: `runHandle`, `runCmdHandle`, `runSimpleHandle` which return an `MvuHandle(msg)` rather than the unit value
* Add `Mvu.dispatch : (msg, MvuHandle(msg)) ~> ()`, which directly dispatches a message to the MVU loop

The patch is structured in such a way that the change is backwards-compatible.
See `examples/mvu/dispatch.links` for an example.