### PR TITLE
Options for linking JS runtime

### DIFF
--- a/bin/driver.ml
+++ b/bin/driver.ml
@@ -218,6 +218,10 @@ module Phases = struct
       let _venv', code =
         let program' =
           let (bs, tc) = program in
+          (* TODO(dhil): This is a slight hack. We shouldn't need to
+             use the webserver to retrieve the prelude, alas, the
+             current infrastructure does not let us get hold of the
+             prelude bindings by other means. *)
           (Webserver.get_prelude () @ bs, tc)
         in
         Compiler.generate_program venv program'

--- a/core/basicsettings.ml
+++ b/core/basicsettings.ml
@@ -105,4 +105,22 @@ module System = struct
     | Some Interactive -> true
     | _ -> false
 
+  let link_js_runtime =
+    Settings.(flag "link_js_runtime" ~default:true
+              |> privilege `User
+              |> synopsis "In compile mode, this flag toggles whether the JS compiler statically links the JS runtime"
+              |> convert parse_bool
+              |> hidden
+              |> CLI.(add (long "Ljs-runtime"))
+              |> sync)
+
+  let custom_js_runtime =
+    Settings.(option "custom_js_runtime"
+              |> privilege `User
+              |> synopsis "If link_js_runtime is set to true, then the JS compiler will link the provided file(s) rather than the standard Links JS runtime"
+              |> to_string from_string_option
+              |> convert (fun s -> Some s)
+              |> hidden
+              |> CLI.(add (long "Xcustom-js-runtime"))
+              |> sync)
 end

--- a/core/irtojs.ml
+++ b/core/irtojs.ml
@@ -1503,11 +1503,8 @@ end = functor (K : CONTINUATION) -> struct
   let wrap_with_server_lib_stubs code = GenStubs.wrap_with_server_lib_stubs code
 
   let generate_program venv comp =
-    let env, code = generate_computation venv comp K.toplevel in
-    (* Strip top-level return statement *)
-    match code with
-    | Code.Return e -> env, e
-    | _ -> assert false
+    let (env, code) = generate_computation venv comp K.toplevel in
+    (env, Code.Aux.call (Code.Fn ([], code)) [])
 
   let primitive_bindings = K.primitive_bindings
 end

