### PR TITLE
JavaScript runtime cleanup

### DIFF
--- a/core/page.ml
+++ b/core/page.ml
@@ -57,7 +57,7 @@ module Make_RealPage (C : JS_PAGE_COMPILER) (G : JS_CODEGEN) = struct
                         ^ "<script type=\"text/javascript\">
                              'use strict';
                              function _isRuntimeReady() {
-                                if (window._JSLIB === void 0 || window._JSLIB !== true) {
+                                if (_$Links === void 0) {
                                    const msg = \"<h1>Startup error: Runtime dependency `jslib.js' is not loaded.</h1>\";
                                    document.body.innerHTML = msg;
                                    document.head.innerHTML = \"\";

--- a/lib/js/jslib.js
+++ b/lib/js/jslib.js
@@ -211,19 +211,19 @@ const _$Proc = (function() {
         },
         'yield': Sched.yield,
         'block': function(pid, f) {
-            _$Debug.debug("Blocking ", pid);
+            _$Debug.debug("Blocking " + pid);
             blocked[pid] = f;
             return;
         },
         'wakeUp': function(pid) {
             if (_$Proc.isBlocked(pid)) {
-                _$Debug.debug("Waking up ", pid);
+                _$Debug.debug("Waking up " + pid);
                 const proc = blocked[pid];
                 blocked[pid] = null;
                 return setZeroTimeout(proc);
             } else {
                 // already awake?
-                _$Debug.debug("Tried to wake up ", pid, ", but it is already awake");
+                _$Debug.debug("Tried to wake up " + pid + ", but it is already awake");
                 return;
             }
         },
@@ -449,7 +449,7 @@ const _$Types = Object.freeze({
 });
 
 const _$Debug = Object.freeze({
-  debug: function (...msg) { if (DEBUGGING) console.debug(...msg); return; },
+  debug: function (msg) { if (DEBUGGING) console.debug(msg); return; },
   show: function (any) { return (_$Types.isXmlNode(any)) ? _$Debug.xmldump(any) : _$Links.stringify(any); },
   xmldump: function (xml) { return (new XMLSerializer()).serializeToString(xml); },
   assert: function (fcondition, message) {
@@ -514,7 +514,7 @@ const _$Websocket = (function() {
             _$Debug.assert(function() { return _client_id != undefined; },
                            "Trying to start websocket connection with undefined client ID");
 
-            _$Debug.debug("Connecting to websocket at address ", ws_uri);
+            _$Debug.debug("Connecting to websocket at address " + ws_uri);
             socket = new WebSocket(ws_uri);
 
             /* Set up all of the event handlers */
@@ -618,7 +618,7 @@ const _$Websocket = (function() {
                         break;
                     }
                     default:
-                        _$Debug.debug("Unhandled message: ", evt.data);
+                        _$Debug.debug("Unhandled message: " + evt.data);
                         break;
                     }
                 }
@@ -634,7 +634,7 @@ const _$Websocket = (function() {
         drain_buffer: function () {
             while (buffer.length > 0) {
                 const msg = buffer.pop();
-                _$Debug.debug("Sending buffered message: ", msg);
+                _$Debug.debug("Sending buffered message: " + msg);
                 _$Websocket.serialise_and_send(msg);
             }
             return;
@@ -645,21 +645,16 @@ const _$Websocket = (function() {
             if (is_connected) {
                 socket.send(_$Links.stringify(msg));
             } else {
-                _$Debug.debug("No connection yet; buffering message ", msg);
+                _$Debug.debug("No connection yet; buffering message " + msg);
                 buffer.unshift(msg);
             }
             return;
         },
 
         sendRemoteClientMessage: function (destClientId, destPid, msg) {
-            _$Debug.debug(
-                "Sending message bound for client ",
-                destClientId,
-                ", process ",
-                destPid,
-                ", msg: ",
-                msg
-            );
+            _$Debug.debug("Sending message bound for client " +
+                          destClientId + ", process " + destPid +
+                          ", msg: " + msg);
 
             const to_send_json = {
                 opcode: "CLIENT_TO_CLIENT",
@@ -672,12 +667,8 @@ const _$Websocket = (function() {
         },
 
         sendRemoteServerMessage: function (destServerPid, msg) {
-            _$Debug.debug(
-                "Sending message bound for server process ",
-                destServerPid,
-                ", msg: ",
-                msg
-            );
+            _$Debug.debug("Sending message bound for server process " +
+                          destServerPid + ", msg: " + msg);
 
             const to_send_json = {
                 opcode: "CLIENT_TO_SERVER",
@@ -689,7 +680,7 @@ const _$Websocket = (function() {
         },
 
         sendRemoteAPRequest: function (current_pid, remote_apid) {
-            _$Debug.debug("Requesting a connection from remote AP ", remote_apid);
+            _$Debug.debug("Requesting a connection from remote AP " + remote_apid);
             const to_send_json = {
                 opcode: "SERVER_AP_REQUEST",
                 blockedClientPid: current_pid,
@@ -700,7 +691,7 @@ const _$Websocket = (function() {
         },
 
         sendRemoteAPAccept : function(current_pid, remote_apid) {
-            _$Debug.debug("Accepting a connection from remote AP ", remote_apid);
+            _$Debug.debug("Accepting a connection from remote AP " + remote_apid);
             const to_send_json = {
                 opcode: "SERVER_AP_ACCEPT",
                 blockedClientPid: current_pid,
@@ -712,7 +703,7 @@ const _$Websocket = (function() {
 
         sendRemoteSessionMessage: function (channel, delegated_sessions, val) {
             let remote_ep = channel._sessEP1;
-            _$Debug.debug("Sending value ", val, " to remote endpoint ", remote_ep);
+            _$Debug.debug("Sending value " + val + " to remote endpoint " + remote_ep);
             const to_send_json = {
                 opcode: "REMOTE_SESSION_SEND",
                 remoteEP: remote_ep,
@@ -724,12 +715,8 @@ const _$Websocket = (function() {
         },
 
         sendLostMessageResponse: function (ep_id, lost_message_table) {
-            _$Debug.debug(
-                "Delivering lost messages for remote EP ",
-                ep_id,
-                "message table: ",
-                lost_message_table
-            );
+            _$Debug.debug("Delivering lost messages for remote EP " +
+                          ep_id + "message table: " + lost_message_table);
             const to_send_json = {
                 opcode: "LOST_MESSAGES",
                 epID: ep_id,
@@ -739,8 +726,8 @@ const _$Websocket = (function() {
         },
 
         sendRemoteCancellation : function(notify_ep, cancelled_ep) {
-            _$Debug.debug("Sending remote cancellation. Notify ep ", notify_ep,
-                          ", cancelled ep ", cancelled_ep);
+            _$Debug.debug("Sending remote cancellation. Notify ep " + notify_ep +
+                          ", cancelled ep " + cancelled_ep);
             const to_send_json =
                   { opcode: "CHANNEL_CANCELLATION", notify_ep: notify_ep,
                     cancelled_ep: cancelled_ep };
@@ -1084,7 +1071,7 @@ const _$Links = (function() {
    */
   function _remoteContinue (kappa, continuation, mailbox) {
     return _$K.make(function (res) {
-      _$Debug.debug('Continuing at server with value', res, 'and continuation', continuation);
+      _$Debug.debug('Continuing at server with value' + res + 'and continuation' + continuation);
       const request = new XMLHttpRequest();
       const rootUrl = _removeCGIArgs(location.href);
 
@@ -1144,7 +1131,7 @@ const _$Links = (function() {
    */
   function _activateJsonState(state, clientId, processes, handlers, aps, buffers) {
     // set client ID
-    _$Debug.debug("Setting client ID to ", clientId);
+    _$Debug.debug("Setting client ID to " + clientId);
     _client_id = clientId;
 
     // Register event handlers
@@ -1479,9 +1466,9 @@ const _$Links = (function() {
    * @param {any} callPackage
    */
   function _invokeClientCall (kappa, callPackage) {
-    _$Debug.debug('Invoking client call to ', callPackage.__name);
-    _$Debug.debug('arguments: ', callPackage.__args);
-    _$Debug.debug('arguments: ', callPackage.__args);
+    _$Debug.debug('Invoking client call to ' + callPackage.__name);
+    _$Debug.debug('arguments: ' + callPackage.__args);
+    _$Debug.debug('arguments: ' + callPackage.__args);
 
     // FIXME: the eval is redundant, because done in
     // remoteCallHandler; also this name may actually be a
@@ -1517,7 +1504,7 @@ const _$Links = (function() {
         // than once on the same request object, an anomaly observed by EEKC.
         request.finished = true;
 
-        _$Debug.debug("Server response: ", _$Links.base64decode(request.responseText));
+        _$Debug.debug("Server response: " + _$Links.base64decode(request.responseText));
 
         const serverResponse = _$Links.parseB64Safe(request.responseText);
 
@@ -1550,7 +1537,7 @@ const _$Links = (function() {
           // callPackageOrServerValue is a call package.
           // Bouncing the trampoline
 
-          _$Debug.debug("Client function name, before evaluation, is ", callPackageOrServerValue.__name);
+          _$Debug.debug("Client function name, before evaluation, is " + callPackageOrServerValue.__name);
 
           _$Proc.Sched.setPid(request.pid);
           // TODO(dhil): The call package should probably be tagged
@@ -1568,9 +1555,9 @@ const _$Links = (function() {
         } else {
           // callPackageOrServerValue is a server value
           const serverValue = resolveServerValue(state, callPackageOrServerValue);
-          _$Debug.debug("Client continuing after remote server call, value ", serverValue);
+          _$Debug.debug("Client continuing after remote server call, value " + serverValue);
           // it's the final result: return it.
-          _$Debug.debug("Server response decoded: ", serverValue);
+          _$Debug.debug("Server response decoded: " + serverValue);
           return _$K.apply(kappa,serverValue);
         }
       }
@@ -1592,9 +1579,9 @@ const _$Links = (function() {
 
 
   function replacer (key, value) {
-    _$Debug.debug("In replacer with key: ", key);
-    _$Debug.debug("typeof value: ", typeof value);
-    _$Debug.debug("value: ", value);
+    _$Debug.debug("In replacer with key: " + key);
+    _$Debug.debug("typeof value: " + typeof value);
+    _$Debug.debug("value: " + value);
 
     if (typeof value === 'function') {
       if (value.location === 'server') {
@@ -1693,7 +1680,7 @@ const _$Links = (function() {
      * Concatenate multiple lists
      * @param {any[][]} lists
      */
-    concatList: function (lists) { return [].concat(...lists); },
+    concatList: function (xss) { return xss.flatMap(xs => xs); },
 
     singleXmlToDomNodes: singleXmlToDomNodes,
 
@@ -1773,14 +1760,14 @@ const _$Links = (function() {
     deliverMessage: function(pid, msg) {
       _$Proc.Mail.send(pid, msg);
       _$Proc.wakeUp(pid);
-      _$Debug.debug(pid, ' now has ', _$Proc.Mail.count(pid), ' message(s)');
+      _$Debug.debug(pid + ' now has ' + _$Proc.Mail.count(pid) + ' message(s)');
       return;
     },
 
     // Remote calls
     remoteCall: function (kappa) {
       return function (name, env, args) {
-        _$Debug.debug("Making remote call to: ", name);
+        _$Debug.debug("Making remote call to: " + name);
         const currentPID = _$Proc.Sched.getPid();
 
         // setpid_kappa: Re-establish the process identifier and continue
@@ -1941,9 +1928,9 @@ const _$Links = (function() {
     },
 
     stringify: function (v) {
-      _$Debug.debug("stringifying: ", v);
+      _$Debug.debug("stringifying: " + v);
       const t = JSON.stringify(v, replacer);
-      _$Debug.debug("stringified: ", t);
+      _$Debug.debug("stringified: " + t);
       if (typeof t === 'string') {
         return t;
       }
@@ -2087,9 +2074,9 @@ const implode = _$Links.kify(_implode);
 
 function _debugObj(obj) {
   if (obj == undefined) {
-    _$Debug.debug(obj, " : undefined");
+    _$Debug.debug(obj + " : undefined");
   } else {
-    _$Debug.debug(obj, " : ", typeof(obj), (typeof(obj) == 'object' ? obj.constructor : ''));
+    _$Debug.debug(obj + " : " + typeof(obj) + (typeof(obj) == 'object' ? obj.constructor : ''));
   }
   return [];
 }
@@ -2750,7 +2737,7 @@ function _startTimer() {
 }
 function _stopTimer() {
   _pageTimer = _clientTime() - _pageTimer;
-  _$Debug.debug("Page drawn in ", _pageTimer, "ms");
+  _$Debug.debug("Page drawn in " + _pageTimer + "ms");
   return;
 }
 
@@ -3030,7 +3017,7 @@ function spawnWait(f, kappa) {
   const parentPid = _$Proc.Sched.getPid();
   const childPid = _$Proc.alloc();
 
-  _$Debug.debug("launched process #", childPid);
+  _$Debug.debug("launched process #" + childPid);
   _$Proc.Sched.setPid(childPid);
 
   return f(_$K.make(function(v) {
@@ -3104,7 +3091,7 @@ function _Send(pid, msg) {
   } else if (valid_client_pid) {
     if (get_client_id(pid) == _client_id) {
       // Local send
-      _$Debug.debug("sending message ", msg, " to pid ", pid._clientPid);
+      _$Debug.debug("sending message " + msg + " to pid " + pid._clientPid);
       let client_pid = pid._clientPid;
       _$Links.deliverMessage(client_pid, msg);
     } else {
@@ -3138,7 +3125,7 @@ function recv(kappa) {
       currentPid,
       function () {
         _$Proc.Sched.setPid(currentPid);
-        _$Debug.debug("scheduled process ", currentPid);
+        _$Debug.debug("scheduled process " + currentPid);
         return recv(kappa);
       }
     );
@@ -3258,7 +3245,7 @@ const _$Session = (function() {
                 // delivery / RPC returns
                 let ap = AP.get(localAPID);
                 _$Debug.assert(function() { return ap != undefined; }, "Attempting to request on an undefined AP!");
-                _$Debug.debug("Request called on local AP ", localAPID);
+                _$Debug.debug("Request called on local AP " + localAPID);
                 // If there's a requester, then pop the requester, create the other end of the channel, and
                 // wake up the requester.
 
@@ -3472,10 +3459,10 @@ const _$Session = (function() {
                 // message; we store these and then add them to the buffer when we've got the endpoint.
                 if (!buffers[epid]) {
                     if (lostMessages[epid]) {
-                        _$Debug.debug("Storing lost message ", v, " for port ", epid);
+                        _$Debug.debug("Storing lost message " + v + " for port " + epid);
                         return addMessage(lostMessages, epid, v);
                     } else {
-                        _$Debug.debug("Storing orphan message ", v, " for port ", epid);
+                        _$Debug.debug("Storing orphan message " + v + " for port " + epid);
                         return addMessage(orphanMessages, epid, v);
                     }
                 } else {
@@ -3616,7 +3603,7 @@ const _$Session = (function() {
 
 function _new() {
   const apid = _$Session.AP.alloc();
-  _$Debug.debug("Allocated new access point ", apid);
+  _$Debug.debug("Allocated new access point " + apid);
   return {_clientAPID: apid, _clientId: _client_id};
 }
 
@@ -3773,9 +3760,9 @@ function _close(c) {
 //  };
 //}
 
-function _print(...str) {
-  console.info(...str);
-  return 0;
+function _print(str) {
+  console.info(str);
+  return _$Constants.UNIT;
 }
 
 const print = _$Links.kify(_print);

--- a/lib/js/jslib.js
+++ b/lib/js/jslib.js
@@ -1,5 +1,13 @@
-/* jshint globalstrict: true */
-/* jshint esversion:6 */
+// JSHint environments
+/* jshint browser:true, devel:true */
+// JSHint enforcing options
+/* jshint esversion:6, forin: true, freeze: true, strict: global,
+          varstmt: true */
+// JSHint relaxing options
+/* jshint evil: true, laxbreak: true */
+// JSHint globals whitelist
+/* globals _$K, _initVars, _jsonState, cgiEnv:true, DEBUGGING, escape,
+           event:true, length:true, print:true, unescape */
 'use strict';
 
 /* SCHEDULER */

--- a/lib/js/jslib.js
+++ b/lib/js/jslib.js
@@ -1,8 +1,6 @@
 /* jshint globalstrict: true */
 /* jshint esversion:6 */
 'use strict';
-/* Magic constant -- used by the runtime to determine whether jslib has been loaded. */
-window._JSLIB = true;
 
 /* SCHEDULER */
 class _Continuation {

--- a/lib/js/jslib.js
+++ b/lib/js/jslib.js
@@ -254,7 +254,7 @@ const _$List = (function(){
       let cur = _$List.singleton(null);
       const res = cur;
       while(!_$List.isNil(list)) {
-        cur._tail = _$List.cons(f(list._head),Nil);
+        cur._tail = _$List.cons(f(list._head), _$List.nil);
         cur = cur.tail;
         list = list._tail;
       }

--- a/lib/js/jslib.js
+++ b/lib/js/jslib.js
@@ -643,7 +643,7 @@ const _$Websocket = (function() {
             if (is_connected) {
                 socket.send(_$Links.stringify(msg));
             } else {
-                _$Debug.debug("No connection yet; buffering message " + msg);
+                _$Debug.debug("No connection yet; buffering message " + _$Links.stringify(msg));
                 buffer.unshift(msg);
             }
             return;
@@ -652,7 +652,7 @@ const _$Websocket = (function() {
         sendRemoteClientMessage: function (destClientId, destPid, msg) {
             _$Debug.debug("Sending message bound for client " +
                           destClientId + ", process " + destPid +
-                          ", msg: " + msg);
+                          ", msg: " + _$Links.stringify(msg));
 
             const to_send_json = {
                 opcode: "CLIENT_TO_CLIENT",
@@ -666,7 +666,7 @@ const _$Websocket = (function() {
 
         sendRemoteServerMessage: function (destServerPid, msg) {
             _$Debug.debug("Sending message bound for server process " +
-                          destServerPid + ", msg: " + msg);
+                          destServerPid + ", msg: " + _$Links.stringify(msg));
 
             const to_send_json = {
                 opcode: "CLIENT_TO_SERVER",
@@ -1191,8 +1191,9 @@ const _$Links = (function() {
        const buf = entry.values;
        const bKeys = Object.keys(buf);
        for (let i = 0; i < bKeys.length; i++) {
-           // TODO(dhil): Resolution of buffers currently depends on the
-           // fact that resolveServerValue mutates `val` internally.
+           // TODO(dhil): Resolution of buffers currently depends on
+           // the fact that resolveServerValue mutates `buf[bKeys[i]]`
+           // internally.
            resolveServerValue(state, buf[bKeys[i]]);
        }
        _$Session.Channel.open(id, buf);
@@ -1611,7 +1612,9 @@ const _$Links = (function() {
   function replacer (key, value) {
     _$Debug.debug("In replacer with key: " + key);
     _$Debug.debug("typeof value: " + typeof value);
-    _$Debug.debug("value: " + value);
+    // TODO(dhil): We cannot use _$Links.stringify below, because
+    // _$Links.stringify depends on this function. It seems wrong...
+    _$Debug.debug("value: " + JSON.stringify(value));
 
     if (typeof value === 'function') {
       if (value.location === 'server') {
@@ -1925,9 +1928,7 @@ const _$Links = (function() {
     },
 
     stringify: function (v) {
-      _$Debug.debug("stringifying: " + v);
       const t = JSON.stringify(v, replacer);
-      _$Debug.debug("stringified: " + t);
       if (typeof t === 'string') {
         return t;
       }
@@ -3061,7 +3062,7 @@ function _is_valid_server_pid(pid) {
 }
 
 function get_client_id(pid) {
-  return pid._clientId && true;
+  return pid._clientId;
 }
 
 function get_process_id(pid) {

--- a/lib/js/jslib.js
+++ b/lib/js/jslib.js
@@ -184,7 +184,7 @@ const _$Proc = (function() {
             // decision that clients should only be able to perform
             // local spawn / new operations. This function implements
             // the requisite checks.
-            if ("_clientSpawnLoc" in loc) {
+            if (loc._clientSpawnLoc) {
                 if (loc._clientSpawnLoc === _client_id) return true;
                 else {
                     // TODO(dhil): This is a hack. _$Debug.assert is
@@ -195,7 +195,7 @@ const _$Proc = (function() {
                     _$Debug.assert(function() { return false; }, "Cannot spawn a process on another client");
                     return false;
                 }
-            } else if ("_serverSpawnLoc" in loc) {
+            } else if (loc._serverSpawnLoc) {
                 _$Debug.assert(function () { return false; }, "Cannot spawn process on server from client");
                 return false;
             } else {
@@ -441,7 +441,7 @@ const _$Types = Object.freeze({
     else if (_$Types.isEvent (val))       return 'event';
     else if (_$Types.isUndefined (val))   return 'undefined';
     else if (_$Types.isNull (val))        return 'null';
-    else if (typeof(val) == 'object' && 'constructor' in val) return val.constructor;
+    else if (typeof(val) == 'object' && val.constructor) return val.constructor;
     else return 'Unknown Type';
   }
 });
@@ -500,7 +500,7 @@ const _$Websocket = (function() {
         },
 
         connect_if_required: function (state) {
-            if ("ws_conn_url" in state) {
+            if (state.ws_conn_url) {
                 _$Websocket.connect(_$Websocket.make_uri(state.ws_conn_url));
             } else {
                 _$Debug.debug("No ws_conn_url in JSON state; not connecting to websocket server");
@@ -565,7 +565,7 @@ const _$Websocket = (function() {
             const js_parsed = JSON.parse(evt.data);
             _$Debug.debug("Received message ", js_parsed || evt.data);
             if (_$Types.isObject(js_parsed)) {
-                if ("opcode" in js_parsed) {
+                if (js_parsed.opcode) {
                     switch (js_parsed.opcode) {
                     case "MESSAGE_DELIVERY": {
                         _$Debug.debug("In message delivery case");
@@ -794,13 +794,19 @@ const _$Links = (function() {
       //   - it isn't clear that structural equality is always the same as
       //   referential equality for DOM nodes
 
-      for (let p in l)
-        if (l.hasOwnProperty(p))
-            if (!eq(l[p], r[p])) return false;
+      // TODO(dhil): This can be optimised. The second loop performs
+      // potentially redundant work.
+      const lKeys = Object.keys(l);
+      for (let i = 0; i < lKeys.length; i++) {
+          const key = lKeys[i];
+          if (!eq(l[key], r[key])) return false;
+      }
 
-      for(let p in r)
-        if (r.hasOwnProperty(p))
-            if (!eq(l[p], r[p])) return false;
+      const rKeys = Object.keys(r);
+      for (let i = 0; i < rKeys.length; i++) {
+          const key = rKeys[i];
+          if (!eq(l[key], r[key])) return false;
+      }
 
       return true;
     }
@@ -844,13 +850,19 @@ const _$Links = (function() {
     if (typeof(l) === 'object' && l !== null &&
         typeof(r) === 'object' && r !== null) {
 
-      for (let p in l)
-        if (l.hasOwnProperty(p))
-            if (!gt(l[p], r[p])) return false;
+      // TODO(dhil): This can be optimised. The second loop performs
+      // potentially redundant work.
+      const lKeys = Object.keys(l);
+      for (let i = 0; i < lKeys.length; i++) {
+          const key = lKeys[i];
+          if (!gt(l[key], r[key])) return false;
+      }
 
-      for(let p in r)
-        if (r.hasOwnProperty(p))
-            if (!gt(l[p], r[p])) return false;
+      const rKeys = Object.keys(r);
+      for (let i = 0; i < rKeys.length; i++) {
+          const key = rKeys[i];
+          if (!gt(l[key], r[key])) return false;
+      }
 
       return true;
     }
@@ -892,15 +904,21 @@ const _$Links = (function() {
     if (typeof(l) === 'object' && l !== null &&
         typeof(r) === 'object' && r !== null) {
 
-        for (let p in l)
-          if (l.hasOwnProperty(p))
-              if (!lt(l[p], r[p])) return false;
+      // TODO(dhil): This can be optimised. The second loop performs
+      // potentially redundant work.
+      const lKeys = Object.keys(l);
+      for (let i = 0; i < lKeys.length; i++) {
+          const key = lKeys[i];
+          if (!lt(l[key], r[key])) return false;
+      }
 
-        for(let p in r)
-          if (r.hasOwnProperty(p))
-              if (!lt(l[p], r[p])) return false;
+      const rKeys = Object.keys(r);
+      for (let i = 0; i < rKeys.length; i++) {
+          const key = rKeys[i];
+          if (!lt(l[key], r[key])) return false;
+      }
 
-        return true;
+      return true;
     }
 
     throw ("Comparing " + l + " with " + r + " which either does not make sense or isn't implemented.");
@@ -941,13 +959,19 @@ const _$Links = (function() {
     if (typeof(l) === 'object' && l !== null &&
         typeof(r) === 'object' && r !== null) {
 
-      for (let p in l)
-        if (l.hasOwnProperty(p))
-            if (!lte(l[p], r[p])) return false;
+      // TODO(dhil): This can be optimised. The second loop performs
+      // potentially redundant work.
+      const lKeys = Object.keys(l);
+      for (let i = 0; i < lKeys.length; i++) {
+          const key = lKeys[i];
+          if (!lte(l[key], r[key])) return false;
+      }
 
-      for (let p in r)
-        if (r.hasOwnProperty(p))
-            if (!lte(l[p], r[p])) return false;
+      const rKeys = Object.keys(r);
+      for (let i = 0; i < rKeys.length; i++) {
+          const key = rKeys[i];
+          if (!lte(l[key], r[key])) return false;
+      }
 
       return true;
     }
@@ -990,13 +1014,19 @@ const _$Links = (function() {
     if (typeof(l) === 'object' && l !== null &&
         typeof(r) === 'object' && r !== null) {
 
-      for (let p in l)
-        if (l.hasOwnProperty(p))
-              if (!gte(l[p], r[p])) return false;
+      // TODO(dhil): This can be optimised. The second loop performs
+      // potentially redundant work.
+      const lKeys = Object.keys(l);
+      for (let i = 0; i < lKeys.length; i++) {
+          const key = lKeys[i];
+          if (!gte(l[key], r[key])) return false;
+      }
 
-      for (let p in r)
-        if (r.hasOwnProperty(p))
-            if (!gte(l[p], r[p])) return false;
+      const rKeys = Object.keys(r);
+      for (let i = 0; i < rKeys.length; i++) {
+          const key = rKeys[i];
+          if (!gte(l[key], r[key])) return false;
+      }
 
       return true;
     }
@@ -1101,17 +1131,16 @@ const _$Links = (function() {
    * @param {any} handlers
    */
   function _resolveJsonState(state, handlers) {
-      for (let i in handlers) {
-          if (handlers.hasOwnProperty(i)) {
-              const h = handlers[i];
-              h.clientKey = _registerMobileKey(state, h.key);
+      const hKeys = Object.keys(handlers);
+      for (let i = 0; i < hKeys.length; i++) {
+          const h = handlers[hKeys[i]];
+          h.clientKey = _registerMobileKey(state, h.key);
 
-              // Update nodes with the client keys
-              const nodes = document.querySelectorAll('[key="' + h.key + '"]');
-              Array.prototype.map.call(nodes, function (node) {
-                  node.setAttribute('key', h.clientKey);
-              });
-          }
+          // Update nodes with the client keys
+          const nodes = document.querySelectorAll('[key="' + h.key + '"]');
+          Array.prototype.map.call(nodes, function (node) {
+              node.setAttribute('key', h.clientKey);
+          });
       }
     return;
   }
@@ -1133,40 +1162,41 @@ const _$Links = (function() {
     _client_id = clientId;
 
     // Register event handlers
-    for (let i in handlers) {
-        if (handlers.hasOwnProperty(i)) {
-            handlers[i].eventHandlers = resolveServerValue(state, handlers[i].eventHandlers);
-            _registerMobileEventHandlers(handlers[i].clientKey, handlers[i].eventHandlers);
-        }
+    const hKeys = Object.keys(handlers);
+    for (let i = 0; i < hKeys.length; i++) {
+        const key = hKeys[i];
+        handlers[key].eventHandlers = resolveServerValue(state, handlers[key].eventHandlers);
+        _registerMobileEventHandlers(handlers[key].clientKey, handlers[key].eventHandlers);
     }
 
     // Resolve and create mobile access points
     // Needs to be done before processes, since processes may (will!) reference
-    for (let i in aps)
-      _$Session.AP.alloc(aps[i]);
+    const aKeys = Object.keys(aps);
+    for (let i = 0; i < aps.length; i++)
+        _$Session.AP.alloc(aps[aKeys[i]]);
 
     // Resolve and spawn the mobile processes
-    for (let i in processes) {
-        if (processes.hasOwnProperty(i)) {
-            processes[i] = resolveServerValue(state, processes[i]);
-            let p = processes[i];
-            _$Proc.spawnWithMessages(p.pid, p.process, p.messages);
-        }
+    const pKeys = Object.keys(processes);
+    for (let i = 0; i < pKeys.length; i++) {
+        const key = pKeys[i];
+        processes[key] = resolveServerValue(state, processes[key]);
+        const p = processes[key];
+        _$Proc.spawnWithMessages(p.pid, p.process, p.messages);
     }
 
-   for (let i in buffers) {
-       if (buffers.hasOwnProperty(i)) {
-           const entry = buffers[i];
-           const id = entry.buf_id;
-           const buf = entry.values;
-           for (let val in buf) {
-               // TODO(dhil): Resolution of buffers currently depends on the
-               // fact that resolveServerValue mutates `val` internally.
-               resolveServerValue(state, val);
-           }
-           _$Session.Channel.open(id, buf);
+   const bsKeys = Object.keys(buffers);
+   for (let i = 0; i < bsKeys.length; i++) {
+       const entry = buffers[bsKeys[i]];
+       const id = entry.buf_id;
+       const buf = entry.values;
+       const bKeys = Object.keys(buf);
+       for (let i = 0; i < bKeys.length; i++) {
+           // TODO(dhil): Resolution of buffers currently depends on the
+           // fact that resolveServerValue mutates `val` internally.
+           resolveServerValue(state, buf[bKeys[i]]);
        }
-    }
+       _$Session.Channel.open(id, buf);
+   }
     return;
   }
 
@@ -1184,20 +1214,26 @@ const _$Links = (function() {
    */
   function resolveMobileState(state, processes, handlers) {
     // register event handler keys
-    for (let i in handlers) {
-      handlers[i].clientKey = _registerMobileKey(state, handlers[i].key);
+    let hKeys = Object.keys(handlers);
+    for (let i = 0; i < hKeys.length; i++) {
+      const key = hKeys[i];
+      handlers[key].clientKey = _registerMobileKey(state, handlers[key].key);
     }
 
     // register event handlers
-    for (let i in handlers) {
-      handlers[i].eventHandlers = resolveServerValue(state, handlers[i].eventHandlers);
-      _registerMobileEventHandlers(handlers[i].clientKey, handlers[i].eventHandlers);
+    // TODO(dhil): Fuse the loop below with the above loop?
+    for (let i = 0; i < hKeys.length; i++) {
+      const key = hKeys[i];
+      handlers[key].eventHandlers = resolveServerValue(state, handlers[key].eventHandlers);
+      _registerMobileEventHandlers(handlers[key].clientKey, handlers[key].eventHandlers);
     }
 
     // resolve and spawn the mobile processes
-    for (let i in processes) {
-      processes[i] = resolveServerValue(state, processes[i]);
-      const p = processes[i];
+    const pKeys = Object.keys(processes);
+    for (let i = 0; i < pKeys.length; i++) {
+      const key = pKeys[i];
+      processes[key] = resolveServerValue(state, processes[key]);
+      const p = processes[key];
       _$Proc.spawnWithMessages(p.pid, p.process, p.messages);
     }
     return;
@@ -1374,10 +1410,8 @@ const _$Links = (function() {
           // bottom-up fashion, so in order to resolve the object
           // in-order at runtime construct the continuation from the
           // keys in reverse order.
-          let keys = [];
-          for (let key in obj) {
-              keys.push(key);
-          }
+          const keys = Object.keys(obj);
+
           let g = function(obj) {
               return applyK(k, obj);
           };
@@ -1415,10 +1449,8 @@ const _$Links = (function() {
           // fashion, so in order to resolve the object in-order at
           // runtime construct the continuation from the indices in
           // reverse order.
-          let indices = [];
-          for (let index in obj.messages) {
-              indices.push(index);
-          }
+          const indices = Object.keys(obj.messages);
+
           let g = function(obj) {
               return applyK(k, obj);
           };
@@ -1531,7 +1563,7 @@ const _$Links = (function() {
         // using a signal member like __continuation.
         const callPackageOrServerValue = serverResponse.content.value;
 
-        if ((callPackageOrServerValue instanceof Object) && ('__continuation' in callPackageOrServerValue)) {
+        if ((callPackageOrServerValue instanceof Object) && callPackageOrServerValue.__continuation) {
           // callPackageOrServerValue is a call package.
           // Bouncing the trampoline
 
@@ -1745,7 +1777,9 @@ const _$Links = (function() {
      */
      erase: function (r, labels) {
       const s = {};
-      for (let l in r) {
+      const rKeys = Object.keys(r);
+      for (let i = 0; i < rKeys.length; i++) {
+         const l = rKeys[i];
          if (labels.has(l)) continue;
          else s[l] = r[l];
       }
@@ -3019,15 +3053,15 @@ const haveMail = _$Links.kify(_haveMail);
 /* Send for mailboxes -- adds a message to a local mailbox */
 
 function _is_valid_client_pid(pid) {
-  return (("_clientId" in pid) && ("_clientPid" in pid));
+  return pid._clientId && pid._clientPid;
 }
 
 function _is_valid_server_pid(pid) {
-  return ("_serverPid" in pid);
+  return pid._serverPid && true;
 }
 
 function get_client_id(pid) {
-  return pid._clientId;
+  return pid._clientId && true;
 }
 
 function get_process_id(pid) {
@@ -3254,10 +3288,10 @@ const _$Session = (function() {
                 return blockUntilAPResponse(kappa);
             },
             'isValidClientAP': function(pid) {
-                return (('_clientId' in pid) && ('_clientAPID' in pid));
+                return pid._clientId && pid._clientAPID;
             },
             'isValidServerAP': function(pid) {
-                return ('_serverAPID' in pid);
+                return pid._serverAPID && true;
             },
             'getClientID': function(pid) {
                 return pid._clientId;
@@ -3478,10 +3512,12 @@ const _$Session = (function() {
             },
             'handleLostMessages': function(blockedEp, lostMessageTable) {
                 // Commit all channels
-                for (let epId in lostMessageTable)
+                const mtKeys = Object.keys(lostMessageTable);
+                for (let i = 0; i < mtKeys.length; i++) {
+                    const epId = mtKeys[i];
                     if (lostMessageTable[epId] != null)
                         Channel.commitChannel(epId, lostMessageTable[epId]);
-
+                }
                 // Wake up the channel awaiting the message
                 _$Proc.wakeUp(unblock(blockedEp));
                 return;
@@ -3501,7 +3537,7 @@ const _$Session = (function() {
                 for (let i = 0; i < chans.length; i++) {
                     const curChan = chans[i];
                     const curRecvEp = chans[i]._sessEP2;
-                    _$Debug.assert(function () { return curRecvEp in buffers; }, "Trying to delegate channel without a buffer!");
+                    _$Debug.assert(function () { return buffers.curRecvEp; }, "Trying to delegate channel without a buffer!");
                     const curBuf = buffers[curRecvEp];
                     // Delete buffer, create lost message buffer
                     buffers[curRecvEp] = null;
@@ -3800,15 +3836,14 @@ const exp = _$Links.kify(_exp);
 function _makeCgiEnvironment() {
   let env = [];
 
-  let i = 0;
-  for (let name in cgiEnv) {
-      if (cgiEnv.hasOwnProperty(name)) {
-          env[i] = {'1':name, '2':cgiEnv[name]};
-          ++i;
-      }
+  const cgiKeys = Object.keys(cgiEnv);
+  for (let i = 0; i < cgiKeys.length; i++) {
+      const name = cgiEnv[cgiKeys[i]];
+      env[i] = {'1':name, '2':cgiEnv[name]};
   }
 
   cgiEnv = env;
+  return;
 }
 
 function _environment() {


### PR DESCRIPTION
This is a minor follow-up patch on #1087. It fixes a couple of additional bugs discovered in the runtime. It also gets rid of all uses of spread syntax, as it is not supported by some of the tools we wish to feed Links applications to. For the same reason this patch also gets rid of all uses of `for (... in ...)` in favour of ordinary `for`-loops.