### PR TITLE
Fix assert error with relational lenses

### DIFF
--- a/core/types.ml
+++ b/core/types.ml
@@ -369,7 +369,12 @@ struct
          let (o, write') = o#typ write in
          let (o, needed') = o#typ needed in
          (o, Table (temporality, read', write', needed'))
-      | Lens _ -> assert false (* TODO FIXME *)
+      | Lens t ->
+         (* Lens types are substantially more complex than allowed for by a
+            visitor. If this functionality is needed, then the visitor can
+            be extended and a separate visitor can be written for lens types
+            separately. *)
+         (o, Lens t)
       | ForAll (names, body) ->
          let (o, names') = o#list (fun o -> o#quantifier) names in
          let (o, body') = o#typ body in


### PR DESCRIPTION
The `Lens` type traversal was unimplemented and filled in with an `assert false`. As a result, all RL code fails.

I don't think there is any really sensible default traversal due to the complexity of the Lens types, so I have just filled it in with the identity. This doesn't stop someone implementing a traversal -- they'll just need to write one for `Lens.Type.t` type and plug it in as usual.