### PR TITLE
No more noisy pages

### DIFF
--- a/core/page.ml
+++ b/core/page.ml
@@ -53,6 +53,7 @@ module Make_RealPage (C : JS_PAGE_COMPILER) (G : JS_CODEGEN) = struct
                         ^ ffiLibs ^ "\n"
                         ^ db_config_script
                         ^ env
+                        ^ "<meta charset=\"utf-8\">"
                         ^ head
                         ^ "<script type=\"text/javascript\">
                              'use strict';

--- a/examples/games/pacman.links
+++ b/examples/games/pacman.links
@@ -1407,7 +1407,6 @@ fun main() {
             }
 
             var _ = recv(); # wait for initialize()
-            println("Initialized");
             mainLoop(getInitialGameState(), 0.0, clientTimeMilliseconds(), initialFpsInfo, []);
 
             if (not(haveMail())) self() ! CarryOn else (); # restart

--- a/lib/js/jslib.js
+++ b/lib/js/jslib.js
@@ -2179,12 +2179,7 @@ function _getDocumentNode() {
 
 //getRefById : string -> domRef
 function _getNodeById(id) {
-  const ref = document.getElementById(id);
-
-  if (!ref) {
-    console.warn("getNodeById: ID ", id, " does not exist");
-  }
-  return ref;
+  return document.getElementById(id);
 }
 
 //isNullRef : domRef -> bool
@@ -3855,58 +3850,50 @@ function _redirect(url) {
 }
 const redirect = _$Links.kify(_redirect);
 
-const _$QUIRKS = (function () {
-  return Object.freeze({
-    // BEGIN code from quirksmode.org
-    createCookie: function (name, value, days) {
-        let expires = null;
-        if (days) {
-            const date = new Date(); // makes garbage
+const _$Cookie = (function () {
+    function set(name, value, days) {
+        let expires = 'expires=Thu, 01 Jan 1970 00:00:00 UTC';
+        if (days > 0) {
+            const date = new Date();
             date.setTime(date.getTime() + (days * 24 * 60 * 60 * 1000));
-            expires = "; expires=" + date.toGMTString();
-        } else {
-            expires = "";
+            expires = 'expires=' + date.toUTCString();
         }
-        document.cookie = name + "=" + value + expires + "; path=/";
+        document.cookie = name + '=' + value + '; ' + expires + '; SameSite=Lax; path=/';
         return;
-    },
-
-    readCookie: function (name) {
-      const nameEQ = name + "=";
-      const ca = document.cookie.split(';');
-      for (let i = 0; i < ca.length; i++) {
-        let c = ca[i];
-        while (c.charAt(0) == ' ') c = c.substring(1, c.length);
-        if (c.indexOf(nameEQ) == 0) {
-          return c.substring(nameEQ.length, c.length);
-        }
-      }
-      return null;
-    },
-
-    eraseCookie : function (name) {
-      return _$QUIRKS.createCookie(name,"",-1);
     }
-    // END code from quirksmode.org
+
+    return Object.freeze({
+        'set': set,
+        'read': function(name) {
+            const keyString = name + '=';
+            const keyValuePairs = document.cookie.split(';');
+            for (let i = 0; i < keyValuePairs.length; i++) {
+                const keyValuePair = keyValuePairs[i].trimLeft();
+                if (keyValuePair.startsWith(keyString))
+                    return keyValuePair.substring(keyString.length, keyValuePair.length);
+            }
+            return "";
+        },
+        'erase': function (name) {
+            return set(name, "", -1);
+        }
     });
 })();
 
 function _setCookie(cookieName, value) {
-  _$QUIRKS.createCookie(
-    cookieName,
-    value,
-    10000
-  );
+  _$Cookie.set(cookieName, value, 10000);
   return _$Constants.UNIT;
 }
 const setCookie = _$Links.kify(_setCookie);
 
 function _getCookie(cookieName) {
-  return _$QUIRKS.readCookie(cookieName);
+  return _$Cookie.read(cookieName);
 }
 const getCookie = _$Links.kify(_getCookie);
 
-function _random() {return Math.random();}
+function _random() {
+  return Math.random();
+}
 const random = _$Links.kify(_random);
 
 //


### PR DESCRIPTION
The following browser related warnings/noises have been fixed:
 - `The character encoding of a framed document was not declared. The document may appear different if viewed without the document framing it.` (every Links page)
 - `Layout was forced before the page was fully loaded. If stylesheets are not yet loaded this may cause a flash of unstyled content.` (every Links page)
 - `getNodeById: ID blue0 does not exist` (mandelbrot.links)
 - Cookie warnings (wine.links)
 - Noise printed by pacman.links in the developer console when running with `debug=false`

Resolves #1020