### PR TITLE
New syntax for handlers

### DIFF
--- a/core/compilePatterns.ml
+++ b/core/compilePatterns.ml
@@ -1173,24 +1173,25 @@ module Handlers = struct
     | Pattern.CNOperation names ->
        let cases =
          StringMap.fold
-           (fun name annotated_clauses cases ->
-             if StringSet.mem name names
-             then cases
-             else  let case_type = TypeUtils.variant_at name t in
-                   (*                     let inject_type = TypeUtils.inject_type name case_type in *)
-                   let (case_binder, case_variable) = Var.fresh_var_of_type case_type in
-                   let match_env = bind_type case_variable case_type env in
-                   let match_env =
-                     bind_context var
-                       (Pattern.COperation name,
-                        Inject (name, Variable case_variable, t)) match_env in
-                   let clauses =
-                     apply_annotations
-                       (Inject (name, Variable case_variable, t)) annotated_clauses
-                   in
-                   StringMap.add name
-                     (case_binder,
-                      match_cases (case_variable::vars) clauses def match_env) cases)
+           (assert false)
+           (* (fun name annotated_clauses cases ->
+            *   if StringSet.mem name names
+            *   then cases
+            *   else  let case_type = TypeUtils.variant_at name t in
+            *         (\*                     let inject_type = TypeUtils.inject_type name case_type in *\)
+            *         let (case_binder, case_variable) = Var.fresh_var_of_type case_type in
+            *         let match_env = bind_type case_variable case_type env in
+            *         let match_env =
+            *           bind_context var
+            *             (Pattern.COperation name,
+            *              Inject (name, Variable case_variable, t)) match_env in
+            *         let clauses =
+            *           apply_annotations
+            *             (Inject (name, Variable case_variable, t)) annotated_clauses
+            *         in
+            *         StringMap.add name
+            *           (case_binder,
+            *            match_cases (case_variable::vars) clauses def match_env) cases) *)
            bs StringMap.empty
        in
        ([], Case (Variable var, cases, None))

--- a/core/compilePatterns.ml
+++ b/core/compilePatterns.ml
@@ -229,6 +229,7 @@ type annotation = Pattern.annotation_element list
 type annotated_pattern = annotation * Pattern.t
 
 type raw_clause = Pattern.t list * raw_bound_computation
+type raw_effect_clause = Pattern.t list * Pattern.t option * raw_bound_computation
 type clause = annotated_pattern list * bound_computation
 type annotated_clause = annotation * clause
 
@@ -1111,3 +1112,7 @@ let compile_choices
         (fun () -> "Compiled choices: "^(string_of_computation result));
       result
 
+module Handlers = struct
+  let compile : raw_env -> Ir.computation list -> (Pattern.t * Ir.computation * Types.datatype) list -> raw_effect_clause list -> Sugartypes.handler_descriptor -> Ir.computation
+    = fun _env _exps _params _cases _descriptor -> assert false
+end

--- a/core/compilePatterns.ml
+++ b/core/compilePatterns.ml
@@ -42,6 +42,8 @@ struct
     | CNVariant  of StringSet.t
     | CConstant  of Constant.t
     | CNConstant of ConstSet.t
+    | COperation of string
+    | CNOperation of StringSet.t
 
   type sort =
     | SList
@@ -889,6 +891,59 @@ and match_record
         bindings
         (match_cases (xs @ vars) clauses def env)
 
+and match_operation
+    : var list -> (annotated_clause list) StringMap.t -> bound_computation -> var -> bound_computation =
+  fun vars bs def var env ->
+    let t = lookup_type var env in
+
+    let context, cexp =
+      if mem_context var env then
+        lookup_context var env
+      else
+        Pattern.CNOperation StringSet.empty, Variable var
+    in
+      match context with
+        | Pattern.COperation name ->
+            if StringMap.mem name bs then
+              match cexp with
+                | Inject (_, (Variable case_variable), _) ->
+                    let annotated_clauses = StringMap.find name bs in
+                    (* let case_type = lookup_type case_variable env in *)
+                      (*                    let inject_type = TypeUtils.inject_type name case_type in *)
+                    let clauses = apply_annotations cexp annotated_clauses in
+                      match_cases (case_variable::vars) clauses def env
+                | _ -> assert false
+            else
+              def env
+        | Pattern.CNOperation names ->
+           let cases, _ = (* TODO eliminate cs. *)
+              StringMap.fold
+                (fun name annotated_clauses (cases, cs) ->
+                   if StringSet.mem name names then
+                     (cases, cs)
+                   else
+                     let case_type = TypeUtils.variant_at name t in
+(*                     let inject_type = TypeUtils.inject_type name case_type in *)
+                     let (case_binder, case_variable) = Var.fresh_var_of_type case_type in
+                     let match_env = bind_type case_variable case_type env in
+                     let match_env =
+                       bind_context var
+                         (Pattern.COperation name,
+                          Inject (name, Variable case_variable, t)) match_env in
+                     let clauses =
+                       apply_annotations
+                         (Inject (name, Variable case_variable, t)) annotated_clauses
+                     in
+                       (StringMap.add name
+                          (case_binder,
+                           match_cases (case_variable::vars) clauses def match_env) cases,
+                        StringSet.add name cs))
+                bs
+                (StringMap.empty, names) in
+
+            ([], Case (Variable var, cases, None))
+        | _ -> assert false
+
 (* the interface to the pattern-matching compiler *)
 let compile_cases
     : raw_env -> (Types.datatype * var * raw_clause list) -> Ir.computation =
@@ -1203,6 +1258,7 @@ module Handlers = struct
   let operation_cases : raw_env -> raw_effect_clause list -> Sugartypes.handler_descriptor -> effect_case Ir.name_map
     = fun _env cases descriptor ->
     let cases = List.map reduce_effect_clause cases in
+    let cases = arrange_operation_clauses cases in
     let _vtype = variant_type descriptor in
     assert false
 

--- a/core/desugarModules.ml
+++ b/core/desugarModules.ml
@@ -370,11 +370,9 @@ and desugar ?(toplevel=false) (renamer' : Epithet.t) (scope' : Scope.t) =
         Escape (bndr', body')
       | Handle { expressions; cases; descriptor } ->
          let expressions = self#list (fun o -> o#phrase) expressions in
-         let shd_params =
-           self#option (fun o -> o#handle_params) descriptor.shd_params
-         in
+         let descriptor = self#handle_descriptor descriptor in
          let cases = self#effect_cases cases in
-         Handle { expressions; cases; descriptor = { descriptor with shd_params } }
+         Handle { expressions; cases; descriptor }
       | Switch (expr, cases, dt) ->
         let expr' = self#phrase expr in
         let cases' = self#cases cases in

