### PR TITLE
Fix JSLIB regression

### DIFF
--- a/lib/js/jslib.js
+++ b/lib/js/jslib.js
@@ -445,11 +445,11 @@ const _$Types = Object.freeze({
 const _$Debug = (function() {
     const debugMode = typeof DEBUGGING === "undefined" ? false : DEBUGGING;
     return Object.freeze({
-        debug: function (msg) { if (DEBUGGING) console.debug(msg); return; },
+        debug: function (msg) { if (debugMode) console.debug(msg); return; },
         show: function (any) { return (_$Types.isXmlNode(any)) ? _$Debug.xmldump(any) : _$Links.stringify(any); },
         xmldump: function (xml) { return (new XMLSerializer()).serializeToString(xml); },
         assert: function (fcondition, message) {
-            if (DEBUGGING && !Boolean(fcondition())) {
+            if (debugMode && !Boolean(fcondition())) {
                 throw new Error("Assertion failed: " + message);
             }
             return true;


### PR DESCRIPTION
The variable `DEBUGGING` was inadvertently referenced in the body of the `_$Debug` module, where we meant to reference `debugMode`.