### PR TITLE
Fix regression in compilation of effect handlers to JavaScript.

### DIFF
--- a/core/irtojs.ml
+++ b/core/irtojs.ml
@@ -1278,9 +1278,9 @@ end = functor (K : CONTINUATION) -> struct
               let translate_eff_case env scrutinee (xb, resume, body) kappas =
                 let (_x, x_name) as xb = name_binder xb in
                 let (r, r_name) = name_binder resume in
-                let p = project scrutinee "p" in
+                let p = project (project scrutinee "_value") "p" in
                 let resume =
-                  let s = project scrutinee "s" in
+                  let s = project (project scrutinee "_value") "s" in
                   make_resumption s
                 in
                 let env' =

--- a/examples/handlers/js/alert.js
+++ b/examples/handlers/js/alert.js
@@ -4,9 +4,9 @@ function _alertBox(msg) {
 
 function wait(time, cb, kappa) {
     setTimeout(function() {
-        return _applyCont(_makeCont(cb), _idy);
+        return _$K.apply(_$K.make(cb), _$K.idy);
     }, time);
-    return _applyCont(kappa, {});
+    return _$K.apply(kappa, _$Constants.UNIT);
 }
 
 var alertBox = _$Links.kify(_alertBox);

--- a/examples/handlers/js/canvas.js
+++ b/examples/handlers/js/canvas.js
@@ -1,25 +1,22 @@
-
 function drawUnit(x, y, color, ctx, kappa) {
     ctx.fillStyle= color;
     ctx.fillRect(x,y,1,1);
-    return _yieldCont(kappa, _$Constants.UNIT);
+    return _$K.yield(kappa, _$Constants.UNIT);
 }
 
 function drawCustomUnit(x, y, xheight, yheight, color, ctx, kappa) {
     ctx.fillStyle= color;
     ctx.fillRect(x, y, xheight, yheight);
-    return _yieldCont(kappa, _$Constants.UNIT);
+    return _$K.yield(kappa, _$Constants.UNIT);
 
 }
 
 function getValueFromSelection(id, kappa){
-    var e = document.getElementById(id);
-    return _yieldCont(kappa, e.value);
+    const e = document.getElementById(id);
+    return _$K.yield(kappa, e.value);
 }
 
 function setBorderOfRef(node, style, kappa){
     node.style.border = style;
-    return _yieldCont(kappa, node);
+    return _$K.yield(kappa, node);
 }
-
-_$Constants.UNIT

--- a/examples/handlers/js/runtime.js
+++ b/examples/handlers/js/runtime.js
@@ -1,44 +1,44 @@
 function systemYield(f, kappa){
     window.requestAnimationFrame(function(){
-        return f(_$Constants.UNIT, _idy);
+        return f(_$Constants.UNIT, _$K.idy);
     });
     return _$Constants.UNIT;
 }
 
 function delayExecution(delay, kappa){
-    window.setTimeout(function(){return _yieldCont(kappa, _$Constants.UNIT);}, delay);
+    window.setTimeout(function(){return _$K.yield(kappa, _$Constants.UNIT);}, delay);
     return _$Constants.UNIT;
 }
 
 function delayExecutionOfF(delay, f, kappa){
     window.setTimeout(function(){f()}, delay);
-    return _yieldCont(kappa, _$Constants.UNIT);
+    return _$K.yield(kappa, _$Constants.UNIT);
 }
 
 function requestAnimationFrame(f, delay, kappa){
     window.requestAnimationFrame(f);
-    return _yieldCont(kappa, _$Constants.UNIT);
+    return _$K.yield(kappa, _$Constants.UNIT);
 }
 
 function setIntervalForF(interval, f, kappa){
-    var id = setInterval(function() {
-        return f(_idy);
+    const _id = setInterval(function() {
+        return f(_$K.idy);
     }, interval);
-    return _yieldCont(kappa, _$Constants.UNIT);
+    return _$K.yield(kappa, _$Constants.UNIT);
 }
 
 const SystemQueue = (function(){
 
-    let queue = _$List.Nil;
+    let queue = _$List.nil;
 
     function enqueue(fiber){
-        queue = _$List.Cons(fiber, queue);
+        queue = _$List.cons(fiber, queue);
         return _$Constants.UNIT;
     }
 
     function dequeue(){
         let temp = queue;
-        queue = _$List.Nil;
+        queue = _$List.nil;
         return temp;
     }
 
@@ -46,7 +46,9 @@ const SystemQueue = (function(){
         return _$List.length(queue);
     }
 
-    return {"enqueue": enqueue, "dequeue": dequeue, "length" : length}
+    return { "enqueue": enqueue
+           , "dequeue": dequeue
+           , "length" : length }
 
 }());
 

--- a/examples/handlers/racing-lines.links
+++ b/examples/handlers/racing-lines.links
@@ -1,11 +1,11 @@
 typename Canvas = ();
-alien javascript "/js/canvas.js" {
+alien javascript "/examples/handlers/js/canvas.js" {
     drawUnit: (Int, Int, String, Canvas) ~> ();
     drawCustomUnit: (Int, Int, Int, Int, String, Canvas) ~> ();
     getValueFromSelection: (String) ~> String;
 }
 
-alien javascript "js/runtime.js" {
+alien javascript "/examples/handlers/js/runtime.js" {
     systemYield : ((()) {}~> ()) ~> ();
     delayExecution: (Int) ~> ();
     sysEnqueue: (a) ~> ();
@@ -435,7 +435,7 @@ fun main_page(_){
 sig main: () ~> ()
 fun main() {
     addRoute("/", main_page);
-    addStaticRoute("/js", "js", [("js", "text/javascript")]);
+    addStaticRoute("/examples/handlers/js", "examples/handlers/js", [("js", "text/javascript")]);
 
     servePages()
 }

--- a/examples/handlers/sierpinski-triangle.links
+++ b/examples/handlers/sierpinski-triangle.links
@@ -1,8 +1,8 @@
-alien javascript "/js/canvas.js" {
+alien javascript "/examples/handlers/js/canvas.js" {
     getValueFromSelection: (String) ~> String;
 }
 
-alien javascript "js/runtime.js" {
+alien javascript "/examples/handlers/js/runtime.js" {
     delayExecution: (Int) ~> ();
     requestAnimationFrame: (() -> (), Int) ~> ();
     setIntervalForF: (Int, () ~> ()) ~> ();
@@ -19,8 +19,8 @@ typename Priority = [|High|Low|];
 typename Co(e::Eff) = () {Fork: (Co({ |e}), Priority) -> (), Yield:() |e}~> ();
 typename Fiber0(e::Eff) = (prio: Priority, f: () {Fork: (Fiber0({ |e})) -> (), Yield:()|e}~> ());
 typename SchedulerState(a) = (runQ: PrioQueue(a), prio: Priority, startTime: Int);
-typename Fiber = (prio:Priority, f: (SchedulerState(Fiber)) ~> ());
-typename FiberQueue = PrioQueue(Fiber);
+typename Fiber(e::Eff) = (prio:Priority, f: (SchedulerState(Fiber({ |e}))) ~e~> ());
+typename FiberQueue(e::Eff) = PrioQueue(Fiber({ |e}));
 typename Update = [|TextUpdate: String | LocationUpdate: Float|];
 typename STriangle(e::Eff) = (point: Point, targetSize: Int, text: String, children: [STriangle({ |e})]);
 
@@ -407,7 +407,7 @@ fun main_page(_){
 sig main: () ~> ()
 fun main() {
     addRoute("/", main_page);
-    addStaticRoute("/js", "js", [("js", "text/javascript")]);
+    addStaticRoute("/examples/handlers/js", "examples/handlers/js", [("js", "text/javascript")]);
 
     servePages()
 }


### PR DESCRIPTION
The refactoring of the JavaScript compiler earlier this year apparently introduced a regression in the compilation of effect handlers. This regression manifests computation pattern matching, where the payload of any matched operation was not properly extracted.

This patch also brings
`examples/handlers/{racing-lines,sierpinski-triangle}.links` up to date with the new JavaScript runtime API, meaning these examples now runs correctly again.