--- a/core/desugarSessionExceptions.ml
+++ b/core/desugarSessionExceptions.ml
@@ -88,10 +88,9 @@ object (o : 'self_type)
         let o = o#restore_envs envs in
         let (o, otherwise_phr, otherwise_dt) = o#phrase otherwise_phr in
         (* Now, to create a handler... *)
-        (* Otherwise clause: Distinguished 'session failure' name. Since
-         * we'll never use the continuation (and this is invoked after pattern
-         * deanonymisation in desugarHandlers), generate a fresh name for the
-         * continuation argument. *)
+        (* Otherwise clause: Distinguished 'session failure'
+           name. Since * we'll never use the continuation, generate a
+           fresh name for the * continuation argument. *)
 
         let outer_effects = o#lookup_effects in
 
@@ -103,8 +102,11 @@ object (o : 'self_type)
             |> Types.row_with (failure_op_name, `Present fail_cont_ty)
             |> Types.flatten_row in
 
-        let cont_pat = variable_pat ~ty:(Types.make_function_type [] inner_effects (Types.empty_type))
-          (Utility.gensym ~prefix:"dsh" ()) in
+        let cont_pat =
+          let ty = Types.make_function_type [] inner_effects (Types.empty_type) in
+          (variable_pat ~ty
+             (Utility.gensym ~prefix:"dsh" ())), ty
+        in
 
         let otherwise_pat : Sugartypes.Pattern.with_pos =
           with_dummy_pos (Pattern.Operation { label = failure_op_name; parameters = []; resumption = Some cont_pat }) in

--- a/core/desugarSessionExceptions.ml
+++ b/core/desugarSessionExceptions.ml
@@ -81,7 +81,7 @@ object (o : 'self_type)
         (o, with_pos (Switch (with_pos doOp, [], Some ty)), ty)
     | { node = TryInOtherwise (_, _, _, _, None); _} -> assert false
     | { node = TryInOtherwise (try_phr, pat, as_phr, otherwise_phr, (Some dt)); pos } ->
-        let (o, try_phr, _try_dt) = o#phrase try_phr in
+        let (o, try_phr, try_dt) = o#phrase try_phr in
         let envs = o#backup_envs in
         let (o, pat) = o#pattern pat in
         let (o, as_phr, _as_dt) = o#phrase as_phr in
@@ -124,6 +124,7 @@ object (o : 'self_type)
 
         let descriptor = {
             shd_input_effects = inner_effects;
+            shd_input_types = [try_dt];
             shd_output_effects = outer_effects;
             shd_branch_type = otherwise_dt;
             shd_params = { shp_bindings = []; shp_types = [] };

--- a/core/desugarSessionExceptions.ml
+++ b/core/desugarSessionExceptions.ml
@@ -86,7 +86,7 @@ object (o : 'self_type)
         let (o, pat) = o#pattern pat in
         let (o, as_phr, _as_dt) = o#phrase as_phr in
         let o = o#restore_envs envs in
-        let (o, otherwise_phr, _otherwise_dt) = o#phrase otherwise_phr in
+        let (o, otherwise_phr, otherwise_dt) = o#phrase otherwise_phr in
         (* Now, to create a handler... *)
         (* Otherwise clause: Distinguished 'session failure'
            name. Since * we'll never use the continuation, generate a
@@ -125,6 +125,7 @@ object (o : 'self_type)
         let descriptor = {
             shd_input_effects = inner_effects;
             shd_output_effects = outer_effects;
+            shd_branch_type = otherwise_dt;
             shd_params = { shp_bindings = []; shp_types = [] };
         } in
 

--- a/core/desugarSessionExceptions.ml
+++ b/core/desugarSessionExceptions.ml
@@ -81,12 +81,12 @@ object (o : 'self_type)
         (o, with_pos (Switch (with_pos doOp, [], Some ty)), ty)
     | { node = TryInOtherwise (_, _, _, _, None); _} -> assert false
     | { node = TryInOtherwise (try_phr, pat, as_phr, otherwise_phr, (Some dt)); pos } ->
-        let (o, try_phr, try_dt) = o#phrase try_phr in
+        let (o, try_phr, _try_dt) = o#phrase try_phr in
         let envs = o#backup_envs in
         let (o, pat) = o#pattern pat in
         let (o, as_phr, _as_dt) = o#phrase as_phr in
         let o = o#restore_envs envs in
-        let (o, otherwise_phr, otherwise_dt) = o#phrase otherwise_phr in
+        let (o, otherwise_phr, _otherwise_dt) = o#phrase otherwise_phr in
         (* Now, to create a handler... *)
         (* Otherwise clause: Distinguished 'session failure'
            name. Since * we'll never use the continuation, generate a
@@ -117,16 +117,15 @@ object (o : 'self_type)
         in
 
         (* Manually construct a row with the two hardwired handler cases. *)
-        let raw_row = Types.row_with ("Return", (`Present try_dt)) inner_effects in
+        (* let raw_row = Types.row_with ("Return", (`Present try_dt)) inner_effects in *)
         (* Dummy types *)
-        let types =
-          (inner_effects, try_dt, outer_effects, otherwise_dt) in
+        (* let types =
+         *   (inner_effects, try_dt, outer_effects, otherwise_dt) in *)
 
         let descriptor = {
-          shd_depth = Shallow;
-          shd_types = types;
-          shd_raw_row = raw_row;
-          shd_params = None;
+            shd_input_effects = inner_effects;
+            shd_output_effects = outer_effects;
+            shd_params = { shp_bindings = []; shp_types = [] };
         } in
 
         (o, SourceCode.WithPos.make ~pos (Handle { expressions = [try_phr]; cases; descriptor }), dt)

--- a/core/elaboratePatterns.ml
+++ b/core/elaboratePatterns.ml
@@ -1,0 +1,111 @@
+(* open Utility *)
+
+type state = int
+let empty = 0
+let in_handler_mask = 0b1
+let toplevel_mask = 0b10
+let allow_effect_patterns_mask = in_handler_mask lor toplevel_mask
+let in_handler st = st land in_handler_mask == in_handler_mask
+let toplevel st = st land toplevel_mask == toplevel_mask
+let allow_effect_patterns st = st land allow_effect_patterns_mask == allow_effect_patterns_mask
+let apply mask st = st lor mask
+let remove mask st =
+  if st land mask <> 0 then st lxor mask
+  else st
+
+
+let elaborate =
+  let open Sugartypes in
+  object(self : 'self_type)
+    inherit SugarTraversals.map as super
+
+    val mutable state = empty
+
+    method backup = state
+    method restore state' = state <- state'
+
+    method allow_effect_patterns =
+      allow_effect_patterns state
+
+    method enter_handler =
+      state <- apply in_handler_mask state
+
+    method leave_handler =
+      state <- remove in_handler_mask state
+
+    method below_toplevel =
+      state <- remove toplevel_mask state
+
+    method at_toplevel =
+      state <- apply toplevel_mask state
+
+    method! phrasenode = function
+      | Handle { expressions; cases; descriptor } ->
+         let st' = self#backup in
+         let expressions =
+           self#list
+             (fun o expression ->
+               let expression = o#phrase expression in
+               o#restore st';
+               expression)
+             expressions
+         in
+         let params =
+           self#option (fun o -> o#handle_params) descriptor.shd_params
+         in
+         self#restore st';
+         self#enter_handler;
+         self#at_toplevel;
+         let st'' = self#backup in
+         let cases =
+           self#list
+             (fun o { patterns; resumption; body } ->
+               let patterns =
+                 o#list
+                   (fun o -> o#restore st''; o#pattern)
+                   patterns
+               in
+               let resumption =
+                 o#option
+                   (fun o (p, dt) ->
+                     o#restore st'';
+                     (o#pattern p, dt))
+                   resumption
+               in
+               self#restore st'';
+               let body = o#phrase body in
+               { patterns; resumption; body })
+             cases
+         in
+         self#restore st';
+         Handle { expressions; cases; descriptor = { descriptor with shd_params = params } }
+      | p -> super#phrasenode p
+
+    method! pattern pat =
+      let open SourceCode.WithPos in
+      let open Pattern in
+      match pat.node with
+      | Any -> pat
+      | Nil -> pat
+      | Constant _ -> pat
+      | Negative _ -> pat
+      | Operation ({ parameters; resumption; _ } as d) ->
+         if self#allow_effect_patterns then
+           let () = self#below_toplevel in
+           make
+             ~pos:pat.pos
+             (Operation { d with parameters = self#list (fun o -> o#pattern) parameters;
+                                 resumption = self#option (fun o (p, dt) -> o#pattern p, dt) resumption })
+         else raise (Errors.effect_pattern_below_toplevel pat.pos)
+      | pat' ->
+         self#below_toplevel;
+         make ~pos:pat.pos (self#patternnode pat')
+  end
+
+let program : Sugartypes.program -> Sugartypes.program
+  = fun program ->
+  elaborate#program program
+
+let sentence : Sugartypes.sentence -> Sugartypes.sentence
+  = fun sentence ->
+  elaborate#sentence sentence

--- a/core/elaboratePatterns.ml
+++ b/core/elaboratePatterns.ml
@@ -50,9 +50,7 @@ let elaborate =
                expression)
              expressions
          in
-         let params =
-           self#option (fun o -> o#handle_params) descriptor.shd_params
-         in
+         let descriptor = self#handle_descriptor descriptor in
          self#restore st';
          self#enter_handler;
          self#at_toplevel;
@@ -78,7 +76,7 @@ let elaborate =
              cases
          in
          self#restore st';
-         Handle { expressions; cases; descriptor = { descriptor with shd_params = params } }
+         Handle { expressions; cases; descriptor }
       | p -> super#phrasenode p
 
     method! pattern pat =

--- a/core/errors.ml
+++ b/core/errors.ml
@@ -166,6 +166,7 @@ let format_exception =
      let message =
        Printf.sprintf "Syntax error: Foreign binders cannot contain single quotes `'`.\nIn expression: %s." expr
      in
+     pos_prefix ~pos message
   | EffectPatternBelowToplevel pos ->
      let message = "Effect patterns must be at the top level of a handler case." in
      let pos, _ = Position.resolve_start_expr pos in

--- a/core/errors.ml
+++ b/core/errors.ml
@@ -48,6 +48,8 @@ exception DynlinkError of string
 exception ModuleError of string * Position.t option
 exception DisabledExtension of Position.t option * (string * bool) option * string option * string
 exception PrimeAlien of Position.t
+exception EffectPatternBelowToplevel of Position.t
+exception HandleArityMismatch of Position.t
 
 
 let prefix_lines prefix s =
@@ -164,6 +166,13 @@ let format_exception =
      let message =
        Printf.sprintf "Syntax error: Foreign binders cannot contain single quotes `'`.\nIn expression: %s." expr
      in
+  | EffectPatternBelowToplevel pos ->
+     let message = "Effect patterns must be at the top level of a handler case." in
+     let pos, _ = Position.resolve_start_expr pos in
+     pos_prefix ~pos message
+  | HandleArityMismatch pos ->
+     let message = "Arity mismatch: a handler case must have as many patterns as the handle has input computations." in
+     let pos, _ = Position.resolve_start_expr pos in
      pos_prefix ~pos message
   | Sys.Break -> "Caught interrupt"
   | exn -> pos_prefix ("Error: " ^ Printexc.to_string exn)
@@ -194,3 +203,7 @@ let module_error ?pos message = (ModuleError (message, pos))
 let disabled_extension ?pos ?setting ?flag name =
   DisabledExtension (pos, setting, flag, name)
 let prime_alien pos = PrimeAlien pos
+let effect_pattern_below_toplevel pos =
+  EffectPatternBelowToplevel pos
+let handle_arity_mismatch pos =
+  HandleArityMismatch pos

--- a/core/errors.mli
+++ b/core/errors.mli
@@ -50,3 +50,6 @@ val dynlink_error: string -> exn
 val module_error : ?pos:Position.t -> string -> exn
 val disabled_extension : ?pos:Position.t -> ?setting:(string * bool) -> ?flag:string -> string -> exn
 val prime_alien : Position.t -> exn
+val effect_pattern_below_toplevel : Position.t -> exn
+val handle_arity_mismatch : Position.t -> exn
+

--- a/core/frontend.ml
+++ b/core/frontend.ml
@@ -108,7 +108,6 @@ let program prev_tyenv pos_context program =
   if Settings.get_value Basicsettings.show_pre_frontend_ast then
     Debug.print ("Pre-Frontend AST:\n" ^ Sugartypes.show_program program);
 
-
   let pre_transformers =
     program_pre_typing_transformers pos_context prev_tyenv in
   let apply_pre_tc_transformer program transformer =
@@ -140,7 +139,6 @@ let program prev_tyenv pos_context program =
       program_post_typing_transformers in
 
   let ffi_files = ModuleUtils.get_ffi_files result_program in
-
   if Settings.get_value Basicsettings.show_post_frontend_ast then
     Debug.print ("Post-Frontend AST:\n" ^ Sugartypes.show_program result_program);
 

--- a/core/lexer.mll
+++ b/core/lexer.mll
@@ -234,7 +234,6 @@ let keywords = [
  "select"   , SELECT;
  "server"   , SERVER;
  "set"      , SET;
- "shallowhandle", SHALLOWHANDLE;
  "sig"      , SIG;
  "spawn"    , SPAWN;
  "spawnClient" , SPAWNCLIENT;

--- a/core/parser.mly
+++ b/core/parser.mly
@@ -235,6 +235,7 @@ end
 %token SPAWN SPAWNAT SPAWNANGELAT SPAWNCLIENT SPAWNANGEL SPAWNWAIT
 %token OFFER SELECT
 %token DOOP
+%token LANGLE RANGLE
 %token LPAREN RPAREN
 %token LBRACE RBRACE LBRACEBAR BARRBRACE LQUOTE RQUOTE
 %token RBRACKET LBRACKET LBRACKETBAR BARRBRACKET
@@ -1236,6 +1237,8 @@ parenthesized_pattern:
 | LPAREN pattern RPAREN                                        { $2 }
 | LPAREN pattern COMMA patterns RPAREN                         { with_pos $loc (Pattern.Tuple ($2 :: $4)) }
 | LPAREN labeled_patterns preceded(VBAR, pattern)? RPAREN      { with_pos $loc (Pattern.Record ($2, $3))  }
+| LANGLE constr = pattern RARROW resumption = pattern RANGLE   { constr }
+| LANGLE constr = pattern RANGLE                               { constr }
 
 primary_pattern:
 | VARIABLE                                                     { variable_pat ~ppos:$loc $1   }

--- a/core/sugarConstructors.ml
+++ b/core/sugarConstructors.ml
@@ -303,6 +303,7 @@ module SugarConstructors (Position : Pos)
                descriptor =
                  { shd_input_effects = empty_row;
                    shd_output_effects = empty_row;
+                   shd_branch_type = `Not_typed;
                    shd_params   = {shp_bindings = parameters; shp_types = []} }
         }
     in

--- a/core/sugarConstructors.ml
+++ b/core/sugarConstructors.ml
@@ -302,6 +302,7 @@ module SugarConstructors (Position : Pos)
                cases;
                descriptor =
                  { shd_input_effects = empty_row;
+                   shd_input_types = [];
                    shd_output_effects = empty_row;
                    shd_branch_type = `Not_typed;
                    shd_params   = {shp_bindings = parameters; shp_types = []} }

--- a/core/sugarConstructors.ml
+++ b/core/sugarConstructors.ml
@@ -295,16 +295,15 @@ module SugarConstructors (Position : Pos)
     node
 
   (** Handlers *)
-  let untyped_handler ?(ppos=dp) ?parameters expressions cases =
+  let untyped_handler ?(ppos=dp) ?(parameters=[]) expressions cases =
+    let empty_row = Types.make_empty_closed_row () in
     let node =
       Handle { expressions;
                cases;
                descriptor =
-                 { shd_depth = Deep;
-                   shd_types = ( Types.make_empty_closed_row (), `Not_typed
-                               , Types.make_empty_closed_row (), `Not_typed);
-                   shd_raw_row = Types.make_empty_closed_row ();
-                   shd_params = opt_map (fun pps -> {shp_bindings = pps; shp_types = []}) parameters }
+                 { shd_input_effects = empty_row;
+                   shd_output_effects = empty_row;
+                   shd_params   = {shp_bindings = parameters; shp_types = []} }
         }
     in
     with_pos ppos node

--- a/core/sugarConstructorsIntf.ml
+++ b/core/sugarConstructorsIntf.ml
@@ -79,6 +79,7 @@ module type SugarConstructorsSig = sig
   val variable_pat : ?ppos:t -> ?ty:Types.datatype -> name -> Pattern.with_pos
   val tuple_pat    : ?ppos:t -> Pattern.with_pos list -> Pattern.with_pos
   val any_pat      : t -> Pattern.with_pos
+  val operation_pat : ?ppos:t -> ?resumption:Pattern.with_pos -> (name * Pattern.with_pos list) list -> Pattern.with_pos
 
   (* Fieldspec *)
   val present : Datatype.fieldspec
@@ -149,8 +150,9 @@ module type SugarConstructorsSig = sig
 
   (* Handlers *)
   val untyped_handler
-      : ?val_cases:(clause list)
-     -> ?parameters:((Pattern.with_pos * phrase) list)
-     -> phrase -> clause list -> handler_depth
-     -> handler
+      : ?ppos:t -> ?parameters:((Pattern.with_pos * phrase) list)
+     -> phrase list -> effect_clause list -> phrase
+
+  val unary_effect_case : resumption:Pattern.with_pos option -> Pattern.with_pos -> phrase -> effect_clause
+  val nary_effect_case : resumption:Pattern.with_pos option -> Pattern.with_pos list -> phrase -> effect_clause
 end

--- a/core/sugarTraversals.ml
+++ b/core/sugarTraversals.ml
@@ -274,9 +274,7 @@ class map =
           DoOperation (name, ps, t)
       | Handle { expressions; cases; descriptor } ->
          let expressions = o#list (fun o -> o#phrase) expressions in
-         let params =
-            o#option (fun o -> o#handle_params) descriptor.shd_params
-         in
+         let descriptor = o#handle_descriptor descriptor in
          let cases =
            o#list
              (fun o { patterns; resumption; body } ->
@@ -288,7 +286,7 @@ class map =
                { patterns; resumption; body })
              cases
          in
-         Handle { expressions; cases; descriptor = { descriptor with shd_params = params } }
+         Handle { expressions; cases; descriptor }
       | Switch ((_x, _x_i1, _x_i2)) ->
           let _x = o#phrase _x in
           let _x_i1 =
@@ -541,6 +539,10 @@ class map =
       fun (_x, _x_i1) ->
         let _x = o#list (fun o -> o#list (fun o -> o#pattern)) _x in
         let _x_i1 = o#phrase _x_i1 in (_x, _x_i1)
+
+    method handle_descriptor : handler_descriptor -> handler_descriptor =
+      fun descriptor ->
+      { descriptor with shd_params = o#handle_params descriptor.shd_params }
 
     method handle_params : handler_parameterisation -> handler_parameterisation =
       fun { shp_bindings; shp_types }->
@@ -997,9 +999,7 @@ class fold =
      let o = o#list (fun o -> o#phrase) ps in o
       | Handle { expressions; cases; descriptor } ->
          let o = o#list (fun o -> o#phrase) expressions in
-         let o =
-           o#option (fun o -> o#handle_params) descriptor.shd_params
-         in
+         let o = o#handle_descriptor descriptor in
          let o =
            o#list
              (fun o { patterns; resumption; body } ->
@@ -1237,6 +1237,9 @@ class fold =
       fun (_x, _x_i1) ->
         let o = o#list (fun o -> o#list (fun o -> o#pattern)) _x in
         let o = o#phrase _x_i1 in o
+
+    method handle_descriptor : handler_descriptor -> 'self_type =
+      fun descriptor -> o#handle_params descriptor.shd_params
 
     method handle_params : handler_parameterisation -> 'self_type =
       fun params ->
@@ -1707,9 +1710,7 @@ class fold_map =
      (o, DoOperation (name, ps, t))
       | Handle { expressions; cases; descriptor } ->
           let (o, expressions) = o#list (fun o -> o#phrase) expressions in
-          let (o, params) =
-            o#option (fun o -> o#handle_params) descriptor.shd_params
-          in
+          let (o, descriptor) = o#handle_descriptor descriptor in
           let (o, cases) =
             o#list
               (fun o { patterns; resumption; body } ->
@@ -1725,7 +1726,7 @@ class fold_map =
                 (o, { patterns; resumption; body }))
               cases
           in
-          (o, (Handle { expressions; cases; descriptor = { descriptor with shd_params = params } }))
+          (o, (Handle { expressions; cases; descriptor }))
       | Switch ((_x, _x_i1, _x_i2)) ->
           let (o, _x) = o#phrase _x in
           let (o, _x_i1) =
@@ -2015,6 +2016,11 @@ class fold_map =
       fun (_x, _x_i1) ->
         let (o, _x) = o#list (fun o -> o#list (fun o -> o#pattern)) _x in
         let (o, _x_i1) = o#phrase _x_i1 in (o, (_x, _x_i1))
+
+    method handle_descriptor : handler_descriptor -> ('self_type * handler_descriptor) =
+      fun descriptor ->
+      let (o, shd_params) = o#handle_params descriptor.shd_params in
+      o, { descriptor with shd_params }
 
     method handle_params : handler_parameterisation -> ('self_type * handler_parameterisation) =
       fun params ->

--- a/core/sugarTraversals.mli
+++ b/core/sugarTraversals.mli
@@ -52,6 +52,7 @@ class map :
     method location        : Location.t -> Location.t
     method iterpatt        : iterpatt -> iterpatt
     method funlit          : funlit -> funlit
+    method handle_descriptor : handler_descriptor -> handler_descriptor
     method handle_params   : handler_parameterisation -> handler_parameterisation
     method fieldspec       : Datatype.fieldspec -> Datatype.fieldspec
     method fieldconstraint : fieldconstraint -> fieldconstraint
@@ -128,6 +129,7 @@ class fold :
     method location        : Location.t -> 'self
     method iterpatt        : iterpatt -> 'self
     method funlit          : funlit -> 'self
+    method handle_descriptor : handler_descriptor -> 'self
     method handle_params   : handler_parameterisation -> 'self
     (* method quantifier      : quantifier -> 'self *)
     method fieldspec       : Datatype.fieldspec -> 'self
@@ -181,6 +183,7 @@ object ('self)
   method int             : int -> 'self * int
   method float           : float -> 'self * float
   method funlit          : funlit -> 'self * funlit
+  method handle_descriptor : handler_descriptor -> 'self * handler_descriptor
   method handle_params   : handler_parameterisation -> 'self * handler_parameterisation
   method iterpatt        : iterpatt -> 'self * iterpatt
   method list            : 'a . ('self -> 'a -> 'self * 'a) -> 'a list -> 'self * 'a list

--- a/core/sugartoir.ml
+++ b/core/sugartoir.ml
@@ -896,7 +896,7 @@ struct
           | DoOperation (name, ps, Some t) ->
              let vs = evs ps in
              I.do_operation (name, vs, t)
-          | Handle { expressions; _ } -> ec (List.hd expressions)
+          | Handle { expressions; cases; descriptor } -> ec (List.hd expressions)
              (* let henv, params =
               *   let empty_env = (NEnv.empty, TEnv.empty, Types.make_empty_open_row (lin_any, res_any)) in
               *    match (sh_descr.shd_params) with

--- a/core/sugartoir.ml
+++ b/core/sugartoir.ml
@@ -703,8 +703,6 @@ struct
     M.bind vs (fun vs -> lift (Special (DoOperation (name, vs, t)), t))
 
   let handle env expressions raw_cases raw_params descriptor =
-    (* For now assume unary handlers. *)
-    assert (List.length expressions = 1);
     let params =
       List.map
         (fun (pat, body, t) -> pat, reify (body env), t)
@@ -717,7 +715,7 @@ struct
     in
     let computations = List.map reify expressions in
     let (bs, tc) = CompilePatterns.Handlers.compile env computations params cases descriptor in
-    reflect (bs, (tc, `Not_typed))
+    reflect (bs, (tc, descriptor.Sugartypes.shd_branch_type))
   (* let handle env (m, val_cases, eff_cases, params, desc) = *)
     (* let params =
      *   List.map
@@ -943,36 +941,6 @@ struct
                  cases
              in
              I.handle env (List.map ec expressions) raw_cases raw_params descriptor
-             (* let henv, params =
-              *   let empty_env = (NEnv.empty, TEnv.empty, Types.make_empty_open_row (lin_any, res_any)) in
-              *    match (sh_descr.shd_params) with
-              *    | None -> empty_env, []
-              *    | Some { shp_bindings = bindings; shp_types = types } ->
-              *       let env, bindings =
-              *         List.fold_right2
-              *           (fun (p, body) t (env, bindings) ->
-              *             let p, penv = CompilePatterns.desugar_pattern p in
-              *             let bindings = ((fun env -> eval env body), p, t) :: bindings in
-              *             ((env ++ penv), bindings))
-              *           bindings types (empty_env, [])
-              *       in
-              *       env, List.rev bindings
-              * in
-              * let eff_cases =
-              *   List.map
-              *     (fun (p, body) ->
-              *       let p, penv = CompilePatterns.desugar_pattern p in
-              *       (p, fun env -> eval ((env ++ henv) ++ penv) body))
-              *     sh_effect_cases
-              * in
-              * let val_cases =
-              *    List.map
-              *      (fun (p, body) ->
-              *        let p, penv = CompilePatterns.desugar_pattern p in
-              *        (p, fun env -> eval ((env ++ henv) ++ penv) body))
-              *      sh_value_cases
-              * in
-              * I.handle env (ec sh_expr, val_cases, eff_cases, params, sh_descr) *)
           | Switch (e, cases, Some t) ->
               let cases =
                 List.map

--- a/core/sugartoir.ml
+++ b/core/sugartoir.ml
@@ -895,42 +895,37 @@ struct
           | DoOperation (name, ps, Some t) ->
              let vs = evs ps in
              I.do_operation (name, vs, t)
-          | Handle { sh_expr; sh_effect_cases; sh_value_cases; sh_descr } ->
-             (* it happens that the ambient effects are the right ones
-                for all of the patterns here (they match those of the
-                initial computations for parameterised handlers and
-                the bodies of the cases) *)
-             let eff = lookup_effects env in
-             let henv, params =
-               let empty_env = (NEnv.empty, TEnv.empty, eff) in
-                match (sh_descr.shd_params) with
-                | None -> empty_env, []
-                | Some { shp_bindings = bindings; shp_types = types } ->
-                   let env, bindings =
-                     List.fold_right2
-                       (fun (p, body) t (env, bindings) ->
-                         let p, penv = CompilePatterns.desugar_pattern eff p in
-                         let bindings = ((fun env -> eval env body), p, t) :: bindings in
-                         ((env ++ penv), bindings))
-                       bindings types (empty_env, [])
-                   in
-                   env, List.rev bindings
-             in
-             let eff_cases =
-               List.map
-                 (fun (p, body) ->
-                   let p, penv = CompilePatterns.desugar_pattern eff p in
-                   (p, fun env -> eval ((env ++ henv) ++ penv) body))
-                 sh_effect_cases
-             in
-             let val_cases =
-                List.map
-                  (fun (p, body) ->
-                    let p, penv = CompilePatterns.desugar_pattern eff p in
-                    (p, fun env -> eval ((env ++ henv) ++ penv) body))
-                  sh_value_cases
-             in
-             I.handle env (ec sh_expr, val_cases, eff_cases, params, sh_descr)
+          | Handle _ -> assert false
+             (* let henv, params =
+              *   let empty_env = (NEnv.empty, TEnv.empty, Types.make_empty_open_row (lin_any, res_any)) in
+              *    match (sh_descr.shd_params) with
+              *    | None -> empty_env, []
+              *    | Some { shp_bindings = bindings; shp_types = types } ->
+              *       let env, bindings =
+              *         List.fold_right2
+              *           (fun (p, body) t (env, bindings) ->
+              *             let p, penv = CompilePatterns.desugar_pattern p in
+              *             let bindings = ((fun env -> eval env body), p, t) :: bindings in
+              *             ((env ++ penv), bindings))
+              *           bindings types (empty_env, [])
+              *       in
+              *       env, List.rev bindings
+              * in
+              * let eff_cases =
+              *   List.map
+              *     (fun (p, body) ->
+              *       let p, penv = CompilePatterns.desugar_pattern p in
+              *       (p, fun env -> eval ((env ++ henv) ++ penv) body))
+              *     sh_effect_cases
+              * in
+              * let val_cases =
+              *    List.map
+              *      (fun (p, body) ->
+              *        let p, penv = CompilePatterns.desugar_pattern p in
+              *        (p, fun env -> eval ((env ++ henv) ++ penv) body))
+              *      sh_value_cases
+              * in
+              * I.handle env (ec sh_expr, val_cases, eff_cases, params, sh_descr) *)
           | Switch (e, cases, Some t) ->
               let cases =
                 List.map

--- a/core/sugartoir.ml
+++ b/core/sugartoir.ml
@@ -895,7 +895,7 @@ struct
           | DoOperation (name, ps, Some t) ->
              let vs = evs ps in
              I.do_operation (name, vs, t)
-          | Handle _ -> assert false
+          | Handle { expressions; _ } -> ec (List.hd expressions)
              (* let henv, params =
               *   let empty_env = (NEnv.empty, TEnv.empty, Types.make_empty_open_row (lin_any, res_any)) in
               *    match (sh_descr.shd_params) with

--- a/core/sugartoir.ml
+++ b/core/sugartoir.ml
@@ -702,22 +702,23 @@ struct
     let vs = lift_list vs in
     M.bind vs (fun vs -> lift (Special (DoOperation (name, vs, t)), t))
 
-  let handle env (m, val_cases, eff_cases, params, desc) =
-    let params =
-      List.map
-        (fun (body, p, t) -> p, reify (body env), t) params
-    in
-    let val_cases, eff_cases =
-      let reify cases =
-        List.map
-          (fun (p, body) -> ([p], fun env -> reify (body env))) cases
-      in
-      reify val_cases, reify eff_cases
-    in
-    let comp = reify m in
-    let (bs, tc) = CompilePatterns.compile_handle_cases env (val_cases, eff_cases, params, desc) comp in
-    let (_,_,_,t) = desc.Sugartypes.shd_types in
-    reflect (bs, (tc, t))
+  let handle _env _ = assert false
+  (* let handle env (m, val_cases, eff_cases, params, desc) = *)
+    (* let params =
+     *   List.map
+     *     (fun (body, p, t) -> p, reify (body env), t) params
+     * in
+     * let val_cases, eff_cases =
+     *   let reify cases =
+     *     List.map
+     *       (fun (p, body) -> ([p], fun env -> reify (body env))) cases
+     *   in
+     *   reify val_cases, reify eff_cases
+     * in
+     * let comp = reify m in
+     * let (bs, tc) = CompilePatterns.compile_handle_cases env (val_cases, eff_cases, params, desc) comp in
+     * let (_,_,_,t) = desc.Sugartypes.shd_types in
+     * reflect (bs, (tc, t)) *)
 
   let switch env (v, cases, t) =
     let cases =

--- a/core/sugartypes.ml
+++ b/core/sugartypes.ml
@@ -204,10 +204,9 @@ and effect_clause =
     body: phrase }
 and funlit = Pattern.with_pos list list * phrase
 and handler_descriptor =
-  { shd_depth   : handler_depth
-  ; shd_types   : Types.row * Types.datatype * Types.row * Types.datatype
-  ; shd_raw_row : Types.row
-  ; shd_params  : handler_parameterisation option
+  { shd_input_effects: Types.row
+  ; shd_output_effects: Types.row
+  ; shd_params  : handler_parameterisation
   }
 and handler_parameterisation =
   { shp_bindings : (Pattern.with_pos * phrase) list
@@ -509,15 +508,13 @@ struct
                      diff (option_map phrase orderby) pat_bound]
     | Handle { expressions; cases; descriptor } ->
        let params_bound =
-         option_map
-           (fun params -> union_map (fst ->- pattern) params.shp_bindings)
-           descriptor.shd_params
+         union_map (fst ->- pattern) descriptor.shd_params.shp_bindings
        in
        union_all [union_map phrase expressions;
                   union_map effect_case cases;
-                  diff (option_map (fun params -> union_map (snd ->- phrase)
-                                                    params.shp_bindings)
-                          descriptor.shd_params) params_bound]
+                  diff
+                    (union_map (snd ->- phrase) descriptor.shd_params.shp_bindings)
+                    params_bound]
     | Switch (p, cases, _)
     | Offer (p, cases, _) -> union (phrase p) (union_map case cases)
     | CP cp -> cp_phrase cp

--- a/core/sugartypes.ml
+++ b/core/sugartypes.ml
@@ -206,6 +206,7 @@ and funlit = Pattern.with_pos list list * phrase
 and handler_descriptor =
   { shd_input_effects: Types.row
   ; shd_output_effects: Types.row
+  ; shd_branch_type: Types.datatype
   ; shd_params  : handler_parameterisation
   }
 and handler_parameterisation =

--- a/core/sugartypes.ml
+++ b/core/sugartypes.ml
@@ -205,6 +205,7 @@ and effect_clause =
 and funlit = Pattern.with_pos list list * phrase
 and handler_descriptor =
   { shd_input_effects: Types.row
+  ; shd_input_types: Types.datatype list
   ; shd_output_effects: Types.row
   ; shd_branch_type: Types.datatype
   ; shd_params  : handler_parameterisation

--- a/core/sugartypes.ml
+++ b/core/sugartypes.ml
@@ -154,6 +154,8 @@ module Pattern = struct
     | List     of with_pos list
     | Variant  of name * with_pos option
     | Effect   of name * with_pos list * with_pos
+    (* | Operation of name * with_pos * with_pos option *)
+    (* | MultiOperation of (name * with_pos list) list *)
     | Negative of name list
     | Record   of (name * with_pos) list * with_pos option
     | Tuple    of with_pos list
@@ -162,7 +164,50 @@ module Pattern = struct
     | As       of Binder.with_pos * with_pos
     | HasType  of with_pos * datatype'
   and with_pos = t WithPos.t
-   [@@deriving show]
+     [@@deriving show]
+
+  (* open WithPos
+   * let is_operation : with_pos -> bool = function
+   *   | { node = Operation _; _ } -> true
+   *   | _ -> false
+   *)
+  module Syntax = struct
+    module Operation = struct
+      open WithPos
+      let elucidate : (name * with_pos option) list -> with_pos = function
+        | [] -> assert false
+        | [(label, param)] -> assert false (* Operation (label, param, None) *)
+        | xs -> assert false (* MultiOperation xs *)
+
+      (* let  *)
+    end
+    (* let rec check : bool -> bool -> with_pos -> with_pos
+     *   = fun in_handler toplevel pat ->
+     *   let check = check in_handler false in
+     *   let node = match pat.node with
+     *     | Effect (ps, p) when in_handler && toplevel ->
+     *        let p = opt_map check p in
+     *        begin match ps with
+     *        | [] -> assert false
+     *        | [{ node = Operation _; _ }] -> Effect (ps, p)
+     *        | [{ node = Tuple ps'; _ }] when List.exists is_operation ps' ->
+     *           Effect (List.map check ps', p)
+     *        | _ -> assert false (\* Syntax error. *\)
+     *        end
+     *     | Effect _ -> assert false (\* Syntax error. *\)
+     *     | Cons (hd, tl) -> Cons (check hd, check tl)
+     *     | List ps       -> List (List.map check ps)
+     *     | Variant (label, p) -> Variant (label, opt_map check p)
+     *     | Operation (p, p') when in_handler -> Operation (check p, opt_map check p')
+     *     | Operation _ -> assert false (\* Syntax error. *\)
+     *     | Record (ps, p) -> Record (List.map (fun (label, p) -> (label, check p)) ps, opt_map check p)
+     *     | Tuple ps -> Tuple (List.map check ps)
+     *     | As (bndr, p) -> As (bndr, check p)
+     *     | HasType (p, dt) -> HasType (check p, dt)
+     *     | _ -> pat.node
+     *   in
+     *   WithPos.make ~pos:pat.pos nod *)
+  end
 end
 
 type spawn_kind = Angel | Demon | Wait

--- a/core/transformSugar.ml
+++ b/core/transformSugar.ml
@@ -494,7 +494,6 @@ class transform (env : Types.typing_environment) =
            let o, output = o#row descriptor.shd_output_effects in
            input, output, o
          in
-         let descriptor = { shd_input_effects; shd_output_effects; shd_params } in
          (* Transform cases. *)
          let transform_case { patterns; resumption; body } (cases, _branch_type, o) =
            let envs = o#backup_envs in
@@ -512,12 +511,17 @@ class transform (env : Types.typing_environment) =
            let (o, body, t) = o#phrase body in
            { patterns; resumption; body } :: cases, t, o#restore_envs envs
          in
-         let cases, branch_type, o =
+         let cases, shd_branch_type, o =
            List.fold_right transform_case cases ([], `Not_typed, o)
+         in
+         let descriptor = { shd_input_effects;
+                            shd_output_effects;
+                            shd_branch_type;
+                            shd_params }
          in
          (* Restore the environments. *)
          let o = o#restore_envs envs in
-         (o, Handle { expressions; cases; descriptor }, branch_type)
+         (o, Handle { expressions; cases; descriptor }, shd_branch_type)
       | TryInOtherwise (try_phr, as_pat, as_phr, otherwise_phr, (Some dt)) ->
           let (o, try_phr, _) = o#phrase try_phr in
           let (o, as_pat) = o#pattern as_pat in

--- a/core/transformSugar.ml
+++ b/core/transformSugar.ml
@@ -466,8 +466,8 @@ class transform (env : Types.typing_environment) =
          (* Ensure the expressions are independent. *)
          let transform_expression exp (exps, o) =
            let envs = o#backup_envs in
-           let (o, exp, _t) = o#phrase exp in
-           (exp :: exps, o#restore_envs envs)
+           let (o, exp, t) = o#phrase exp in
+           ((exp, t) :: exps, o#restore_envs envs)
          in
          let (expressions, o) =
            List.fold_right transform_expression expressions ([], o)
@@ -514,7 +514,10 @@ class transform (env : Types.typing_environment) =
          let cases, shd_branch_type, o =
            List.fold_right transform_case cases ([], `Not_typed, o)
          in
+         let shd_input_types = List.map snd expressions in
+         let expressions = List.map fst expressions in
          let descriptor = { shd_input_effects;
+                            shd_input_types;
                             shd_output_effects;
                             shd_branch_type;
                             shd_params }

--- a/core/transformSugar.ml
+++ b/core/transformSugar.ml
@@ -459,7 +459,7 @@ class transform (env : Types.typing_environment) =
       | DoOperation (name, ps, Some t) ->
          let (o, ps, _) = list o (fun o -> o#phrase) ps in
          (o, DoOperation (name, ps, Some t), t)
-      | Handle _ -> assert false
+      | (Handle { descriptor = { shd_types = (_,_,_,t); _ }; _ }) as h -> (o, h, t)
          (* let (input_row, input_t, output_row, output_t) = sh_descr.shd_types in
           * let (o, expr, _) = o#phrase sh_expr in
           * let envs = o#backup_envs in

--- a/core/typeSugar.ml
+++ b/core/typeSugar.ml
@@ -3998,6 +3998,7 @@ let rec type_check : context -> phrase -> phrase * Types.datatype * usagemap =
              merge_usages (List.map (fun (_, _, body) -> usages body) cases)
            in
            let descriptor = { descriptor with shd_input_effects = inner_eff;
+                                              shd_input_types = List.map typ expressions;
                                               shd_output_effects = outer_eff;
                                               shd_branch_type = body_type }
            in

--- a/core/typeSugar.ml
+++ b/core/typeSugar.ml
@@ -3998,7 +3998,8 @@ let rec type_check : context -> phrase -> phrase * Types.datatype * usagemap =
              merge_usages (List.map (fun (_, _, body) -> usages body) cases)
            in
            let descriptor = { descriptor with shd_input_effects = inner_eff;
-                                              shd_output_effects = outer_eff }
+                                              shd_output_effects = outer_eff;
+                                              shd_branch_type = body_type }
            in
            (Handle { expressions = List.map erase expressions;
                      cases = erase_effect_cases cases;

--- a/core/typeUtils.ml
+++ b/core/typeUtils.ml
@@ -163,11 +163,6 @@ let rec arg_types ?(overstep_quantifiers=true) t = match (concrete_type t, overs
       extract_tuple row
   | (`Lolli (`Record row, _, _), _) ->
      extract_tuple row
-(*   | `Function (t', _, _) when is_thunk_type t' -> [Types.unit_type] (\* THIS IS A HACK. TODO: Trace down cause of bug. At some point during the compilation process the formal parameter to (() {Op: a -> b} -> c) -> d gets unwrapped yielding a function type composed internally as *)
-(*  `Function ((`Function (), {Op: a -> b}, c) *)
-(*            , <empty effects>, d) *)
-(*   which is wrong; the formal parameter should be wrapped inside a `Record. *)
-(* *\) (\*error ("arg_types: " ^ (string_of_datatype t') ^ ", ret: " ^ string_of_datatype t'')*\) *)
   | (t, _) ->
      error ("Attempt to take arg types of non-function: " ^ string_of_datatype t)
 

--- a/core/typeUtils.ml
+++ b/core/typeUtils.ml
@@ -166,6 +166,11 @@ let rec arg_types ?(overstep_quantifiers=true) t = match (concrete_type t, overs
   | (t, _) ->
      error ("Attempt to take arg types of non-function: " ^ string_of_datatype t)
 
+let arity ?(overstep_quantifiers=true) t =
+  try List.length (arg_types ~overstep_quantifiers t)
+  with _ ->
+     error ("Attempt to take arity of non-function: " ^ string_of_datatype t)
+
 let rec effect_row ?(overstep_quantifiers=true) t = match (concrete_type t, overstep_quantifiers)  with
   | (`ForAll (_, t), true) -> effect_row t
   | (`Function (_, effects, _), _) -> effects

--- a/core/typeUtils.mli
+++ b/core/typeUtils.mli
@@ -8,6 +8,7 @@ val erase_type   : ?overstep_quantifiers:bool -> Utility.stringset -> Types.data
 val inject_type  : string -> Types.datatype -> Types.datatype
 val return_type  : ?overstep_quantifiers:bool -> Types.datatype -> Types.datatype
 val arg_types    : ?overstep_quantifiers:bool -> Types.datatype -> Types.datatype list
+val arity        : ?overstep_quantifiers:bool -> Types.datatype -> int
 val effect_row   : ?overstep_quantifiers:bool -> Types.datatype -> Types.row
 val is_function_type : Types.datatype -> bool
 val is_thunk_type : Types.datatype -> bool

--- a/core/types.ml
+++ b/core/types.ml
@@ -2638,6 +2638,14 @@ let make_thunk_type : row -> datatype -> datatype
   = fun effs rtype ->
   make_function_type [] effs rtype
 
+let make_operation_type : datatype list -> datatype -> datatype
+  = make_pure_function_type
+
+let recursive_applications t =
+  let o = new GetRecursiveApplications.visitor in
+  let (_, o) = o#typ t in
+  o#get_applications |> StringSet.elements
+
 (* We replace some of the generated printing functions here such that
    they may use our own printing functions instead. If the generated functions are
    to be used, we remove potential cycles arising from recursive types/rows first.

--- a/core/types.ml
+++ b/core/types.ml
@@ -2641,11 +2641,6 @@ let make_thunk_type : row -> datatype -> datatype
 let make_operation_type : datatype list -> datatype -> datatype
   = make_pure_function_type
 
-let recursive_applications t =
-  let o = new GetRecursiveApplications.visitor in
-  let (_, o) = o#typ t in
-  o#get_applications |> StringSet.elements
-
 (* We replace some of the generated printing functions here such that
    they may use our own printing functions instead. If the generated functions are
    to be used, we remove potential cycles arising from recursive types/rows first.

--- a/core/types.mli
+++ b/core/types.mli
@@ -368,6 +368,7 @@ val add_tyvar_names : ('a -> Vars.vars_list)
 val make_pure_function_type : datatype list -> datatype -> datatype
 val make_function_type      : ?linear:bool -> datatype list -> row -> datatype -> datatype
 val make_thunk_type : row -> datatype -> datatype
+val make_operation_type : datatype list -> datatype -> datatype
 
 val pp_datatype : Format.formatter -> datatype -> unit
 val pp_tycon_spec: Format.formatter -> tycon_spec -> unit

--- a/core/utility.ml
+++ b/core/utility.ml
@@ -569,6 +569,11 @@ struct
     match xs with
     | [] -> raise (Invalid_argument "empty list")
     | x :: xs -> List.fold_left f x xs
+
+  let rec init : (int -> 'a) -> int -> 'a list
+    = fun f n ->
+    if n <= 0 then []
+    else f n :: init f (n - 1)
 end
 include ListUtils
 

--- a/core/utility.ml
+++ b/core/utility.ml
@@ -1395,3 +1395,20 @@ end = struct
       files root (Str.regexp pattern)
   end
 end
+
+
+module MutablePair: sig
+  type ('a, 'b) t = { mutable fst: 'a;
+                      mutable snd: 'b }
+
+  val make : 'a -> 'b -> ('a, 'b) t
+  val fst : ('a, 'b) t -> 'a
+  val snd : ('a, 'b) t -> 'b
+end = struct
+  type ('a, 'b) t = { mutable fst: 'a;
+                      mutable snd: 'b }
+
+  let make fst snd = { fst; snd }
+  let fst { fst; _ } = fst
+  let snd { snd; _ } = snd
+end

--- a/core/utility.ml
+++ b/core/utility.ml
@@ -563,6 +563,12 @@ struct
     | [] :: xss -> transpose xss
     | (x :: xs) :: xss ->
        (x :: (List.map List.hd xss)) :: transpose (xs :: List.map List.tl xss)
+
+  let fold_left1 : ('a -> 'a -> 'a) -> 'a list -> 'a
+    = fun f xs ->
+    match xs with
+    | [] -> raise (Invalid_argument "empty list")
+    | x :: xs -> List.fold_left f x xs
 end
 include ListUtils
 


### PR DESCRIPTION
This PR changes the syntax for handlers.
Instead of
```ocaml
handle (...) {
  case Op(params, resumption) -> ...
  case Return(x) -> x
}
```
we write
```ocaml
handle (...) {
  case <Op(params) => resumption> -> ...
  case x -> x
}
```
We can also write `case <Op(params) -> resumption> -> ...`. For now, the semantics for `->` and `=>` are the same. This is in prevision for a future step : we will not have `shallowhandler` anymore and we will indicate if a resumption is shallow with `->` and deep with `=>`.