### PR TITLE
Simpler PID synonym for processes

### DIFF
--- a/prelude.links
+++ b/prelude.links
@@ -1224,6 +1224,9 @@ fun sendSuspend(pagef) {
   }
 }
 
+#### CONCURRENCY ####
+typename Pid(a::Type) = Process({hear: a});
+
 #### SESSION TYPING STUFF ####
 #sig fork : forall s::Session,e::Row.((s) ~e~> ()) ~e~> ~s
 sig fork : forall s::Session,e::Row.((s) {SessionFail:[||]}~> ()) ~e~> ~s


### PR DESCRIPTION
The current `Process` type gives the type of effects that a process can perform.
When using actor style concurrency, this will typically be of the form

```Process({hear: Foo})```

for some message of type `Foo`. (I often forget the specific syntax).

Indeed this is a fairly common use case. Especially when writing MVU applications, it's often good practice to write down type signatures for PIDs if they're contained within a model.

This small patch introduces a synonym `Pid(A) = Process({hear: A})` for some type A, so we can just write

```Pid(Foo)```
 
This won't be flexible enough for some cases where we want the more fine-grained reasoning about the effects performed by the spawned process, but IMO it's an easy win for a majority of cases.