### PR TITLE
Add h0 and a0 to MvuHTML and MvuAttrs libraries

### DIFF
--- a/examples/mvu/commands.links
+++ b/examples/mvu/commands.links
@@ -11,10 +11,6 @@ sig view : (Model) ~%~> MvuHTML.HTML(Message)
 fun view(model) {
   open MvuAttrs;
   open MvuHTML;
-
-  var a0 = MvuAttrs.empty;
-  var h0 = MvuHTML.empty;
-
   var disabled = MvuAttrs.attr("disabled", "disabled");
 
   var (text, buttonAttr) =

--- a/examples/mvu/dispatch.links
+++ b/examples/mvu/dispatch.links
@@ -14,9 +14,6 @@ fun view(model) {
     open MvuAttrs;
     open MvuHTML;
 
-    var h0 = MvuHTML.empty;
-    var a0 = MvuAttrs.empty;
-
     h1(a0, textNode(intToString(model)))
 }
 

--- a/examples/mvu/pong.links
+++ b/examples/mvu/pong.links
@@ -89,21 +89,19 @@ fun keyUpHandler() {
 }
 
 # Rendering
-var ae = MvuAttrs.empty;
-var he = MvuHTML.empty;
 fun ch(xs) { MvuHTML.concat(xs) }
 
 sig drawCircle : (Float,Float) -> HTML(Msg)
 fun drawCircle(x,y) {
   div (class ("circle") +@
        style ("left:" ^^ floatToString(x) ^^ "px;top:" ^^ floatToString(y) ^^ "px;position:absolute;"),
-       he)
+       h0)
 }
 
 sig drawPaddle : (Float, Float) -> HTML(Msg)
 fun drawPaddle(x,y) {
   div (class ("paddle") +@
-       style ("left:" ^^ floatToString(x) ^^ "px;top:" ^^ floatToString(y) ^^ "px;position:absolute;"), he)
+       style ("left:" ^^ floatToString(x) ^^ "px;top:" ^^ floatToString(y) ^^ "px;position:absolute;"), h0)
 }
 
 fun physicsUpdate(ball) {

--- a/examples/mvu/time.links
+++ b/examples/mvu/time.links
@@ -61,8 +61,6 @@ fun updt(msg, model) {
   }
 }
 
-var ae = MvuAttrs.empty;
-var he = MvuHTML.empty;
 fun ch(xs) { MvuHTML.concat(xs) }
 
 sig view : (Model) ~> MvuHTML.HTML(Msg)
@@ -75,13 +73,13 @@ fun view(model) {
       "Pause"
     };
     div (id ("swatch") +@ class ("swatch"), ch([
-      h1 (ae, textNode(pad(model.minutes)) +* textNode(":" ^^ pad(model.seconds))),
+      h1 (a0, textNode(pad(model.minutes)) +* textNode(":" ^^ pad(model.seconds))),
       button (id ("togglepause") +@ togglePauseHandler, textNode(toggleText)),
       button (id ("reset") +@ resetHandler, textNode("Reset")),
       button (id ("stop") +@ stopHandler, textNode("Stop")),
       div (class ("footer"), ch([
-        b (ae, textNode("Keyboard shortcuts")),
-        br (ae, he),
+        b (a0, textNode("Keyboard shortcuts")),
+        br (a0, h0),
         textNode("| p : start/pause | "),
         textNode("r : reset | "),
         textNode("s : stop |")

--- a/lib/stdlib/mvuAttrs.links
+++ b/lib/stdlib/mvuAttrs.links
@@ -19,6 +19,7 @@ fun attr(k, v) {
 }
 
 var empty = AttrEmpty;
+var a0 = empty;
 
 fun eventHandler(hndlr) {
   AttrEventHandler(hndlr)

--- a/lib/stdlib/mvuHTML.links
+++ b/lib/stdlib/mvuHTML.links
@@ -11,7 +11,7 @@ typename HTML(a :: Type(Any, Any)) =
    |];
 
 var empty = HTMLEmpty;
-var h0 = HTMLEmpty;
+var h0 = empty;
 
 fun textNode(str) {
   HTMLText(str)

--- a/lib/stdlib/mvuHTML.links
+++ b/lib/stdlib/mvuHTML.links
@@ -11,6 +11,7 @@ typename HTML(a :: Type(Any, Any)) =
    |];
 
 var empty = HTMLEmpty;
+var h0 = HTMLEmpty;
 
 fun textNode(str) {
   HTMLText(str)


### PR DESCRIPTION
The monoidal units of MvuHTML.HTML and MvuAttrs.Attr are accessed by `MvuHTML.empty` and `MvuAttrs.empty`.
When creating a tree, these are quite verbose to use, so the pattern I've ended up doing is:

```
var a0 = MvuAttrs.empty;
var h0 = MvuHTML.empty;
div(a0, h0)
```

I do this so much that I think it would actually be better to have these shortcuts in the actual libraries. It's handy for me and I don't see any harm in it.