### PR TITLE
Fix `output_file` option

### DIFF
--- a/core/basicsettings.ml
+++ b/core/basicsettings.ml
@@ -89,6 +89,7 @@ module System = struct
               |> synopsis "Set output file name to <file>"
               |> hint "<file>"
               |> to_string from_string_option
+              |> convert (fun s -> Some s)
               |> CLI.(add (long "output" <&> short 'o'))
               |> sync)
 


### PR DESCRIPTION
The `output_file` option was missing a converter, causing it to raise an exception when used.