### PR TITLE
Fix off-by-one errors in month serialisation (Issue #1119)

### DIFF
--- a/lib/js/jslib.js
+++ b/lib/js/jslib.js
@@ -4387,7 +4387,7 @@ function _dateYear(dt, offset) {
 }
 
 function _dateMonth(dt, offset) {
-    return shiftOffset(projectDate(dt), offset).getUTCMonth();
+    return shiftOffset(projectDate(dt), offset).getUTCMonth() + 1;
 }
 
 function _dateDay(dt, offset) {
@@ -4464,7 +4464,7 @@ function showLocalDate(dt) {
             if (offset < 0) {
                 offsetSign = "-";
             }
-            const month = ts.getMonth().toString().padStart(2, "0");
+            const month = (ts.getMonth() + 1).toString().padStart(2, "0");
             const day = ts.getDate().toString().padStart(2, "0");
             const hours = ts.getHours().toString().padStart(2, "0");
             const minutes = ts.getMinutes().toString().padStart(2, "0");


### PR DESCRIPTION
This was a silly one -- `DateTime.getMonth()` is 0-indexed rather than 1-indexed (i.e., January is month 0).

Fixes #1119.