### PR TITLE
Fix comparison operations for DateTime

### DIFF
--- a/core/lib.ml
+++ b/core/lib.ml
@@ -126,6 +126,7 @@ let rec equal l r =
         let f1 = CalendarShow.to_unixfloat dt1 in
         let f2 = CalendarShow.to_unixfloat dt2 in
         f1 = f2
+    | `DateTime _, `DateTime _ -> false (* comparing timestamps with (-)infinity *)
     | l, r ->
         runtime_error
           (Printf.sprintf "Comparing %s with %s which either does not make sense or isn't implemented."

--- a/examples/mvu/dates.links
+++ b/examples/mvu/dates.links
@@ -61,7 +61,25 @@ fun view(model) {
     entry("Local milliseconds", intToString(localMilliseconds(ts))) +*
     entry("Client-parsed date", show(parseDate("2021-07-26 10:10:10+1"))) +*
     entry("Infinity on client", show(forever)) +*
-    entry("-Infinity on client", show(beginningOfTime))
+    entry("Local time = Local time", show(ts == ts)) +*
+    entry("Local time < Local time", show(ts < ts)) +*
+    entry("Local time <= Local time", show(ts <= ts)) +*
+    entry("Local time >= Local time", show(ts >= ts)) +*
+    entry("Local time > Local time", show(ts > ts)) +*
+    entry("-Infinity on client", show(beginningOfTime)) +*
+    entry("-infinity == -infinity", show(beginningOfTime == beginningOfTime)) +*
+    entry("-infinity < -infinity", show(beginningOfTime < beginningOfTime)) +*
+    entry("-infinity < infinity", show(beginningOfTime < forever)) +*
+    entry("-infinity <= -infinity", show(beginningOfTime <= beginningOfTime)) +*
+    entry("-infinity < local time", show(beginningOfTime < ts)) +*
+    entry("-infinity >= local time", show(beginningOfTime >= ts)) +*
+    entry("infinity == infinity", show(forever == forever)) +*
+    entry("infinity < infinity", show(forever < forever)) +*
+    entry("infinity < -infinity", show(forever < beginningOfTime)) +*
+    entry("infinity <= -infinity", show(forever <= beginningOfTime)) +*
+    entry("infinity < local time", show(forever < ts)) +*
+    entry("infinity > local time", show(forever > ts)) +*
+    entry("infinity >= local time", show(forever >= ts))
 }
 
 sig subscriptions : (Model) ~> MvuSubscriptions.Sub(Msg)

--- a/lib/js/jslib.js
+++ b/lib/js/jslib.js
@@ -806,6 +806,14 @@ const _$Links = (function() {
       return true;
     }
 
+    if (_$Types.isDateTime(l) && _$Types.isDateTime(r)) {
+        if (l._type === "timestamp" && r._type === "timestamp") {
+            return l._value === r._value;
+        } else {
+            return l._type === r._type;
+        }
+    }
+
     throw ("Comparing " + l + " with " + r + " which either does not make sense or isn't implemented.");
   }
 
@@ -840,6 +848,14 @@ const _$Links = (function() {
             i++;
         }
         return l.length > r.length;
+    }
+
+    if (_$Types.isDateTime(l) && _$Types.isDateTime(r)) {
+        if (l._type === "timestamp" && r._type === "timestamp") {
+            return l._value > r._value;
+        } else {
+            return l._type === "infinity";
+        }
     }
 
     if (typeof(l) === "object" && l !== null &&
@@ -894,6 +910,14 @@ const _$Links = (function() {
             i++;
         }
         return l.length < r.length;
+    }
+
+    if (_$Types.isDateTime(l) && _$Types.isDateTime(r)) {
+        if (l._type === "timestamp" && r._type === "timestamp") {
+            return l._value < r._value;
+        } else {
+            return l._type === "-infinity";
+        }
     }
 
     if (typeof(l) === "object" && l !== null &&
@@ -951,6 +975,14 @@ const _$Links = (function() {
         return l.length === r.length || l.length < r.length;
     }
 
+    if (_$Types.isDateTime(l) && _$Types.isDateTime(r)) {
+        if (l._type === "timestamp" && r._type === "timestamp") {
+            return l._value <= r._value;
+        } else {
+            return (l._type === r._type) || (l._type === "-infinity");
+        }
+    }
+
     if (typeof(l) === "object" && l !== null &&
         typeof(r) === "object" && r !== null) {
 
@@ -1004,6 +1036,14 @@ const _$Links = (function() {
             i++;
         }
         return l.length === r.length || l.length > r.length;
+    }
+
+    if (_$Types.isDateTime(l) && _$Types.isDateTime(r)) {
+        if (l._type === "timestamp" && r._type === "timestamp") {
+            return l._value >= r._value;
+        } else {
+            return (l._type === r._type) || (l._type === "infinity");
+        }
     }
 
     if (typeof(l) === "object" && l !== null &&

--- a/lib/js/jslib.js
+++ b/lib/js/jslib.js
@@ -781,6 +781,14 @@ const _$Links = (function() {
       return true;
     }
 
+    if (_$Types.isDateTime(l) && _$Types.isDateTime(r)) {
+        if (l._type === "timestamp" && r._type === "timestamp") {
+            return l._value === r._value;
+        } else {
+            return l._type === r._type;
+        }
+    }
+
     if(typeof(l) === "object" && l !== null &&
        typeof(r) === "object" && r !== null) {
       if (l.constructor !== r.constructor) return false;
@@ -804,14 +812,6 @@ const _$Links = (function() {
       }
 
       return true;
-    }
-
-    if (_$Types.isDateTime(l) && _$Types.isDateTime(r)) {
-        if (l._type === "timestamp" && r._type === "timestamp") {
-            return l._value === r._value;
-        } else {
-            return l._type === r._type;
-        }
     }
 
     throw ("Comparing " + l + " with " + r + " which either does not make sense or isn't implemented.");

--- a/tests/datetime.tests
+++ b/tests/datetime.tests
@@ -38,12 +38,28 @@ Parse BST
 parseDate("2021-07-26 11:14:57+1") == intToDate(1627294497)
 stdout : true : Bool
 
+Dates (eq)
+intToDate(1627294497) == intToDate(1627294497)
+stdout : true : Bool
+
+Dates (leq)
+intToDate(1627294497) <= intToDate(1627294497)
+stdout : true : Bool
+
+Dates (geq)
+intToDate(1627294497) >= intToDate(1627294497)
+stdout : true : Bool
+
 -infinity lowest value
 beginningOfTime < intToDate(0)
 stdout : true : Bool
 
 +infinity highest value
 forever > intToDate(2147483647)
+stdout : true : Bool
+
++infinity highest value (eq)
+forever >= intToDate(2147483647)
 stdout : true : Bool
 
 -infinity = -infinity
@@ -53,6 +69,34 @@ stdout : true : Bool
 +infinity = +infinity
 forever == forever
 stdout : true : Bool
+
+-infinity < -infinity
+beginningOfTime < beginningOfTime
+stdout : true : Bool
+
+-infinity <= -infinity
+beginningOfTime <= beginningOfTime
+stdout : true : Bool
+
+infinity >= -infinity
+forever >= beginningOfTime
+stdout : true : Bool
+
+-infinity lowest value (eq)
+beginningOfTime <= intToDate(2147483647)
+stdout : true : Bool
+
+Issue 1126 (1)
+forever == parseDate("2022-08-04 12:03:12")
+stdout : false : Bool
+
+Issue 1126 (2)
+forever <> parseDate("2022-08-04 12:03:12")
+stdout : true : Bool
+
+Issue 1126 (3)
+forever <= parseDate("2022-08-04 12:03:12")
+stdout : false : Bool
 
 Date parser roundtrips
 var bday = parseDate("1992-04-24 06:00:00+0"); bday == parseDate(show(bday))


### PR DESCRIPTION
Equality was not implemented on the server, and comparisons weren't
correctly implemented on the client.

Fixes #1126