### PR TITLE
[Prelude] replicate: Return empty list on non-positive argument.

### DIFF
--- a/prelude.links
+++ b/prelude.links
@@ -173,7 +173,7 @@ fun zip(l, r) {
 }
 
 fun replicate(n, item) {
-  if (n == 0) []
+  if (n <= 0) []
   else item :: replicate(n-1, item)
 }
 


### PR DESCRIPTION
This patch slightly changes the semantics of the function `replicate` in `prelude.links` such that it conforms more closely with the semantics of `replicate` from the Haskell prelude. In particular, `replicate` now returns an empty list on non-positive arguments.

Resolves #1068.