### PR TITLE
Delayed assert condition expressions

### DIFF
--- a/lib/js/jslib.js
+++ b/lib/js/jslib.js
@@ -189,14 +189,19 @@ const _$Proc = (function() {
             if ("_clientSpawnLoc" in loc) {
                 if (loc._clientSpawnLoc === _client_id) return true;
                 else {
-                    _$Debug.assert(false, "Cannot spawn a process on another client");
+                    // TODO(dhil): This is a hack. _$Debug.assert is
+                    // being abused to kill the process in
+                    // debug. Whether the process is killed or
+                    // recovered shouldn't depend on whether debug
+                    // mode is toggled.
+                    _$Debug.assert(function() { return false; }, "Cannot spawn a process on another client");
                     return false;
                 }
             } else if ("_serverSpawnLoc" in loc) {
-                _$Debug.assert(false, "Cannot spawn process on server from client");
+                _$Debug.assert(function () { return false; }, "Cannot spawn process on server from client");
                 return false;
             } else {
-                _$Debug.assert(false, "Invalid spawn location " + loc);
+                _$Debug.assert(function() { return false; }, "Invalid spawn location " + loc);
                 return false;
             }
         },
@@ -234,7 +239,7 @@ const _$List = (function(){
     nil: null,
     isNil: function(n) { return n === null; },
     cons: function(x,xs) {
-        _$Debug.assert(_$List.isList(xs), "Second argument must be linked list");
+        _$Debug.assert(function() { return _$List.isList(xs); }, "Second argument must be linked list");
         return {_head: x, _tail: xs};
     },
     isList: function(v) {
@@ -300,11 +305,11 @@ const _$List = (function(){
       return out;
     },
     head: function(v) {
-      _$Debug.assert(_$Types.isList(v), "Not a linked list");
+      _$Debug.assert(function() { return _$Types.isList(v); }, "Not a linked list");
       return _$List.isNil(v) ? _error('head') : v._head;
     },
     tail: function(v) {
-      _$Debug.assert(_$Types.isList(v), "Not a linked list");
+      _$Debug.assert(function() { return _$Types.isList(v); }, "Not a linked list");
       return _$List.isNil(v) ? _error('tail') : v._tail;
     },
     revAppend: function(xs, ys) {
@@ -316,7 +321,7 @@ const _$List = (function(){
       return out;
     },
     append: function(xs, ys) {
-      _$Debug.assert(_$Types.isList(xs) && _$Types.isList(ys), "Not linked lists");
+      _$Debug.assert(function() { return _$Types.isList(xs) && _$Types.isList(ys); }, "Not linked lists");
       if (_$List.isNil(xs)) {
         return ys;
       }
@@ -444,14 +449,14 @@ const _$Types = Object.freeze({
 });
 
 const _$Debug = Object.freeze({
-    debug: function (...msg) { if (DEBUGGING) console.debug(...msg); return; },
+  debug: function (...msg) { if (DEBUGGING) console.debug(...msg); return; },
   show: function (any) { return (_$Types.isXmlNode(any)) ? _$Debug.xmldump(any) : _$Links.stringify(any); },
   xmldump: function (xml) { return (new XMLSerializer()).serializeToString(xml); },
-  assert: function (condition, message) {
+  assert: function (fcondition, message) {
     // TODO(dhil): condition should be a thunk rather than a
     // computed boolean. Currently when debugging is disabled we
     // perform needless computation.
-    if (DEBUGGING && !Boolean(condition)) {
+    if (DEBUGGING && !Boolean(fcondition())) {
       throw new Error(`Assertion failed: ${message}`);
     }
     return true;
@@ -506,10 +511,8 @@ const _$Websocket = (function() {
         },
 
         connect: function (ws_uri) {
-            _$Debug.assert(
-                _client_id != undefined,
-                "Trying to start websocket connection with undefined client ID"
-            );
+            _$Debug.assert(function() { return _client_id != undefined; },
+                           "Trying to start websocket connection with undefined client ID");
 
             _$Debug.debug("Connecting to websocket at address ", ws_uri);
             socket = new WebSocket(ws_uri);
@@ -1017,10 +1020,8 @@ const _$Links = (function() {
   }
 
   function singleXmlToDomNodes(xmlObj) {
-    _$Debug.assert(
-      _isXmlItem(xmlObj),
-      '_$Links.singleXmlToDomNodes expected a XmlItem, but got ' + xmlObj
-    );
+    _$Debug.assert(function() { return _isXmlItem(xmlObj); },
+                   '_$Links.singleXmlToDomNodes expected a XmlItem, but got ' + xmlObj);
 
     const type = xmlObj.type;
     switch (type) {
@@ -1702,12 +1703,9 @@ const _$Links = (function() {
       Implictly converts from linked list to JS Array, use with caution!
     */
     XmlToDomNodes : function (xmlForest) {
-      _$Debug.assert(
-        _$Types.isList(xmlForest),
-        '_$Links.XmlToDomNodes expected a linked list, but got ',
-        xmlForest
-      );
-      let domNodeArray = [];
+      _$Debug.assert(function () { return _$Types.isList(xmlForest); },
+                     '_$Links.XmlToDomNodes expected a linked list, but got '+ xmlForest);
+      const domNodeArray = [];
       _$List.forEach(xmlForest,function(xmlNode){
           domNodeArray.push(singleXmlToDomNodes(xmlNode));
       });
@@ -1722,12 +1720,9 @@ const _$Links = (function() {
      */
     XML : function (tag, attrs, body) {
       let children = _$List.nil;
-      _$List.forEach(body,function(e) {
-        if(_$Types.isList(e)) {
-          children = _$List.append(children,e);
-        } else {
-          children = _$List.snoc(children,e);
-        }
+      _$List.forEach(body, function(e) {
+        if(_$Types.isList(e)) children = _$List.append(children,e);
+        else children = _$List.snoc(children,e);
       });
       return _$List.cons({
           type: 'ELEMENT',
@@ -1855,7 +1850,7 @@ const _$Links = (function() {
         }
       }
 
-      _$Debug.assert(Boolean(containingForm), "Form does not exist!");
+      _$Debug.assert(function() { return Boolean(containingForm); }, "Form does not exist!");
 
       // find the input value
       const xs = document.getElementsByName(name);
@@ -2256,8 +2251,8 @@ function _nodeTextContent(node) {
 // getInputValue : String -> String
 function _getInputValue(id) {
   const element = document.getElementById(id);
-  _$Debug.assert(element != null, "invalid input node (id " + id + ")");
-  _$Debug.assert(element.value != undefined, "invalid input value in id " + id);
+  _$Debug.assert(function() { return element != null; }, "invalid input node (id " + id + ")");
+  _$Debug.assert(function() { return element.value != undefined }, "invalid input value in id " + id);
   if ((element.type !== "radio" && element.type !== "checkbox") || element.checked) {
     return element.value;
   } else {
@@ -2304,9 +2299,11 @@ function _getValue(nodeRef) {
             }
 
             _$Debug.assert(
-                !_$List.some(function (e) { return e.type !== 'ELEMENT' && e.type !== 'TEXT'; }, children),
-                'Invalid children constructed in _getValue'
-            );
+                function() {
+                    return !_$List.some(function (e) {
+                        return e.type !== 'ELEMENT' && e.type !== 'TEXT'; }
+                                        , children);
+                }, 'Invalid children constructed in _getValue');
 
             return {
                 type: 'ELEMENT',
@@ -2431,11 +2428,10 @@ const nextSibling = _$Links.kify(_nextSibling);
 //swapNodes : (domRef, domRef) -> ()
 function _swapNodes(x, y) {
   _$Debug.assert(
-    x.parentNode != null && y.parentNode != null,
-    "cannot swap root nodes"
-  );
-  _$Debug.assert(x.parentNode != y, "cannot swap a node with its parent");
-  _$Debug.assert(y.parentNode != x, "cannot swap a node with its parent");
+      function() { return x.parentNode != null && y.parentNode != null; },
+      "cannot swap root nodes");
+  _$Debug.assert(function() { return x.parentNode != y; }, "cannot swap a node with its parent");
+  _$Debug.assert(function() { return y.parentNode != x; }, "cannot swap a node with its parent");
 
   let xNextSibling = x.nextSibling;
   let yNextSibling = y.nextSibling;
@@ -2781,13 +2777,12 @@ function _focus() {
 //  _replaceDocument(tree)
 //    Replace the current page with `tree'.
 function _replaceDocument(tree) {
-  _$Debug.assert(tree != null, "No argument given to _replaceDocument");
+  _$Debug.assert(function() { return tree != null; }, "No argument given to _replaceDocument");
   const firstChild = _$List.head(tree);
-  _$Debug.assert(firstChild != null, "Null tree passed to _replaceDocument");
-  _$Debug.assert(
-    firstChild.type === "ELEMENT",
-    "New document value was not an XML element (it was non-XML or was an XML text node)."
-  );
+  _$Debug.assert(function() { return firstChild != null; }, "Null tree passed to _replaceDocument");
+  _$Debug.assert(function() {
+      return firstChild.type === "ELEMENT";
+  }, "New document value was not an XML element (it was non-XML or was an XML text node).");
   tree = _$Links.XmlToDomNodes(tree);
 
   // save here
@@ -3097,7 +3092,7 @@ function get_process_id(pid) {
   } else if (_is_valid_server_pid(pid)) {
     return pid._serverPid;
   } else {
-    _$Debug.assert(false, "Invalid PID in get_process_id");
+    _$Debug.assert(function() { return false; }, "Invalid PID in get_process_id");
     return;
   }
 }
@@ -3107,10 +3102,8 @@ function _Send(pid, msg) {
   /* First, check to see whether we are sending to a well-formed PID */
   let valid_server_pid = _is_valid_server_pid(pid);
   let valid_client_pid = _is_valid_client_pid(pid);
-  _$Debug.assert(
-    valid_server_pid || valid_client_pid,
-    "Malformed PID in _Send: neither client nor server PID"
-  );
+  _$Debug.assert(function() { return valid_server_pid || valid_client_pid; },
+                 "Malformed PID in _Send: neither client nor server PID");
 
   if (valid_server_pid) {
     _$Websocket.sendRemoteServerMessage(pid._serverPid, msg);
@@ -3137,10 +3130,9 @@ function Send(pid, msg, kappa) {
 //   recv is an unusual library function that may capture the
 //   continuation; hence there is no _recv form (direct-style).
 function recv(kappa) {
-  _$Debug.assert(
-    arguments.length == 1,
-    'recv received ' + arguments.length + ' arguments, expected 1'
-  );
+  const args = arguments;
+  _$Debug.assert(function() { return args.length == 1 },
+                 'recv received ' + arguments.length + ' arguments, expected 1');
 
   const currentPid = _$Proc.Sched.getPid();
   if (_$Proc.Mail.hasAny(currentPid)) {
@@ -3185,7 +3177,7 @@ const _$Session = (function() {
                 _$Proc.Sched.setPid(currentPid);
                 // Grab the returned channel EP out of the
                 // returnedChannels table, and continue
-                _$Debug.assert(returnedChannels[currentPid] != null,
+                _$Debug.assert(function() { return returnedChannels[currentPid] != null; },
                                "resuming process after remote accept, but no channel available!");
                 const chan = returnedChannels[currentPid];
                 returnedChannels[currentPid] = null;
@@ -3223,7 +3215,7 @@ const _$Session = (function() {
                 // state dumps provided in realpages delivery / RPC
                 // returns
                 let ap = AP.get(localAPID);
-                _$Debug.assert(ap != undefined, "Attempting to accept on an undefined AP!");
+                _$Debug.assert(function() { return ap != undefined; }, "Attempting to accept on an undefined AP!");
                 // If there's a requester, then pop the requester, create
                 // the other end of the channel, and wake up the
                 // requester.
@@ -3243,7 +3235,7 @@ const _$Session = (function() {
                 case ACCEPTING:
                     return makeAndBlock();
                 case REQUESTING:
-                    _$Debug.assert(ap.pending.length > 0, "Accepting on a requesting endpoint with no pending requests!");
+                    _$Debug.assert(function() { return ap.pending.length > 0; }, "Accepting on a requesting endpoint with no pending requests!");
                     let top = ap.pending.pop();
                     if (ap.pending.length === 0) {
                         _$Debug.debug("Changing state to BALANCED");
@@ -3271,7 +3263,7 @@ const _$Session = (function() {
                 // this client should be serialised in state dumps provided in realpages
                 // delivery / RPC returns
                 let ap = AP.get(localAPID);
-                _$Debug.assert(ap != undefined, "Attempting to request on an undefined AP!");
+                _$Debug.assert(function() { return ap != undefined; }, "Attempting to request on an undefined AP!");
                 _$Debug.debug("Request called on local AP ", localAPID);
                 // If there's a requester, then pop the requester, create the other end of the channel, and
                 // wake up the requester.
@@ -3293,7 +3285,7 @@ const _$Session = (function() {
                 case REQUESTING :
                     return makeAndBlock();
                 case ACCEPTING:
-                    _$Debug.assert(ap.pending.length > 0, "Requesting on an accepting endpoint with no pending requests!");
+                    _$Debug.assert(function() { return ap.pending.length > 0; }, "Requesting on an accepting endpoint with no pending requests!");
                     let top = ap.pending.pop();
                     if (ap.pending.length === 0) {
                         _$Debug.debug("Changing state to balanced");
@@ -3565,7 +3557,7 @@ const _$Session = (function() {
                 for (let i = 0; i < chans.length; i++) {
                     const curChan = chans[i];
                     const curRecvEp = chans[i]._sessEP2;
-                    _$Debug.assert(curRecvEp in buffers, "Trying to delegate channel without a buffer!");
+                    _$Debug.assert(function () { return curRecvEp in buffers; }, "Trying to delegate channel without a buffer!");
                     const curBuf = buffers[curRecvEp];
                     // Delete buffer, create lost message buffer
                     buffers[curRecvEp] = null;
@@ -3578,7 +3570,7 @@ const _$Session = (function() {
                 if (Channel.isEndpointCancelled(ch))
                     return; // Re-cancelling sessions is a no-op
 
-                _$Debug.assert(_$Types.isChannel(ch), "Cancelling non-channel");
+                _$Debug.assert(function() { return _$Types.isChannel(ch); }, "Cancelling non-channel");
 
                 const peerEp = ch._sessEP1;
                 const localEp = ch._sessEP2;
@@ -3640,13 +3632,13 @@ function accept(ap, kappa) {
       return _$Session.AP.remoteAccept(_$Session.AP.getServerAPID(ap), kappa);
   } else if (_$Session.AP.isValidClientAP(ap)) {
     if (_$Session.AP.getClientID(ap) != _client_id) {
-      _$Debug.assert(false, "alas, accepting on a remote client AP is not yet supported");
+      _$Debug.assert(function() { return false; }, "alas, accepting on a remote client AP is not yet supported");
       return;
     } else {
       return _$Session.AP.localAccept(_$Session.AP.getClientAPID(ap), kappa);
     }
   } else {
-    _$Debug.assert(false, "invalid access point ID in accept! " + JSON.stringify(ap));
+    _$Debug.assert(function() { return false; }, "invalid access point ID in accept! " + JSON.stringify(ap));
     return;
   }
 }
@@ -3656,13 +3648,13 @@ function request(ap, kappa) {
     return _$Session.AP.remoteRequest(_$Session.AP.getServerAPID(ap), kappa);
   } else if (_$Session.AP.isValidClientAP(ap)) {
     if (_$Session.AP.getClientID(ap) != _client_id) {
-      _$Debug.assert(false, "alas, requesting from a remote client AP is not yet supported");
+      _$Debug.assert(function() { return false; }, "alas, requesting from a remote client AP is not yet supported");
       return;
     } else {
       return _$Session.AP.localRequest(_$Session.AP.getClientAPID(ap), kappa);
     }
   } else {
-    _$Debug.assert(false, "invalid access point ID in request! " + JSON.stringify(ap));
+    _$Debug.assert(function() { return false; }, "invalid access point ID in request! " + JSON.stringify(ap));
     return;
   }
 }
@@ -4244,7 +4236,7 @@ const strContains = _$Links.kify(_strContains);
  * @returns {{ _label: string, _value: Object }[]}
  */
 function _xmlToVariant (xml) {
-  _$Debug.assert(_$Types.isArray(xml), 'xmlToVariant expects Xml (array of XmlItem)');
+  _$Debug.assert(function() { return _$Types.isArray(xml); }, 'xmlToVariant expects Xml (array of XmlItem)');
   return xml.map(_xmlItemToVariant);
 }
 const xmlToVariant = _$Links.kify(_xmlToVariant);
@@ -4256,7 +4248,7 @@ const xmlToVariant = _$Links.kify(_xmlToVariant);
  * @returns {{ namespace?: string, tagName?: string, text?: string, attrs?: Object, children?: any[] }[]}
  */
 function _variantToXml (variants) {
-  _$Debug.assert(_$Types.isArray(variants), 'variantToXml expects an array');
+  _$Debug.assert(function() { return _$Types.isArray(variants); }, 'variantToXml expects an array');
   return variants.map(_variantToXmlItem);
 }
 const variantToXml = _$Links.kify(_variantToXml);
@@ -4268,15 +4260,11 @@ const variantToXml = _$Links.kify(_variantToXml);
  * @returns {{ _label: string, _value: Object }}
  */
 function _xmlItemToVariant (xmlItem) {
-  _$Debug.assert(
-    xmlItem.type === 'ELEMENT' || xmlItem.type === 'TEXT',
-    'Non-XmlItem passed to xmlItemToVariant'
-  );
+  _$Debug.assert(function() { return xmlItem.type === 'ELEMENT' || xmlItem.type === 'TEXT'; },
+                 'Non-XmlItem passed to xmlItemToVariant');
   if (xmlItem.type === 'ELEMENT') {
-    _$Debug.assert(
-      xmlItem.tagName && xmlItem.children && xmlItem.attrs,
-      'Malformed element passed to xmlItemToVariant'
-    );
+      _$Debug.assert(function() { return xmlItem.tagName && xmlItem.children && xmlItem.attrs; },
+                     'Malformed element passed to xmlItemToVariant');
     const attrs = _$List.mapFromArray(Object.keys(xmlItem.attrs),function (name) {
       const splitIndex = name.indexOf(':');
       if (splitIndex > -1) {
@@ -4337,9 +4325,9 @@ const xmlItemToVariant = _$Links.kify(_xmlItemToVariant);
  * @returns {{ namespace?: string, tagName?: string, text?: string, attrs?: Object, children?: any[] }}
  */
 function _variantToXmlItem (variant) {
-  _$Debug.assert(_$Types.isObject(variant), 'variantToXmlItem expects an object');
-  _$Debug.assert(variant._label, 'variantToXmlItem expects a variant type object');
-  _$Debug.assert(variant._value, 'Malformed variant passed to variantToXmlItem');
+  _$Debug.assert(function() { return _$Types.isObject(variant); }, 'variantToXmlItem expects an object');
+  _$Debug.assert(function() { return variant._label; }, 'variantToXmlItem expects a variant type object');
+  _$Debug.assert(function() { return variant._value; }, 'Malformed variant passed to variantToXmlItem');
 
   const attrs = {};
 
@@ -4405,7 +4393,7 @@ function shiftOffset(date, offset) {
 
 function projectDate(dt) {
     if (dt._type == "timestamp") {
-        _$Debug.assert(dt._value instanceof Date);
+        _$Debug.assert(function() { return dt._value instanceof Date; }, "dt is not an instance of Date");
         return dt._value;
     } else {
         throw new Error('Unable to project date component from infinity / -infinity');

--- a/lib/js/jslib.js
+++ b/lib/js/jslib.js
@@ -2252,7 +2252,7 @@ function _nodeTextContent(node) {
 function _getInputValue(id) {
   const element = document.getElementById(id);
   _$Debug.assert(function() { return element != null; }, "invalid input node (id " + id + ")");
-  _$Debug.assert(function() { return element.value != undefined }, "invalid input value in id " + id);
+  _$Debug.assert(function() { return element.value != undefined; }, "invalid input value in id " + id);
   if ((element.type !== "radio" && element.type !== "checkbox") || element.checked) {
     return element.value;
   } else {
@@ -2301,8 +2301,7 @@ function _getValue(nodeRef) {
             _$Debug.assert(
                 function() {
                     return !_$List.some(function (e) {
-                        return e.type !== 'ELEMENT' && e.type !== 'TEXT'; }
-                                        , children);
+                        return e.type !== 'ELEMENT' && e.type !== 'TEXT'; }, children);
                 }, 'Invalid children constructed in _getValue');
 
             return {

--- a/lib/js/jslib.js
+++ b/lib/js/jslib.js
@@ -3130,7 +3130,7 @@ function Send(pid, msg, kappa) {
 //   continuation; hence there is no _recv form (direct-style).
 function recv(kappa) {
   const args = arguments;
-  _$Debug.assert(function() { return args.length == 1 },
+  _$Debug.assert(function() { return args.length == 1; },
                  'recv received ' + arguments.length + ' arguments, expected 1');
 
   const currentPid = _$Proc.Sched.getPid();


### PR DESCRIPTION
This patch provides a quickfix for #1095 as it delays evaluation of the potentially expensive condition expressions of `_$Debug.assert`. I will look into a preprocessor-based solution to dispense entirely of `_$Debug.debug` and `_$Debug.assert` when we start doing more serious benchmarking.

Resolves #1095.