--- a/core/page.ml
+++ b/core/page.ml
@@ -57,7 +57,7 @@ module Make_RealPage (C : JS_PAGE_COMPILER) (G : JS_CODEGEN) = struct
                         ^ "<script type=\"text/javascript\">
                              'use strict';
                              function _isRuntimeReady() {
-                                if (window._JSLIB === void 0 || window._JSLIB !== true) {
+                                if (_$Links === void 0) {
                                    const msg = \"<h1>Startup error: Runtime dependency `jslib.js' is not loaded.</h1>\";
                                    document.body.innerHTML = msg;
                                    document.head.innerHTML = \"\";

--- a/core/utility.ml
+++ b/core/utility.ml
@@ -1623,3 +1623,16 @@ module UnixTimestamp = struct
   let to_utc_calendar t =
     Unix.gmtime t |> to_calendar
 end
+
+module IO = struct
+  module Channel = struct
+    let cat : in_channel -> out_channel -> unit
+      = fun ic oc ->
+      try
+        let rec loop () =
+          output_string oc (input_line ic ^ "\n"); loop ()
+        in
+        loop ()
+      with End_of_file -> ()
+  end
+end

--- a/core/webserver.ml
+++ b/core/webserver.ml
@@ -149,6 +149,8 @@ struct
   let set_prelude bs =
     prelude := bs
 
+  let get_prelude () = !prelude
+
   let external_files : (string list) ref = ref []
 
   let init some_env some_globals some_external_files =

--- a/core/webserver_types.ml
+++ b/core/webserver_types.ml
@@ -37,6 +37,7 @@ sig
 
   val init : (Value.env * Ir.var Env.String.t * Types.typing_environment) -> Ir.binding list -> string list -> unit
   val set_prelude : Ir.binding list -> unit
+  val get_prelude : unit -> Ir.binding list
   val add_route : bool -> string -> (string * (string * string) list, request_handler_fn) either -> unit
   val start : Value.env -> unit Lwt.t
 

--- a/core/webserver_types.mli
+++ b/core/webserver_types.mli
@@ -16,6 +16,7 @@ sig
 
   val init : (Value.env * Ir.var Env.String.t * Types.typing_environment) -> Ir.binding list -> string list -> unit
   val set_prelude : Ir.binding list -> unit
+  val get_prelude : unit -> Ir.binding list (* TODO(dhil): This is a temporary hack to thread the prelude through the compiler. *)
   val add_route : bool -> string -> (string * (string * string) list, request_handler_fn) either -> unit
 
   val start : Value.env -> unit Lwt.t

--- a/lib/js/jslib.js
+++ b/lib/js/jslib.js
@@ -1,8 +1,6 @@
 /* jshint globalstrict: true */
 /* jshint esversion:6 */
 'use strict';
-/* Magic constant -- used by the runtime to determine whether jslib has been loaded. */
-window._JSLIB = true;
 
 /* SCHEDULER */
 class _Continuation {
@@ -372,7 +370,7 @@ let event;
 
 // Set up optimised setZeroTimeout
 const setZeroTimeout = (function() {
-    if (window === undefined) return function(f) { return setTimeout(f, 0); };
+    if (typeof window === 'undefined') return function(f) { return setTimeout(f, 0); };
     // TODO(dhil): It is not clear to me how this setZeroTimeout is
     // 'optimised'. I reckon we can probably dispense of it in favour
     // of the simpler non-browser version above.
@@ -448,20 +446,20 @@ const _$Types = Object.freeze({
   }
 });
 
-const _$Debug = Object.freeze({
-  debug: function (...msg) { if (DEBUGGING) console.debug(...msg); return; },
-  show: function (any) { return (_$Types.isXmlNode(any)) ? _$Debug.xmldump(any) : _$Links.stringify(any); },
-  xmldump: function (xml) { return (new XMLSerializer()).serializeToString(xml); },
-  assert: function (fcondition, message) {
-    // TODO(dhil): condition should be a thunk rather than a
-    // computed boolean. Currently when debugging is disabled we
-    // perform needless computation.
-    if (DEBUGGING && !Boolean(fcondition())) {
-      throw new Error(`Assertion failed: ${message}`);
-    }
-    return true;
-  },
-});
+const _$Debug = (function() {
+    const debugMode = typeof DEBUGGING === 'undefined' ? false : DEBUGGING;
+    return Object.freeze({
+        debug: function (...msg) { if (debugMode) console.debug(...msg); return; },
+        show: function (any) { return (_$Types.isXmlNode(any)) ? _$Debug.xmldump(any) : _$Links.stringify(any); },
+        xmldump: function (xml) { return (new XMLSerializer()).serializeToString(xml); },
+        assert: function (fcondition, message) {
+            if (debugMode && !Boolean(fcondition())) {
+                throw new Error(`Assertion failed: ${message}`);
+            }
+            return true;
+        }
+    });
+})();
 
 const _$Constants = Object.freeze({
   AJAX: Object.freeze({

--- a/lib/js/jslib.js
+++ b/lib/js/jslib.js
@@ -1,4 +1,4 @@
-'use strict';
+"use strict";
 
 /* SCHEDULER */
 class _Continuation {
@@ -20,38 +20,38 @@ const _$Proc = (function() {
         const mailboxes = {};
 
         return Object.freeze({
-            'clear': function(pid) {
+            "clear": function(pid) {
                 mailboxes[pid] = null;
                 return;
             },
-            'sendMany': function(receiver, messages) {
+            "sendMany": function(receiver, messages) {
                 const oldMessages = mailboxes[receiver] || [];
                 mailboxes[receiver] = messages.concat(oldMessages);
                 return;
             },
-            'send': function(receiver, message) {
+            "send": function(receiver, message) {
                 if (!mailboxes[receiver])
                     mailboxes[receiver] = [];
                 const mailbox = mailboxes[receiver];
                 mailbox.unshift(message);
                 return;
             },
-            'readMany': function(pid) {
+            "readMany": function(pid) {
                 const messages = mailboxes[pid] || [];
                 Mail.clear(pid);
                 return messages;
             },
-            'read': function(pid) {
+            "read": function(pid) {
                 // This may return undefined.
                 return mailboxes[pid].pop();
             },
-            'peekMany': function(pid) {
+            "peekMany": function(pid) {
                 return mailboxes[pid] || [];
             },
-            'hasAny': function(pid) {
+            "hasAny": function(pid) {
                 return mailboxes[pid] != null && mailboxes[pid].length > 0;
             },
-            'count': function(pid) {
+            "count": function(pid) {
                 return mailboxes[pid].length;
             }
         });
@@ -60,7 +60,7 @@ const _$Proc = (function() {
     // Scheduler (trampoline) definition.
     const Sched = (function () {
         // Constants.
-        const MAIN_PID = 'MAIN';
+        const MAIN_PID = "MAIN";
         // Internal state.
         let yieldGranularity = 60; // The amount of times a process is
                                    // allowed to yield before getting
@@ -73,7 +73,7 @@ const _$Proc = (function() {
         let handlingEvent = false; // Indicates whether not an event
                                    // handler is currently running.
         return Object.freeze({
-            'yield': function(f) {
+            "yield": function(f) {
                 // yield: give up control for another "thread" to
                 // work.  if we're running in an event handler then
                 // don't yield (but do throw away the stack
@@ -93,26 +93,26 @@ const _$Proc = (function() {
                     return f();
                 }
             },
-            'getPid': function() {
+            "getPid": function() {
                 return currentPid;
             },
-            'setPid': function(pid) {
+            "setPid": function(pid) {
                 currentPid = pid;
                 return;
             },
-            'swapPid': function(pid) {
+            "swapPid": function(pid) {
                 const previous = Sched.getPid();
                 Sched.setPid(pid);
                 return previous;
             },
-            'swapMainPid': function() {
+            "swapMainPid": function() {
                 return Sched.swapPid(MAIN_PID);
             },
-            'generatePid': function() {
+            "generatePid": function() {
                 const pid = nextPid++;
                 return "cl_" + pid;
             },
-            'wrapEventHandler': function (handler) {
+            "wrapEventHandler": function (handler) {
                 // Wrap an event handler in a function that sets the
                 // main process id at the beginning of the handler and
                 // unsets it at the end.
@@ -158,10 +158,10 @@ const _$Proc = (function() {
     // Internal state.
     const blocked = {};
     return Object.freeze({
-        'Mail': Mail,
-        'Sched': Sched,
-        'generatePid': Sched.generatePid,
-        'spawnWithMessages': function(childPid, f, messages) {
+        "Mail": Mail,
+        "Sched": Sched,
+        "generatePid": Sched.generatePid,
+        "spawnWithMessages": function(childPid, f, messages) {
             _$Proc.Mail.sendMany(childPid, messages);
             setZeroTimeout(function () {
                 _$Debug.debug("launched process #" + childPid);
@@ -172,9 +172,9 @@ const _$Proc = (function() {
                 }));
                 return;
             });
-            return {'_clientPid': childPid, '_clientId': _client_id};
+            return {"_clientPid": childPid, "_clientId": _client_id};
         },
-        'checkSpawnLocation': function(loc) {
+        "checkSpawnLocation": function(loc) {
             // Certain operations, for example spawning or creating an
             // access point, can take a Location as an argument. This
             // typically makes sense on a server, but the semantics
@@ -201,17 +201,17 @@ const _$Proc = (function() {
                 return false;
             }
         },
-        'alloc': function() {
+        "alloc": function() {
             const pid = _$Proc.generatePid();
             return pid;
         },
-        'yield': Sched.yield,
-        'block': function(pid, f) {
+        "yield": Sched.yield,
+        "block": function(pid, f) {
             _$Debug.debug("Blocking " + pid);
             blocked[pid] = f;
             return;
         },
-        'wakeUp': function(pid) {
+        "wakeUp": function(pid) {
             if (_$Proc.isBlocked(pid)) {
                 _$Debug.debug("Waking up " + pid);
                 const proc = blocked[pid];
@@ -223,7 +223,7 @@ const _$Proc = (function() {
                 return;
             }
         },
-        'isBlocked': function(pid) {
+        "isBlocked": function(pid) {
             return Boolean(blocked[pid]);
         }
     });
@@ -301,12 +301,10 @@ const _$List = (function(){
       return out;
     },
     head: function(v) {
-      _$Debug.assert(function() { return _$Types.isList(v); }, "Not a linked list");
-      return _$List.isNil(v) ? _error('head') : v._head;
+      return _$List.isNil(v) ? _error("head") : v._head;
     },
     tail: function(v) {
-      _$Debug.assert(function() { return _$Types.isList(v); }, "Not a linked list");
-      return _$List.isNil(v) ? _error('tail') : v._tail;
+      return _$List.isNil(v) ? _error("tail") : v._tail;
     },
     revAppend: function(xs, ys) {
       let out = ys;
@@ -368,7 +366,7 @@ let event;
 
 // Set up optimised setZeroTimeout
 const setZeroTimeout = (function() {
-    if (typeof window === 'undefined') return function(f) { return setTimeout(f, 0); };
+    if (typeof window === "undefined") return function(f) { return setTimeout(f, 0); };
     // TODO(dhil): It is not clear to me how this setZeroTimeout is
     // 'optimised'. I reckon we can probably dispense of it in favour
     // of the simpler non-browser version above.
@@ -404,9 +402,9 @@ const setZeroTimeout = (function() {
 const _$Types = Object.freeze({
   isUnit: function (val) { return (_$Types.isObject(val) && val.constructor === Object && Object.keys(val).length === 0); },
   isObject: function (val) { return (val && val instanceof Object && !Array.isArray(val)); },
-  isNumber: function (val) { return (typeof val === 'number'); },
-  isString: function (val) { return (typeof val === 'string'); },
-  isBoolean: function (val) { return (typeof val === 'boolean'); },
+  isNumber: function (val) { return (typeof val === "number"); },
+  isString: function (val) { return (typeof val === "string"); },
+  isBoolean: function (val) { return (typeof val === "boolean"); },
   isXmlNode: function (val) {
     try {
       return (val instanceof Node);
@@ -419,9 +417,9 @@ const _$Types = Object.freeze({
   isCharlist: function (val) { return (_$Types.isArray(val) && !val.some(function (c) { return !_$Types.isString(c); })); },
   isEvent: function (val) { return (val instanceof Event); },
   isTextnode: function (val) { return (_$Types.isXmlNode(val) && val.nodeType === document.TEXT_NODE); },
-  isUndefined: function (val) { return (typeof val === 'undefined'); },
+  isUndefined: function (val) { return (typeof val === "undefined"); },
   isNull: function (val) { return (val === null); },
-  isFunction: function (val) { return (typeof val === 'function'); },
+  isFunction: function (val) { return (typeof val === "function"); },
   isDateTime: function (val) {
       return val.hasOwnProperty("_type") &&
         (val._type == "timestamp" && val.hasOwnProperty("_value")) ||
@@ -429,18 +427,18 @@ const _$Types = Object.freeze({
   },
  isChannel: function (val) { return val.hasOwnProperty("_sessEP1") && val.hasOwnProperty("_sessEP2"); },
  getType: function (val) {
-    if (_$Types.isNumber (val))    return 'number';
-    else if (_$Types.isString (val))      return 'string';
-    else if (_$Types.isBoolean (val))     return 'boolean';
-    else if (_$Types.isTextnode (val))    return 'textnode';
-    else if (_$Types.isXmlnode (val))     return 'xmlnode';
-    else if (_$Types.isArray (val))       return 'array';
-    else if (_$Types.isList (val))  return 'linkedlist';
-    else if (_$Types.isEvent (val))       return 'event';
-    else if (_$Types.isUndefined (val))   return 'undefined';
-    else if (_$Types.isNull (val))        return 'null';
-    else if (typeof(val) == 'object' && val.constructor) return val.constructor;
-    else return 'Unknown Type';
+    if (_$Types.isNumber (val))    return "number";
+    else if (_$Types.isString (val))      return "string";
+    else if (_$Types.isBoolean (val))     return "boolean";
+    else if (_$Types.isTextnode (val))    return "textnode";
+    else if (_$Types.isXmlnode (val))     return "xmlnode";
+    else if (_$Types.isArray (val))       return "array";
+    else if (_$Types.isList (val))  return "linkedlist";
+    else if (_$Types.isEvent (val))       return "event";
+    else if (_$Types.isUndefined (val))   return "undefined";
+    else if (_$Types.isNull (val))        return "null";
+    else if (typeof(val) == "object" && val.constructor) return val.constructor;
+    else return "Unknown Type";
   }
 });
 
@@ -484,8 +482,8 @@ const _$Websocket = (function() {
             let loc = window.location;
             // Remove leading and trailing slashes if necessary
             if (path.length > 0) {
-                let startIdx = (path.charAt(0) == '/') ? 1 : 0;
-                let endIdx = (path.charAt(path.length - 1) == '/') ? path.length - 1 : path.length;
+                let startIdx = (path.charAt(0) == "/") ? 1 : 0;
+                let endIdx = (path.charAt(path.length - 1) == "/") ? path.length - 1 : path.length;
                 if (startIdx < endIdx) {
                     path = path.substring(startIdx, endIdx);
                 } else {
@@ -738,7 +736,7 @@ const _$Links = (function() {
     // It is possible to compare two function objects in JavaScript,
     // so we need to explicitly check whether l or r are functions in
     // order respects the equality semantics of the server-side.
-    if (typeof(l) === 'function' || typeof(r) === 'function')
+    if (typeof(l) === "function" || typeof(r) === "function")
         throw ("Comparing " + l + " with " + r + " which either does not make sense or isn't implemented.");
 
     // Fast path.
@@ -783,8 +781,8 @@ const _$Links = (function() {
       return true;
     }
 
-    if(typeof(l) === 'object' && l !== null &&
-       typeof(r) === 'object' && r !== null) {
+    if(typeof(l) === "object" && l !== null &&
+       typeof(r) === "object" && r !== null) {
       if (l.constructor !== r.constructor) return false;
 
       // DODGEYNESS:
@@ -812,13 +810,13 @@ const _$Links = (function() {
   }
 
   function gt(l, r) {
-    if (typeof(l) === 'function' || typeof(r) === 'function')
+    if (typeof(l) === "function" || typeof(r) === "function")
         throw ("Comparing " + l + " with " + r + " which either does not make sense or isn't implemented.");
 
     // Fast path.
     // Some care is required as JavaScript has a wacky relational
     // semantics on objects.
-    if (typeof l !== 'object' && typeof r !== 'object' && l > r) return true;
+    if (typeof l !== "object" && typeof r !== "object" && l > r) return true;
 
     if (_$Types.isNumber(l) && _$Types.isNumber(r)
         || _$Types.isString(l) && _$Types.isString(r)
@@ -844,8 +842,8 @@ const _$Links = (function() {
         return l.length > r.length;
     }
 
-    if (typeof(l) === 'object' && l !== null &&
-        typeof(r) === 'object' && r !== null) {
+    if (typeof(l) === "object" && l !== null &&
+        typeof(r) === "object" && r !== null) {
 
       // TODO(dhil): This can be optimised. The second loop performs
       // potentially redundant work.
@@ -868,11 +866,11 @@ const _$Links = (function() {
   }
 
   function lt(l, r) {
-    if (typeof(l) === 'function' || typeof(r) === 'function')
+    if (typeof(l) === "function" || typeof(r) === "function")
         throw ("Comparing " + l + " with " + r + " which either does not make sense or isn't implemented.");
 
     // Fast path.
-    if (typeof l !== 'object' && typeof r !== 'object' && l < r) return true;
+    if (typeof l !== "object" && typeof r !== "object" && l < r) return true;
 
     if (_$Types.isNumber(l) && _$Types.isNumber(r)
         || _$Types.isString(l) && _$Types.isString(r)
@@ -898,8 +896,8 @@ const _$Links = (function() {
         return l.length < r.length;
     }
 
-    if (typeof(l) === 'object' && l !== null &&
-        typeof(r) === 'object' && r !== null) {
+    if (typeof(l) === "object" && l !== null &&
+        typeof(r) === "object" && r !== null) {
 
       // TODO(dhil): This can be optimised. The second loop performs
       // potentially redundant work.
@@ -922,11 +920,11 @@ const _$Links = (function() {
   }
 
   function lte(l, r) {
-    if (typeof(l) === 'function' || typeof(r) === 'function')
+    if (typeof(l) === "function" || typeof(r) === "function")
         throw ("Comparing " + l + " with " + r + " which either does not make sense or isn't implemented.");
 
     // Fast path.
-    if (typeof l !== 'object' && typeof r !== 'object' && l <= r) return true;
+    if (typeof l !== "object" && typeof r !== "object" && l <= r) return true;
 
     if (_$Types.isNumber(l) && _$Types.isNumber(r)
         || _$Types.isString(l) && _$Types.isString(r)
@@ -953,8 +951,8 @@ const _$Links = (function() {
         return l.length === r.length || l.length < r.length;
     }
 
-    if (typeof(l) === 'object' && l !== null &&
-        typeof(r) === 'object' && r !== null) {
+    if (typeof(l) === "object" && l !== null &&
+        typeof(r) === "object" && r !== null) {
 
       // TODO(dhil): This can be optimised. The second loop performs
       // potentially redundant work.
@@ -977,11 +975,11 @@ const _$Links = (function() {
   }
 
   function gte(l, r) {
-    if (typeof(l) === 'function' || typeof(r) === 'function')
+    if (typeof(l) === "function" || typeof(r) === "function")
         throw ("Comparing " + l + " with " + r + " which either does not make sense or isn't implemented.");
 
     // Fast path.
-    if (typeof l !== 'object' && typeof r !== 'object' && l >= r) return true;
+    if (typeof l !== "object" && typeof r !== "object" && l >= r) return true;
 
     if (_$Types.isNumber(l) && _$Types.isNumber(r)
         || _$Types.isString(l) && _$Types.isString(r)
@@ -1008,8 +1006,8 @@ const _$Links = (function() {
         return l.length === r.length || l.length > r.length;
     }
 
-    if (typeof(l) === 'object' && l !== null &&
-        typeof(r) === 'object' && r !== null) {
+    if (typeof(l) === "object" && l !== null &&
+        typeof(r) === "object" && r !== null) {
 
       // TODO(dhil): This can be optimised. The second loop performs
       // potentially redundant work.
@@ -1033,11 +1031,11 @@ const _$Links = (function() {
 
   function singleXmlToDomNodes(xmlObj) {
     _$Debug.assert(function() { return _isXmlItem(xmlObj); },
-                   '_$Links.singleXmlToDomNodes expected a XmlItem, but got ' + xmlObj);
+                   "_$Links.singleXmlToDomNodes expected a XmlItem, but got " + xmlObj);
 
     const type = xmlObj.type;
     switch (type) {
-      case 'ELEMENT':
+      case "ELEMENT":
         const tagName = xmlObj.tagName;
         const attributes = xmlObj.attrs;
         const children = xmlObj.children !== undefined ? _$List.toArray(xmlObj.children) : [ ];
@@ -1048,7 +1046,7 @@ const _$Links = (function() {
           document.createElement(tagName);
 
         Object.keys(attributes).forEach(function (k) {
-          const splitRes = k.split(':');
+          const splitRes = k.split(":");
 
           if (splitRes.length === 1) {
             const name = splitRes[0];
@@ -1058,7 +1056,7 @@ const _$Links = (function() {
             const name = splitRes[1];
             node.setAttributeNS(ns, name, attributes[k]);
           } else {
-            throw new Error('attribute names can contain one or no colon. `' + k + '` found.');
+            throw new Error("attribute names can contain one or no colon. `" + k + "` found.");
           }
         });
         if(xmlObj.children) {
@@ -1068,8 +1066,8 @@ const _$Links = (function() {
         }
 
         return node;
-      case 'TEXT':
-        return document.createTextNode(xmlObj.text || '');
+      case "TEXT":
+        return document.createTextNode(xmlObj.text || "");
       default:
         return null;
     }
@@ -1096,17 +1094,17 @@ const _$Links = (function() {
    */
   function _remoteContinue (kappa, continuation, mailbox) {
     return _$K.make(function (res) {
-      _$Debug.debug('Continuing at server with value' + res + 'and continuation' + continuation);
+      _$Debug.debug("Continuing at server with value" + res + "and continuation" + continuation);
       const request = new XMLHttpRequest();
       const rootUrl = _removeCGIArgs(location.href);
 
-      request.open('POST', rootUrl);
+      request.open("POST", rootUrl);
 
       request.onreadystatechange = remoteCallHandler(kappa, request);
 
       request.setRequestHeader(
-        'Content-Type',
-        'application/x-www-form-urlencoded'
+        "Content-Type",
+        "application/x-www-form-urlencoded"
       );
 
       request.pid = _$Proc.Sched.getPid();
@@ -1136,7 +1134,7 @@ const _$Links = (function() {
           // Update nodes with the client keys
           const nodes = document.querySelectorAll('[key="' + h.key + '"]');
           Array.prototype.map.call(nodes, function (node) {
-              node.setAttribute('key', h.clientKey);
+              node.setAttribute("key", h.clientKey);
           });
       }
     return;
@@ -1421,7 +1419,7 @@ const _$Links = (function() {
       case "Variant":
           return _yield(function () {
               return resolveServerValueCPS(state, obj._value, function(value) {
-                  return applyK(k, {'_label': obj._label, '_value': value});
+                  return applyK(k, {"_label": obj._label, "_value": value});
               });
           });
       case "FunctionPtr":
@@ -1494,9 +1492,9 @@ const _$Links = (function() {
    * @param {any} callPackage
    */
   function _invokeClientCall (kappa, callPackage) {
-    _$Debug.debug('Invoking client call to ' + callPackage.__name);
-    _$Debug.debug('arguments: ' + callPackage.__args);
-    _$Debug.debug('arguments: ' + callPackage.__args);
+    _$Debug.debug("Invoking client call to " + callPackage.__name);
+    _$Debug.debug("arguments: " + callPackage.__args);
+    _$Debug.debug("arguments: " + callPackage.__args);
 
     // FIXME: the eval is redundant, because done in
     // remoteCallHandler; also this name may actually be a
@@ -1613,8 +1611,8 @@ const _$Links = (function() {
     // _$Links.stringify depends on this function. It seems wrong...
     _$Debug.debug("value: " + JSON.stringify(value));
 
-    if (typeof value === 'function') {
-      if (value.location === 'server') {
+    if (typeof value === "function") {
+      if (value.location === "server") {
         return {
           _serverFunc: value.func,
           _env: value.environment,
@@ -1625,7 +1623,7 @@ const _$Links = (function() {
 
       return { _closureTable: id };
     } else if ( // SL: HACK for sending XML to the server
-      key !== '_xml' &&
+      key !== "_xml" &&
       _isXmlItem(value)
     ) {
       return { _xml: value };
@@ -1669,7 +1667,7 @@ const _$Links = (function() {
       return decodeURIComponent(escape(atob(s)));
     },
 
-    unimpl: function (name) { throw new Error('Fatal error: function ' + name + ' not available on client.'); },
+    unimpl: function (name) { throw new Error("Fatal error: function " + name + " not available on client."); },
 
     /**
      * Turns a direct-style js function into a continuationized one under the
@@ -1721,7 +1719,7 @@ const _$Links = (function() {
     */
     XmlToDomNodes : function (xmlForest) {
       _$Debug.assert(function () { return _$Types.isList(xmlForest); },
-                     '_$Links.XmlToDomNodes expected a linked list, but got '+ xmlForest);
+                     "_$Links.XmlToDomNodes expected a linked list, but got " + xmlForest);
       const domNodeArray = [];
       _$List.forEach(xmlForest,function(xmlNode){
           domNodeArray.push(singleXmlToDomNodes(xmlNode));
@@ -1742,7 +1740,7 @@ const _$Links = (function() {
         else children = _$List.snoc(children,e);
       });
       return _$List.cons({
-          type: 'ELEMENT',
+          type: "ELEMENT",
           tagName: tag,
           attrs: attrs,
           children: children
@@ -1792,7 +1790,7 @@ const _$Links = (function() {
     deliverMessage: function(pid, msg) {
       _$Proc.Mail.send(pid, msg);
       _$Proc.wakeUp(pid);
-      _$Debug.debug(pid + ' now has ' + _$Proc.Mail.count(pid) + ' message(s)');
+      _$Debug.debug(pid + " now has " + _$Proc.Mail.count(pid) + " message(s)");
       return;
     },
 
@@ -1813,10 +1811,10 @@ const _$Links = (function() {
 
         // Posting to location.href works in both Firefox and IE
         // (unlike posting to '#', which IE mistakenly urlencodes as %23)
-        request.open('POST', location.href);
+        request.open("POST", location.href);
         request.setRequestHeader(
-          'Content-Type',
-          'application/x-www-form-urlencoded'
+          "Content-Type",
+          "application/x-www-form-urlencoded"
         );
 
         request.onreadystatechange = remoteCallHandler(setpidKappa, request);
@@ -1904,7 +1902,7 @@ const _$Links = (function() {
       function activate (node) {
         if (!isElement(node)) return;
 
-        const key = node.getAttribute('key');
+        const key = node.getAttribute("key");
         if (key) {
           const handlers = _eventHandlers[key];
           Object.keys(handlers || { }).forEach(function (event) {
@@ -1926,14 +1924,14 @@ const _$Links = (function() {
 
     stringify: function (v) {
       const t = JSON.stringify(v, replacer);
-      if (typeof t === 'string') {
+      if (typeof t === "string") {
         return t;
       }
       throw new Error("Internal error: unable to JSONize " + v);
     },
 
     parseB64: function (text) { return { content: JSON.parse(_$Links.base64decode(text)) }; },
-    parseB64Safe: function (text) { return _$Links.parseB64(text.replace('\n', '')); },
+    parseB64Safe: function (text) { return _$Links.parseB64(text.replace("\n", "")); },
   });
 })();
 
@@ -2071,7 +2069,7 @@ function _debugObj(obj) {
   if (obj == undefined) {
     _$Debug.debug(obj + " : undefined");
   } else {
-    _$Debug.debug(obj + " : " + typeof(obj) + (typeof(obj) == 'object' ? obj.constructor : ''));
+    _$Debug.debug(obj + " : " + typeof(obj) + (typeof(obj) == "object" ? obj.constructor : ""));
   }
   return [];
 }
@@ -2206,7 +2204,7 @@ let isNull = _$Links.kify(_isNull);
  * The XML representation in JavaScript has type:
  *
  * type XmlItem = {
- *   type: 'ELEMENT' | 'TEXT',
+ *   type: "ELEMENT" | "TEXT",
  *   text?: string,
  *   tagName?: string,
  *   attrs?: { [attrName: string]: string },
@@ -2255,7 +2253,7 @@ function _getValue(nodeRef) {
     function toDomNode(nodeRef) {
         if (nodeRef.nodeType == document.TEXT_NODE) {
             return {
-                type: 'TEXT',
+                type: "TEXT",
                 text: _nodeTextContent(nodeRef)
             };
         } else if (nodeRef.nodeType == document.ELEMENT_NODE ) {
@@ -2273,11 +2271,11 @@ function _getValue(nodeRef) {
             _$Debug.assert(
                 function() {
                     return !_$List.some(function (e) {
-                        return e.type !== 'ELEMENT' && e.type !== 'TEXT'; }, children);
-                }, 'Invalid children constructed in _getValue');
+                        return e.type !== "ELEMENT" && e.type !== "TEXT"; }, children);
+                }, "Invalid children constructed in _getValue");
 
             return {
-                type: 'ELEMENT',
+                type: "ELEMENT",
                 tagName: nodeRef.tagName,
                 attrs: attrs,
                 children: children,
@@ -2300,9 +2298,9 @@ function _domHasAttribute(nodeRef, attr) {
 }
 
 function _domGetAttributeFromRef(nodeRef, attr) {
-  if (attr == 'offsetTop') {
+  if (attr == "offsetTop") {
     return _intToString(nodeRef.offsetTop);
-  } else if (attr == 'offsetLeft') {
+  } else if (attr == "offsetLeft") {
     return _intToString(nodeRef.offsetLeft);
   }
 
@@ -2430,7 +2428,7 @@ let swapNodes = _$Links.kify(_swapNodes);
 function _domReplaceChildren(xml, parent) {
   const newNodes = _$Links.XmlToDomNodes(xml);
 
-  parent.innerHTML = '';
+  parent.innerHTML = "";
 
   newNodes.forEach(function (node) { return _domAppendChildRef(node, parent); });
   return _$Constants.UNIT;
@@ -2450,7 +2448,7 @@ function _registerMobileEventHandlers(key, handlers) {
 }
 
 function _registerEventHandlers(handlers) {
-  const key = '_key' + _get_fresh_node_key();
+  const key = "_key" + _get_fresh_node_key();
 
   _$List.forEach(handlers, function(h) {
     const event = h[1];
@@ -2499,12 +2497,12 @@ function _getTargetElement(event) { return event.target; }
 function _getPageX(event) { return polyFillEvent(event).pageX; }
 function _getPageY(event) { return polyFillEvent(event).pageY;  }
 function _getFromElement(event) {
-  if (event.type === 'mouseover') {
+  if (event.type === "mouseover") {
     return event.relatedTarget;
-  } else if (event.type === 'mouseout') {
+  } else if (event.type === "mouseout") {
     return event.target;
   } else {
-    throw new Error('Can only get the from element for mouseover and mouseout events');
+    throw new Error("Can only get the from element for mouseover and mouseout events");
   }
 }
 
@@ -2541,7 +2539,7 @@ function _isXmlItem(obj) {
     return false;
   }
 
-  if (obj.type === 'ELEMENT') {
+  if (obj.type === "ELEMENT") {
 
     if (!_$Types.isList(obj.children)) {
       return false;
@@ -2564,7 +2562,7 @@ function _isXmlItem(obj) {
     );
   }
 
-  if (obj.type === 'TEXT') {
+  if (obj.type === "TEXT") {
     return _$Types.isString(obj.text);
   }
 
@@ -2581,7 +2579,7 @@ function _isXml(obj) {
 }
 
 function _stringToXml(s) {
-  const res = _$List.cons({ type: 'TEXT',text: s}, _$List.nil);
+  const res = _$List.cons({ type: "TEXT",text: s}, _$List.nil);
   return res;
 }
 
@@ -2609,10 +2607,10 @@ function _getTagName(xml) {
 
 function _getNamespace (xml) {
   let first = _$List.head(xml);
-  if (first.type !== 'ELEMENT') {
-    throw new Error('getNameSpace applied to non-element node');
+  if (first.type !== "ELEMENT") {
+    throw new Error("getNameSpace applied to non-element node");
   }
-  return first.namespace || '';
+  return first.namespace || "";
 }
 
 function _itemChildNodes(xmlitem) {
@@ -2626,7 +2624,7 @@ function _itemTextContent(xmlitem) {
   if (xmlitem.type !== "TEXT") {
     throw new Error("itemTextContent() applied to non-text node");
   }
-  return xmlitem.text || '';
+  return xmlitem.text || "";
 }
 
 function _getAttributes(xml) {
@@ -2702,7 +2700,7 @@ function _activateStyleElement() {
   if(!_cssText)
     return;
 
-  let styleElement = document.getElementsByTagName('style')[0];
+  let styleElement = document.getElementsByTagName("style")[0];
   if (!styleElement || !styleElement.styleSheet)
       throw ("style element doesn't have a style sheet");
 
@@ -2762,7 +2760,7 @@ function _replaceDocument(tree) {
   for (let i = 0; i < inputFields.length; i++) {
      let current = inputFields[i];
      if (current.id != null && current.id != "") { // only store fields with an id!
-       _saved_fieldvals.push({'field' : current.id, 'value' : current.value});
+       _saved_fieldvals.push({"field" : current.id, "value" : current.value});
      }
   }
 
@@ -2771,7 +2769,7 @@ function _replaceDocument(tree) {
   let d = document.documentElement;
   let body;
   while (d.hasChildNodes()) {
-    if (isElementWithTag(d.firstChild, 'body')) {
+    if (isElementWithTag(d.firstChild, "body")) {
       body = d.firstChild;
       let bodyLength = body.childNodes.length;
       while (body.hasChildNodes()) {
@@ -2784,7 +2782,7 @@ function _replaceDocument(tree) {
 
   // insert new dom nodes
   for (let p = tree[0].firstChild; p != null; p = p.nextSibling) {
-    if (isElementWithTag(p, 'body')) {
+    if (isElementWithTag(p, "body")) {
      // insert body nodes inside the existing body node
       for (let q = p.firstChild; q != null; q = q.nextSibling) {
         let it = q.cloneNode(true);
@@ -2835,7 +2833,7 @@ let _eventHandlers = {};
 
 // SL: I think this function is no longer used
 function _registerFormEventHandlers(actions) {
-   const key = '_key' + _get_fresh_node_key();
+   const key = "_key" + _get_fresh_node_key();
 
   for (let i = 0; i < actions.length; i++) {
     const action = actions[i];
@@ -2962,7 +2960,7 @@ function _vmapOp (f, z) {
 // is a single CPS term.
 
 function _registerMobileKey(state, serverKey) {
-  let clientKey = '_key' + _get_fresh_node_key();
+  let clientKey = "_key" + _get_fresh_node_key();
   state.mobileKeys[serverKey] = clientKey;
   return clientKey;
 }
@@ -2988,7 +2986,7 @@ function _newAP(loc) {
 
 function _newClientAP() { return _new(); }
 function _newServerAP() {
-    throw new Error('Cannot create a server access point from a client');
+    throw new Error("Cannot create a server access point from a client");
 }
 
 const newClientAP = _$Links.kify(_newClientAP);
@@ -3103,7 +3101,7 @@ function Send(pid, msg, kappa) {
 function recv(kappa) {
   const args = arguments;
   _$Debug.assert(function() { return args.length == 1; },
-                 'recv received ' + arguments.length + ' arguments, expected 1');
+                 "recv received " + arguments.length + " arguments, expected 1");
 
   const currentPid = _$Proc.Sched.getPid();
   if (_$Proc.Mail.hasAny(currentPid)) {
@@ -3167,20 +3165,20 @@ const _$Session = (function() {
 
         /* Public interface */
         return Object.freeze({
-            'generateId': function() {
+            "generateId": function() {
                 return "clAP_" + nextId++;
             },
-            'alloc': function(optId) {
+            "alloc": function(optId) {
                 // Access point: { ap_state : access point state code; pending : request list }
                 const id = optId || AP.generateId();
-                aps[id] = {'state': BALANCED, pending: []};
+                aps[id] = {"state": BALANCED, pending: []};
                 return id;
             },
-            'get': function(id) {
+            "get": function(id) {
                 return aps[id];
             },
             // Do an accept on a local access point. localAPID: the key into the aps table.
-            'localAccept': function(localAPID, kappa) {
+            "localAccept": function(localAPID, kappa) {
                 // This should explicitly not happen -- all server-created
                 // APs residing on this client should be serialised in
                 // state dumps provided in realpages delivery / RPC
@@ -3223,13 +3221,13 @@ const _$Session = (function() {
                     throw ("Invalid access point state: " + ap.state);
                 }
             },
-            'remoteAccept': function(remote_apid, kappa) {
+            "remoteAccept": function(remote_apid, kappa) {
                 // Accept remotely
                 _$Websocket.sendRemoteAPAccept(_$Proc.Sched.getPid(), remote_apid);
                 return blockUntilAPResponse(kappa);
             },
             // Do a request on a local access point. localAPID: the key into the aps table.
-            'localRequest': function(localAPID, kappa) {
+            "localRequest": function(localAPID, kappa) {
                 // This should explicitly not happen -- all server-created APs residing on
                 // this client should be serialised in state dumps provided in realpages
                 // delivery / RPC returns
@@ -3275,27 +3273,27 @@ const _$Session = (function() {
                     throw ("Invalid access point state: " + ap.state);
                 }
             },
-            'remoteRequest': function(remoteApid, kappa) {
+            "remoteRequest": function(remoteApid, kappa) {
                 // Request remotely
                 _$Websocket.sendRemoteAPRequest(_$Proc.Sched.getPid(), remoteApid);
                 return blockUntilAPResponse(kappa);
             },
-            'isValidClientAP': function(pid) {
+            "isValidClientAP": function(pid) {
                 return pid._clientId && pid._clientAPID;
             },
-            'isValidServerAP': function(pid) {
+            "isValidServerAP": function(pid) {
                 return pid._serverAPID && true;
             },
-            'getClientID': function(pid) {
+            "getClientID": function(pid) {
                 return pid._clientId;
             },
-            'getClientAPID': function(apid) {
+            "getClientAPID": function(apid) {
                 return apid._clientAPID;
             },
-            'getServerAPID': function(apid) {
+            "getServerAPID": function(apid) {
                 return apid._serverAPID;
             },
-            'registerChannel': function(apid, ch) {
+            "registerChannel": function(apid, ch) {
                 returnedChannels[apid] = ch;
                 return;
             }
@@ -3356,7 +3354,7 @@ const _$Session = (function() {
                     res = res.concat(getContainedSessions(vals[i]));
                 }
                 return res;
-            } else if(v.hasOwnProperty('__closureEnv')) {
+            } else if(v.hasOwnProperty("__closureEnv")) {
                 return getContainedSessions(v.__closureEnv); // tee hee, dynamic typing is nice sometimes
             } else {
                 return [];
@@ -3376,61 +3374,61 @@ const _$Session = (function() {
         }
 
         return Object.freeze({
-            'resolveSet': resolveSet, // required by _handleSessionException
-            'isLocal': function(epid) {
+            "resolveSet": resolveSet, // required by _handleSessionException
+            "isLocal": function(epid) {
                 return Boolean(buffers[epid]);
             },
-            'close': function(epid) {
+            "close": function(epid) {
                 buffers[epid] = null;
                 return;
             },
-            'open': function(epid, optMsgs) {
+            "open": function(epid, optMsgs) {
                 buffers[epid] = optMsgs || [];
                 return;
             },
-            'block': function(ch, pid) {
+            "block": function(ch, pid) {
                 blocked[ch] = pid;
                 return;
             },
-            'unblock': unblock,
-            'isEndpointCancelled': function(ch) {
+            "unblock": unblock,
+            "isEndpointCancelled": function(ch) {
                 return cancelledEndpoints.has(ch);
             },
-            'cancelEndpoint': function(ch) {
+            "cancelEndpoint": function(ch) {
                 cancelledEndpoints.add(ch);
                 return;
             },
-            'addOrphanMessage': function(port, msg) {
+            "addOrphanMessage": function(port, msg) {
                 return addMessage(orphanMessages, port, msg);
             },
-            'addLostMessage': function(port, msg) {
+            "addLostMessage": function(port, msg) {
                 return addMessage(lostMessages, port, msg);
             },
-            'make': function() {
+            "make": function() {
                 const ep1 = freshChannelID();
                 const ep2 = freshChannelID();
                 buffers[ep1] = [];
                 buffers[ep2] = [];
                 return { _sessEP1: ep1, _sessEP2: ep2 };
             },
-            'flip': function(ch) {
+            "flip": function(ch) {
                 return { _sessEP1 : ch._sessEP2, _sessEP2 : ch._sessEP1 };
             },
-            'receive': function(epid) {
+            "receive": function(epid) {
                 return buffers[epid].pop();
             },
-            'peekReceive': function(epid) {
+            "peekReceive": function(epid) {
                 return buffers[epid][buffers[epid].length - 1];
             },
-            'send': function(epid, msg) {
+            "send": function(epid, msg) {
                 buffers[epid].unshift(msg);
                 return;
             },
-            'hasPendingMessages': function(epid) {
+            "hasPendingMessages": function(epid) {
                 const buffer = buffers[epid];
                 return Boolean(buffer && buffer.length > 0);
             },
-            'canReceiveMessage': function(v) {
+            "canReceiveMessage": function(v) {
                 // Check whether all contained sessions are in buffers (i.e. are committed)
                 const containedSessions = getContainedSessions(v);
                 for (let i = 0; i < containedSessions.length; i++) {
@@ -3439,7 +3437,7 @@ const _$Session = (function() {
                 }
                 return true;
             },
-            'deliverSessionMessage': function(epid, v) {
+            "deliverSessionMessage": function(epid, v) {
                 // There are two circumstances under which we will get a message for which
                 // we don't have a buffer. The first is if we've started delegating an endpoint,
                 // and a message has been sent between our request and the server processing the
@@ -3462,7 +3460,7 @@ const _$Session = (function() {
                     return;
                 }
             },
-            'migrateDelegatedSessions': function(delegatedChannels, requiresLostMessages) {
+            "migrateDelegatedSessions": function(delegatedChannels, requiresLostMessages) {
                 // Adds the buffers of a set of delegated channels to the pending list if we
                 // need to wait for lost messages (i.e. message has been delegated from another
                 // client) or to buffers if we can proceed right away
@@ -3475,8 +3473,8 @@ const _$Session = (function() {
                 }
                 return;
             },
-            'getContainedSessions': getContainedSessions,
-            'handleGetLostMessages': function(remoteEp, epIds) {
+            "getContainedSessions": getContainedSessions,
+            "handleGetLostMessages": function(remoteEp, epIds) {
                 // Handle all lost messages. Given a list of endpoint IDs,
                 // creates a mapping of the associated entries, and deletes them from
                 // the lost messages table.
@@ -3489,7 +3487,7 @@ const _$Session = (function() {
                 }
                 return _$Websocket.sendLostMessageResponse(remoteEp, ret);
             },
-            'commitChannel': function(epid, lostMessages) {
+            "commitChannel": function(epid, lostMessages) {
                 // Given an endpoint ID and a list of lost messages:
                 //   - Stores  EPID |-> buffer + lost messages + orphan messages in buffers
                 //     (note that JS queues grow at the front, so the order is reversed)
@@ -3503,7 +3501,7 @@ const _$Session = (function() {
                 orphanMessages[epid] = null;
                 return;
             },
-            'handleLostMessages': function(blockedEp, lostMessageTable) {
+            "handleLostMessages": function(blockedEp, lostMessageTable) {
                 // Commit all channels
                 const mtKeys = Object.keys(lostMessageTable);
                 for (let i = 0; i < mtKeys.length; i++) {
@@ -3515,7 +3513,7 @@ const _$Session = (function() {
                 _$Proc.wakeUp(unblock(blockedEp));
                 return;
             },
-            'prepareDelegatedChannels': function(chans) {
+            "prepareDelegatedChannels": function(chans) {
                 // This function expects a list of channel references in the form
                 // chan = { _sessEP1: <send port>, _sessEP2: <recv port> }.
                 // The function is side effecting.
@@ -3539,7 +3537,7 @@ const _$Session = (function() {
                 }
                 return res;
             },
-            'cancel': function(ch) {
+            "cancel": function(ch) {
                 if (Channel.isEndpointCancelled(ch))
                     return; // Re-cancelling sessions is a no-op
 
@@ -3576,7 +3574,7 @@ const _$Session = (function() {
                 notifyPeer();
                 return;
             },
-            'handleChannelCancellation': function(notifyEp, cancelledEp) {
+            "handleChannelCancellation": function(notifyEp, cancelledEp) {
                 // Need to add cancelled_ep to cancelled EP set, and wake up
                 // any processes blocked on notify_ep
                 Channel.cancelEndpoint(cancelledEp);
@@ -3588,8 +3586,8 @@ const _$Session = (function() {
     })();
 
     return Object.freeze({
-        'AP': AP,
-        'Channel': Channel
+        "AP": AP,
+        "Channel": Channel
     });
 })();
 
@@ -3765,22 +3763,22 @@ function _attribute(xml, attr) {
   //   obj = xml[0];
   const obj = xml;
   if (obj == undefined) {
-     return ({_label:'None', '_value':(_$Constants.UNIT)});
+     return ({_label:"None", "_value":(_$Constants.UNIT)});
   }
 
   //  Take note!!!
-  if (attr == 'class') attr = 'className';
+  if (attr == "class") attr = "className";
 
   const val = obj[attr];
 
-  if (val == undefined) return({_label:'None', '_value':(_$Constants.UNIT)});
-  else return({'_label':'Some', '_value':val});
+  if (val == undefined) return({_label:"None", "_value":(_$Constants.UNIT)});
+  else return({"_label":"Some", "_value":val});
 }
 const attribute = _$Links.kify(_attribute);
 
 function _objectType(obj) {
   obj = obj[0];
-  return typeof(obj) === 'object' ? obj.constructor : typeof(obj);
+  return typeof(obj) === "object" ? obj.constructor : typeof(obj);
 }
 
 const objectType = _$Links.kify(_objectType);
@@ -3832,7 +3830,7 @@ function _makeCgiEnvironment() {
   const cgiKeys = Object.keys(cgiEnv);
   for (let i = 0; i < cgiKeys.length; i++) {
       const name = cgiEnv[cgiKeys[i]];
-      env[i] = {'1':name, '2':cgiEnv[name]};
+      env[i] = {"1":name, "2":cgiEnv[name]};
   }
 
   cgiEnv = env;
@@ -3851,21 +3849,21 @@ const redirect = _$Links.kify(_redirect);
 
 const _$Cookie = (function () {
     function set(name, value, days) {
-        let expires = 'expires=Thu, 01 Jan 1970 00:00:00 UTC';
+        let expires = "expires=Thu, 01 Jan 1970 00:00:00 UTC";
         if (days > 0) {
             const date = new Date();
             date.setTime(date.getTime() + (days * 24 * 60 * 60 * 1000));
-            expires = 'expires=' + date.toUTCString();
+            expires = "expires=" + date.toUTCString();
         }
-        document.cookie = name + '=' + value + '; ' + expires + '; SameSite=Lax; path=/';
+        document.cookie = name + "=" + value + "; " + expires + "; SameSite=Lax; path=/";
         return;
     }
 
     return Object.freeze({
-        'set': set,
-        'read': function(name) {
-            const keyString = name + '=';
-            const keyValuePairs = document.cookie.split(';');
+        "set": set,
+        "read": function(name) {
+            const keyString = name + "=";
+            const keyValuePairs = document.cookie.split(";");
             for (let i = 0; i < keyValuePairs.length; i++) {
                 const keyValuePair = keyValuePairs[i].trimLeft();
                 if (keyValuePair.startsWith(keyString))
@@ -3873,7 +3871,7 @@ const _$Cookie = (function () {
             }
             return "";
         },
-        'erase': function (name) {
+        "erase": function (name) {
             return set(name, "", -1);
         }
     });
@@ -3940,7 +3938,7 @@ function jsRestore(ctx, kappa) {
 
 function _jsSetOnKeyDown(node, fn) {
   // note: node has to exist in the document, otherwise we get a JavaScript error
-  node.addEventListener('keydown', function(e) { return fn(e, _$K.idy); }, true);
+  node.addEventListener("keydown", function(e) { return fn(e, _$K.idy); }, true);
   return;
 }
 function jsSetOnKeyDown(node, fn, kappa) {
@@ -3965,7 +3963,7 @@ function _jsSetWindowEvent(event, fn, capture) {
 const jsSetWindowEvent = _$Links.kify(_jsSetWindowEvent);
 
 function _jsSetOnLoad(fn) {
-  window.addEventListener('load', function(e) { return fn(e, _$K.idy); }, false);
+  window.addEventListener("load", function(e) { return fn(e, _$K.idy); }, false);
   return;
 }
 function jsSetOnLoad(fn, kappa) {
@@ -3993,7 +3991,7 @@ function jsLoadGlobalObject(name, kappa) {
 }
 
 function _jsGetContext2D(node) {
-  return node.getContext('2d');
+  return node.getContext("2d");
 }
 function jsGetContext2D(node, kappa) {
   _jsGetContext2D(node);
@@ -4167,12 +4165,12 @@ let jsSaveCanvas = _jsSaveCanvas;
 function _makeXml (name, attrs, children) {
   const attrObj = { };
   attrs.forEach(function (attr) {
-    attrObj[attr['1']] = attr['2'];
+    attrObj[attr[1]] = attr[2];
     return;
   });
 
   return {
-    type: 'ELEMENT',
+    type: "ELEMENT",
     tagName: name,
     attrs: attrObj,
     children: children,
@@ -4200,7 +4198,7 @@ const strContains = _$Links.kify(_strContains);
  * @returns {{ _label: string, _value: Object }[]}
  */
 function _xmlToVariant (xml) {
-  _$Debug.assert(function() { return _$Types.isArray(xml); }, 'xmlToVariant expects Xml (array of XmlItem)');
+  _$Debug.assert(function() { return _$Types.isArray(xml); }, "xmlToVariant expects Xml (array of XmlItem)");
   return xml.map(_xmlItemToVariant);
 }
 const xmlToVariant = _$Links.kify(_xmlToVariant);
@@ -4212,7 +4210,7 @@ const xmlToVariant = _$Links.kify(_xmlToVariant);
  * @returns {{ namespace?: string, tagName?: string, text?: string, attrs?: Object, children?: any[] }[]}
  */
 function _variantToXml (variants) {
-  _$Debug.assert(function() { return _$Types.isArray(variants); }, 'variantToXml expects an array');
+  _$Debug.assert(function() { return _$Types.isArray(variants); }, "variantToXml expects an array");
   return variants.map(_variantToXmlItem);
 }
 const variantToXml = _$Links.kify(_variantToXml);
@@ -4224,19 +4222,19 @@ const variantToXml = _$Links.kify(_variantToXml);
  * @returns {{ _label: string, _value: Object }}
  */
 function _xmlItemToVariant (xmlItem) {
-  _$Debug.assert(function() { return xmlItem.type === 'ELEMENT' || xmlItem.type === 'TEXT'; },
-                 'Non-XmlItem passed to xmlItemToVariant');
-  if (xmlItem.type === 'ELEMENT') {
+  _$Debug.assert(function() { return xmlItem.type === "ELEMENT" || xmlItem.type === "TEXT"; },
+                 "Non-XmlItem passed to xmlItemToVariant");
+  if (xmlItem.type === "ELEMENT") {
       _$Debug.assert(function() { return xmlItem.tagName && xmlItem.children && xmlItem.attrs; },
-                     'Malformed element passed to xmlItemToVariant');
+                     "Malformed element passed to xmlItemToVariant");
     const attrs = _$List.mapFromArray(Object.keys(xmlItem.attrs),function (name) {
-      const splitIndex = name.indexOf(':');
+      const splitIndex = name.indexOf(":");
       if (splitIndex > -1) {
         const ns = name.slice(0, splitIndex);
         const nm = name.slice(splitIndex + 1);
         return {
-          '_label': 'NsAttr',
-          '_value': {
+          "_label": "NsAttr",
+          "_value": {
             1: ns,
             2: nm,
             3: xmlItem.attrs[name],
@@ -4244,8 +4242,8 @@ function _xmlItemToVariant (xmlItem) {
         };
       } else {
         return {
-          '_label': 'Attr',
-          '_value': {
+          "_label": "Attr",
+          "_value": {
             1: name,
             2: xmlItem.attrs[name],
           },
@@ -4257,8 +4255,8 @@ function _xmlItemToVariant (xmlItem) {
 
     if (xmlItem.namespace) {
       return {
-        '_label': 'NsNode',
-        '_value': {
+        "_label": "NsNode",
+        "_value": {
           1: xmlItem.namespace,
           2: xmlItem.tagName,
           3: _$List.append(attrs,children),
@@ -4266,8 +4264,8 @@ function _xmlItemToVariant (xmlItem) {
       };
     } else {
       return {
-        '_label': 'Node',
-        '_value': {
+        "_label": "Node",
+        "_value": {
           1: xmlItem.tagName,
           2: _$List.append(attrs,children),
         }
@@ -4275,8 +4273,8 @@ function _xmlItemToVariant (xmlItem) {
     }
   } else {
     return {
-      '_label': 'Text',
-      '_value': xmlItem.text || '',
+      "_label": "Text",
+      "_value": xmlItem.text || "",
     };
   }
 }
@@ -4289,50 +4287,50 @@ const xmlItemToVariant = _$Links.kify(_xmlItemToVariant);
  * @returns {{ namespace?: string, tagName?: string, text?: string, attrs?: Object, children?: any[] }}
  */
 function _variantToXmlItem (variant) {
-  _$Debug.assert(function() { return _$Types.isObject(variant); }, 'variantToXmlItem expects an object');
-  _$Debug.assert(function() { return variant._label; }, 'variantToXmlItem expects a variant type object');
-  _$Debug.assert(function() { return variant._value; }, 'Malformed variant passed to variantToXmlItem');
+  _$Debug.assert(function() { return _$Types.isObject(variant); }, "variantToXmlItem expects an object");
+  _$Debug.assert(function() { return variant._label; }, "variantToXmlItem expects a variant type object");
+  _$Debug.assert(function() { return variant._value; }, "Malformed variant passed to variantToXmlItem");
 
   const attrs = {};
 
   let valueAsArray = _$List.toArray(variant._value);
-  if (variant._label === 'Node' || variant._label === 'NsNode') {
+  if (variant._label === "Node" || variant._label === "NsNode") {
     valueAsArray[2]
-      .filter(function (c) { return (c._label === 'Attr'); })
+      .filter(function (c) { return (c._label === "Attr"); })
       .forEach(function (a) { attrs[a._value][1] = a._value[2]; return; });
     valueAsArray[2]
-      .filter(function (c) { return (c._label === 'NsAttr'); })
-      .forEach(function (a) { attrs[a._value[1] + ':' + a._value[2]] = a._value[3]; return; });
+      .filter(function (c) { return (c._label === "NsAttr"); })
+      .forEach(function (a) { attrs[a._value[1] + ":" + a._value[2]] = a._value[3]; return; });
   }
 
   switch (variant._label) {
-    case 'Text':
+    case "Text":
       return {
-        type: 'TEXT',
+        type: "TEXT",
         text: valueAsArray[1],
       };
-    case 'Node':
+    case "Node":
       return {
-        type: 'ELEMENT',
+        type: "ELEMENT",
         tagName: valueAsArray[1],
         attrs: attrs,
         children:
-        _$List.map(_$List.filter(valueAsArray[2],function (c) { return (c._label === 'Node' || c._label === 'NsNode'); }),_variantToXmlItem)
+        _$List.map(_$List.filter(valueAsArray[2],function (c) { return (c._label === "Node" || c._label === "NsNode"); }),_variantToXmlItem)
       };
-    case 'NsNode':
+    case "NsNode":
       return {
-        type: 'ELEMENT',
+        type: "ELEMENT",
         namespace: valueAsArray[1],
         tagName: valueAsArray[2],
         attrs: attrs,
         children:
-        _$List.map(_$List.filter(valueAsArray[2],function (c) { return (c._label === 'Node' || c._label === 'NsNode');}),_variantToXmlItem)
+        _$List.map(_$List.filter(valueAsArray[2],function (c) { return (c._label === "Node" || c._label === "NsNode");}),_variantToXmlItem)
       };
-    case 'Attr':
-    case 'NsAttr':
-      throw new Error('Cannot construct detached attribute');
+    case "Attr":
+    case "NsAttr":
+      throw new Error("Cannot construct detached attribute");
     default:
-      throw new Error('Unknown Variant passed to variantToXmlItem');
+      throw new Error("Unknown Variant passed to variantToXmlItem");
   }
 }
 const variantToXmlItem = _$Links.kify(_variantToXmlItem);
@@ -4360,7 +4358,7 @@ function projectDate(dt) {
         _$Debug.assert(function() { return dt._value instanceof Date; }, "dt is not an instance of Date");
         return dt._value;
     } else {
-        throw new Error('Unable to project date component from infinity / -infinity');
+        throw new Error("Unable to project date component from infinity / -infinity");
     }
 }
 
@@ -4371,7 +4369,7 @@ const beginningOfTime = { _type: "-infinity" };
 /* API (direct style) */
 function _dateToInt(dt) {
   if (dt._type != "timestamp")
-      throw new Error('Unable to get UNIX timestamp for infinity / -infinity');
+      throw new Error("Unable to get UNIX timestamp for infinity / -infinity");
 
   const tzOffset = new Date().getTimezoneOffset() * -1 * 60 * 1000;
   return Math.floor((dt.getTime() - tzOffset) / 1000);
@@ -4443,11 +4441,11 @@ function _showUTC(dt) {
             if (offset < 0) {
                 offsetSign = "-";
             }
-            const month = (ts.getUTCMonth() + 1).toString().padStart(2, '0');
-            const day = ts.getUTCDate().toString().padStart(2, '0');
-            const hours = ts.getUTCHours().toString().padStart(2, '0');
-            const minutes = ts.getMinutes().toString().padStart(2, '0');
-            const seconds = ts.getSeconds().toString().padStart(2, '0');
+            const month = (ts.getUTCMonth() + 1).toString().padStart(2, "0");
+            const day = ts.getUTCDate().toString().padStart(2, "0");
+            const hours = ts.getUTCHours().toString().padStart(2, "0");
+            const minutes = ts.getMinutes().toString().padStart(2, "0");
+            const seconds = ts.getSeconds().toString().padStart(2, "0");
             return `${ts.getUTCFullYear()}-${month}-${day} ${hours}:${minutes}:${seconds}+0`;
         default:
             throw new Error("Invalid DateTime type");
@@ -4466,12 +4464,13 @@ function showLocalDate(dt) {
             if (offset < 0) {
                 offsetSign = "-";
             }
-            const month = ts.getMonth().toString().padStart(2, '0');
-            const day = ts.getDate().toString().padStart(2, '0');
-            const hours = ts.getHours().toString().padStart(2, '0');
-            const minutes = ts.getMinutes().toString().padStart(2, '0');
-            const seconds = ts.getSeconds().toString().padStart(2, '0');
-            return `${ts.getFullYear()}-${month}-${day} ${hours}:${minutes}:${seconds}${offsetSign}${offset}`;
+            const month = ts.getMonth().toString().padStart(2, "0");
+            const day = ts.getDate().toString().padStart(2, "0");
+            const hours = ts.getHours().toString().padStart(2, "0");
+            const minutes = ts.getMinutes().toString().padStart(2, "0");
+            const seconds = ts.getSeconds().toString().padStart(2, "0");
+            return "" + ts.getFullYear() + "-" + month + "-" + day + " " +
+                   hours + ":" + minutes + ":" + seconds + offsetSign + offset;
         default:
             throw new Error("Invalid DateTime type");
     }


### PR DESCRIPTION
This patch is a follow-up on patch #1083. This patch adds two new (experimental) options to Links `-Ljs-runtime` and `-Xcustom-js-runtime`. The former option instructs the Links compiler to statically link the JavaScript runtime into a JavaScript compilation artefact. The latter option lets the user override the default JavaScript runtime (i.e. `jslib.js`) with a runtime of their own choosing.