### PR TITLE
Polymorphic operations

### DIFF
--- a/core/desugarDatatypes.ml
+++ b/core/desugarDatatypes.ml
@@ -113,6 +113,8 @@ module Desugar = struct
         | Record r -> Types.Record (row alias_env r t')
         | Variant r -> Types.Variant (row alias_env r t')
         | Effect r -> Types.Effect (row alias_env r t')
+        | Operation (f, t) -> Types.Operation ( Types.make_tuple_type (List.map datatype f)
+                           , datatype t )
         | Table (tmp, r, w, n) -> Types.Table (tmp, datatype r, datatype w, datatype n)
         | List k -> Types.Application (Types.list, [(PrimaryKind.Type, datatype k)])
         | TypeApplication (tycon, ts) ->

--- a/core/desugarEffects.ml
+++ b/core/desugarEffects.ml
@@ -1,7 +1,6 @@
 open Utility
 open CommonTypes
 open Sugartypes
-open SourceCode
 
 (**
 
@@ -85,14 +84,14 @@ let cannot_insert_presence_var2 pos op =
       ^ ". However, in the current context, implictly bound (presence) \
          variables are disallowed" )
 
-let unexpected_effects_on_abstract_op pos name =
-  Errors.Type_error
-    ( pos,
-      "The abstract operation "
-      ^ name
-      ^ " has unexpected effects in its signature. The effect signature on an \
-         abstract operation arrow is always supposed to be empty, since any \
-         effects it might have are ultimately conferred by its handler." )
+(* let unexpected_effects_on_abstract_op pos name = *)
+(*   Errors.Type_error *)
+(*     ( pos, *)
+(*       "The abstract operation " *)
+(*       ^ name *)
+(*       ^ " has unexpected effects in its signature. The effect signature on an \ *)
+(*          abstract operation arrow is always supposed to be empty, since any \ *)
+(*          effects it might have are ultimately conferred by its handler." ) *)
 
 let shared_effect_forbidden_here pos =
   Errors.Type_error
@@ -357,36 +356,21 @@ let cleanup_effects tycon_env =
 
      method effect_row ~allow_shared (fields, var) =
        let open Datatype in
-       let open SourceCode.WithPos in
-       let fields =
-         List.map
-           (function
-             | ( name,
-                 Present
-                   { node = Function (domain, (fields, rv), codomain); pos } )
-               as op
-               when not (TypeUtils.is_builtin_effect name) -> (
-                 (* Elaborates `Op : a -> b' to `Op : a {}-> b' *)
-                 match (rv, fields) with
-                 | Closed, [] -> op
-                 | Open _, []
-                 | Recursive _, [] ->
-                     (* might need an extra check on recursive rows *)
-                     ( name,
-                       Present
-                         (SourceCode.WithPos.make ~pos
-                            (Function (domain, ([], Closed), codomain))) )
-                 | _, _ -> raise (unexpected_effects_on_abstract_op pos name) )
-             | name, Present ({ node ; pos } as node') when not (TypeUtils.is_builtin_effect name) ->
-                 (* Elaborates `Op : a' to `Op : () {}-> a' *)
-                 let node = match node with
-                 (* | Forall (qs, node') -> Forall (qs, WithPos.make ~pos (Function ([], ([], Closed), node'))) *)
-                 | _ -> Function ([], ([], Closed), node')
-                 in
-                 ( name,
-                   Present (WithPos.make ~pos node) )
-             | x -> x)
-           fields
+       let open SourceCode in
+       let open WithPos in
+       (* Elaborates `Op : a' to `Op : () {}-> a' *)
+       let rec elaborate_op dt =
+         let { node ; pos } = dt in
+         WithPos.make ~pos (match node with
+             | Datatype.Operation _     -> node
+             | Datatype.Forall (qs, dt) -> Datatype.Forall (qs, elaborate_op dt)
+             | _                        -> Datatype.Operation ([], dt))
+       in
+       let fields = List.map (function
+           | name, Present dt when not (TypeUtils.is_builtin_effect name) ->
+             ( name, Present (elaborate_op dt) )
+           | x -> x
+         ) fields
        in
        let gue = SugarTypeVar.get_unresolved_exn in
        let var =

--- a/core/desugarSessionExceptions.ml
+++ b/core/desugarSessionExceptions.ml
@@ -86,8 +86,8 @@ object (o : 'self_type)
          * (where (do SessionFail) has the empty type) *)
         let ty =
           Types.fresh_type_variable (CommonTypes.lin_any, CommonTypes.res_any) in
-        let doOp = DoOperation (failure_op_name, [], Some (Types.empty_type)) in
         let with_pos x = SourceCode.WithPos.make ~pos x in
+        let doOp = DoOperation (with_pos (Operation failure_op_name), [], Some (Types.empty_type)) in
         (o, with_pos (Switch (with_pos doOp, [], Some ty)), ty)
     | { node = TryInOtherwise (_, _, _, _, None); _} -> assert false
     | { node = TryInOtherwise (try_phr, pat, as_phr, otherwise_phr, (Some dt)); pos }

--- a/core/generalise.ml
+++ b/core/generalise.ml
@@ -71,6 +71,10 @@ let rec get_type_args : gen_kind -> TypeVarSet.t -> datatype -> type_arg list =
            get_type_args kind (TypeVarSet.add_quantifiers qs bound_vars) t
         (* Effect *)
         | Effect row -> get_row_type_args kind bound_vars row
+        | Operation (f, t) ->
+            let from_gens = gt f
+            and to_gens = gt t in
+              from_gens @ to_gens
         (* Row *)
         | Row (field_env, row_var, _) ->
            let field_vars =

--- a/core/instantiate.ml
+++ b/core/instantiate.ml
@@ -76,6 +76,7 @@ let instantiates : instantiation_maps -> (datatype -> datatype) * (row -> row) *
         | Record row -> Record (instr row)
         | Variant row -> Variant (instr row)
         | Effect row -> Effect (instr row)
+        | Operation (f, t) -> Operation (inst f, inst t)
         | Table (tmp, f, d, r) -> Table (tmp, inst f, inst d, inst r)
         | ForAll (qs, t) ->
            let remove_shadowed_quantifier tmap q =

--- a/core/irCheck.ml
+++ b/core/irCheck.ml
@@ -350,6 +350,13 @@ let eq_types occurrence : type_eq_context -> (Types.datatype * Types.datatype) -
          | Effect r -> eq_rows (context, l, r)
          | _         -> false
          end
+      | Operation (lfrom, lto) ->
+          begin match t2 with
+            | Operation (rfrom, rto) ->
+              eqt     (context, lfrom, rfrom) &&
+              eqt     (context, lto  , rto  )
+            | _ -> false
+          end
       (* Row *)
       | Row _ ->
          begin match t2 with
@@ -595,7 +602,9 @@ struct
             let o, v, vt = o#value v in
             let _ = match TypeUtils.concrete_type t with
               | Variant _ ->
-                 o#check_eq_types  (variant_at ~overstep_quantifiers:false name t) vt (SVal orig)
+                 Debug.print "2" ;
+                 let x = o#check_eq_types  (variant_at ~overstep_quantifiers:false name t) vt (SVal orig)
+                 in Debug.print "22" ; x
               | _ -> raise_ir_type_error "trying to inject into non-variant type" (SVal orig) in
             o, Inject (name, v, t), t
         | TAbs (tyvars, v) ->
@@ -753,7 +762,9 @@ struct
                  StringMap.fold
                    (fun name  (binder, comp) (o, cases, types) ->
                      let type_binder = Var.type_of_binder binder in
+                     Debug.print "1" ;
                      let type_variant = variant_at ~overstep_quantifiers:false name variant in
+                     Debug.print "11" ;
                      o#check_eq_types type_binder type_variant (STC orig);
                      let o, b = o#binder binder in
                      let o, c, t = o#computation comp in

--- a/core/sugarTraversals.ml
+++ b/core/sugarTraversals.ml
@@ -315,10 +315,14 @@ class map =
           let _x_i1 = o#option (fun o -> o#phrase) _x_i1 in
           let _x_i2 = o#option (fun o -> o#typ) _x_i2 in
           ConstructorLit ((_x, _x_i1, _x_i2))
-      | DoOperation (name, ps, t) ->
+      | DoOperation (op, ps, t) ->
+          let op  = o#phrase op in
           let ps  = o#list (fun o -> o#phrase) ps in
           let t   = o#option (fun o -> o#typ) t in
-          DoOperation (name, ps, t)
+          DoOperation (op, ps, t)
+      | Operation _x ->
+          let _x = o#name _x in
+          Operation _x
       | Handle { sh_expr; sh_effect_cases; sh_value_cases; sh_descr } ->
          let m = o#phrase sh_expr in
          let params =
@@ -671,6 +675,9 @@ class map =
       | Record _x -> let _x = o#row _x in Record _x
       | Variant _x -> let _x = o#row _x in Variant _x
       | Effect r -> let r = o#row r in Effect r
+      | Operation (_x, _x_i1) ->
+        let _x = o#list (fun o -> o#datatype) _x in
+        let _x_i1 = o#datatype _x_i1 in Operation (_x, _x_i1)
       | Table (_t, _x, _x_i1, _x_i2) ->
          let _x = o#datatype _x in
          let _x_i1 = o#datatype _x_i1 in
@@ -1125,10 +1132,12 @@ class fold =
       | ConstructorLit ((_x, _x_i1, _x_i2)) ->
           let o = o#name _x in
           let o = o#option (fun o -> o#phrase) _x_i1 in o
-      | DoOperation (name,ps,t) ->
-         let o = o#name name in
-     let o = o#option (fun o -> o#unknown) t in
-     let o = o#list (fun o -> o#phrase) ps in o
+      | DoOperation (op,ps,t) ->
+         let o = o#phrase op in
+         let o = o#option (fun o -> o#unknown) t in
+         let o = o#list (fun o -> o#phrase) ps in o
+      | Operation (_x) ->
+          let o = o#name _x in o
       | Handle { sh_expr; sh_effect_cases; sh_value_cases; sh_descr } ->
          let o = o#phrase sh_expr in
          let o =
@@ -1443,6 +1452,9 @@ class fold =
       | Record _x -> let o = o#row _x in o
       | Variant _x -> let o = o#row _x in o
       | Effect r -> let o = o#row r in o
+      | Operation (_x, _x_i1) ->
+        let o = o#list (fun o -> o#datatype) _x in
+        let o = o#datatype _x_i1 in o
       | Table (_t, _x, _x_i1, _x_i2) ->
           let o = o#datatype _x in
           let o = o#datatype _x_i1 in
@@ -1936,10 +1948,14 @@ class fold_map =
           let (o, _x_i1) = o#option (fun o -> o#phrase) _x_i1 in
           let o, _x_i2 = o#option (fun o -> o#typ) _x_i2 in
           (o, (ConstructorLit ((_x, _x_i1, _x_i2))))
-      | DoOperation (name, ps, t) ->
+      | DoOperation (op, ps, t) ->
+          let (o, op) = o#phrase op in
           let (o, t) = o#option (fun o -> o#typ) t in
           let (o, ps) = o#list (fun o -> o#phrase) ps in
-          (o, DoOperation (name, ps, t))
+          (o, DoOperation (op, ps, t))
+      | Operation _x ->
+          let (o, _x) = o#name _x in
+          (o, Operation _x)
       | Handle { sh_expr; sh_effect_cases; sh_value_cases; sh_descr } ->
           let (o, m) = o#phrase sh_expr in
           let (o, params) =
@@ -2353,6 +2369,9 @@ class fold_map =
       | Record _x -> let (o, _x) = o#row _x in (o, (Record _x))
       | Variant _x -> let (o, _x) = o#row _x in (o, (Variant _x))
       | Effect r -> let (o, r) = o#row r in (o, Effect r)
+      | Operation (_x, _x_i1) ->
+        let (o, _x) = o#list (fun o -> o#datatype) _x in
+        let (o, _x_i1) = o#datatype _x_i1 in (o, Operation (_x, _x_i1))
       | Table (_t, _x, _x_i1, _x_i2) ->
           let (o, _x) = o#datatype _x in
           let (o, _x_i1) = o#datatype _x_i1 in

--- a/core/sugartoir.ml
+++ b/core/sugartoir.ml
@@ -982,9 +982,25 @@ struct
               cofv (I.inject (name, I.record ([], None), t))
           | ConstructorLit (name, Some e, Some t) ->
               cofv (I.inject (name, ev e, t))
-          | DoOperation (name, ps, Some t) ->
-             let vs = evs ps in
-             I.do_operation (name, vs, t)
+          | DoOperation (op, ps, Some t) ->
+            let name =
+              let o = (object (o)
+                inherit SugarTraversals.fold as super
+                val mutable opname = None
+
+                method opname = match opname with
+                  | Some name -> name
+                  | None -> failwith "Operation with no name"
+
+                method! phrasenode = function
+                  | Operation name -> opname <- Some name ; o
+                  | p -> super#phrasenode p
+              end)#phrase op in
+              o#opname
+            in
+            let vs = evs ps in
+            I.do_operation (name, vs, t)
+          | Operation _ -> assert false
           | Handle { sh_expr; sh_effect_cases; sh_value_cases; sh_descr } ->
              (* it happens that the ambient effects are the right ones
                 for all of the patterns here (they match those of the

--- a/core/sugartypes.ml
+++ b/core/sugartypes.ml
@@ -195,6 +195,7 @@ module Datatype = struct
     | Record          of row
     | Variant         of row
     | Effect          of row
+    | Operation       of with_pos list * with_pos
     | Table           of Temporality.t * with_pos * with_pos * with_pos
     | List            of with_pos
     | TypeApplication of string * type_arg list
@@ -473,7 +474,8 @@ and phrasenode =
   | Instantiate      of phrase
   | Generalise       of phrase
   | ConstructorLit   of Name.t * phrase option * Types.datatype option
-  | DoOperation      of Name.t * phrase list * Types.datatype option
+  | DoOperation      of phrase * phrase list * Types.datatype option
+  | Operation        of Name.t
   | Handle           of handler
   | Switch           of phrase * (Pattern.with_pos * phrase) list *
                           Types.datatype option
@@ -791,6 +793,7 @@ struct
                      diff (union_map (snd ->- phrase) fields) pat_bound]
     | DBTemporalJoin (_, p, _) -> phrase p
     | DoOperation (_, ps, _) -> union_map phrase ps
+    | Operation _ -> empty
     | QualifiedVar _ -> empty
     | TryInOtherwise (p1, pat, p2, p3, _ty) ->
        union (union_map phrase [p1; p2; p3]) (pattern pat)

--- a/core/typeSugar.ml
+++ b/core/typeSugar.ml
@@ -139,6 +139,7 @@ struct
     | LensGetLit _
     | LensPutLit _
     | DoOperation _
+    | Operation _
     | DBDelete _
     | DBInsert _
     | TryInOtherwise _
@@ -1669,7 +1670,15 @@ let empty_context eff desugared =
 let bind_var         context (v, t) = {context with var_env    = Env.bind v t context.var_env}
 let unbind_var       context v      = {context with var_env    = Env.unbind v context.var_env}
 let bind_alias       context (v, t) = {context with tycon_env  = Env.bind v t context.tycon_env}
-let bind_effects     context r      = {context with effect_row = r}
+let bind_effects     context r      = {context with effect_row = Types.flatten_row r}
+
+let lookup_effect    context name   =
+  match context.effect_row with
+  | Types.Row (fields, _, _) -> begin match Utility.StringMap.find_opt name fields with
+      | Some (Types.Present t) -> Some t
+      | _ -> None
+    end
+  | _ -> raise (internal_error "Effect row in the context is not a row")
 
 (* TODO(dhil): I have extracted the Usage abstraction from my name
    hygiene/compilation unit patch. The below module is a compatibility
@@ -2116,6 +2125,7 @@ let close_pattern_type : Pattern.with_pos list -> Types.datatype -> Types.dataty
       | Primitive _
       | Function _
       | Lolli _
+      | Operation _
       | Table _
       | Lens _
       (* TODO: do we need to do something special for session types? *)
@@ -2272,7 +2282,7 @@ let type_pattern ?(linear_vars=true) closed
      using types from the inner type.
 
   *)
-  let rec type_pattern {node = pattern; pos = pos'} : Pattern.with_pos * (Types.datatype * Types.datatype) =
+  let rec type_pattern ?ann {node = pattern; pos = pos'} : Pattern.with_pos * (Types.datatype * Types.datatype) =
     let _UNKNOWN_POS_ = "<unknown>" in
     let tp = type_pattern in
     let unify (l, r) = unify_or_raise ~pos:pos' (l, r)
@@ -2363,18 +2373,27 @@ let type_pattern ?(linear_vars=true) closed
              (* Construct operation type, i.e. op : A -> B or op : B *)
              match domain, codomain with
              | [], [] | _, [] -> assert false (* The continuation is at least unary *)
-             | [], [t] -> Function (Types.unit_type, Types.make_empty_closed_row (), t)
+             | [], [t] -> Types.Operation (Types.unit_type, t)
              | [], ts -> Types.make_tuple_type ts
              | ts, [t] ->
-                Types.make_function_type ts (Types.make_empty_closed_row ()) t
+                Types.make_operation_type ts t
              | ts, ts' ->
                 (* parameterised continuation *)
                 let t = ListUtils.last ts' in
-                Types.make_function_type ts (Types.make_empty_closed_row ()) t
+                Types.make_operation_type ts t
            in
-           Types.Effect (make_singleton_row (name, Present t))
+           t
          in
-         Pattern.Operation (name, List.map erase ps, erase k), (eff ot, eff it)
+         let ot, it = match ann with
+         | Some t ->
+           let ot, _it = eff ot, eff it in
+           let _, t_free = TypeUtils.split_quantified_type t in
+           let () = unify ~handle:Gripers.pattern_annotation ((_UNKNOWN_POS_, ot), (_UNKNOWN_POS_, t_free)) in
+           t, t
+         | None ->
+           (eff ot, eff it)
+         in
+         Pattern.Operation (name, List.map erase ps, erase k), (ot, it)
       | Negative names ->
         let row_var = Types.fresh_row_variable (lin_any, res_any) in
 
@@ -2424,7 +2443,7 @@ let type_pattern ?(linear_vars=true) closed
         let p = tp p in
         As (Binder.set_type bndr (it p), erase p), (ot p, it p)
       | HasType (p, (_,Some t as t')) ->
-        let p = tp p in
+        let p = tp ~ann:t p in
         let () = unify ~handle:Gripers.pattern_annotation ((pos p, it p), (_UNKNOWN_POS_, t)) in
         HasType (erase p, t'), (ot p, t)
       | HasType _ -> assert false in
@@ -2610,6 +2629,23 @@ let rec type_check : context -> phrase -> phrase * Types.datatype * Usage.t =
           let wild_open = Types.(open_row default_effect_subkind closed_wild_row) in
           unify ~handle:Gripers.recursive_usage (no_pos (Types.Effect wild_open), (uexp_pos e, Types.Effect context.effect_row));
         end;
+    in
+
+    let find_opname phrase =
+      let o = object (o)
+        inherit SugarTraversals.fold as super
+        val mutable opname = None
+
+        method opname = match opname with
+          | Some name -> name
+          | None -> failwith "Operation with no name"
+
+        method! phrasenode = function
+          | Operation name -> opname <- Some name ; o
+          | p -> super#phrasenode p
+      end in
+      let o = o#phrase phrase in
+      o#opname
     in
 
     let module T = Types in
@@ -3366,7 +3402,7 @@ let rec type_check : context -> phrase -> phrase * Types.datatype * Usage.t =
             let inner_effects = Types.row_with Types.wild_present pid_effects in
             let inner_effects =
               if Settings.get  Basicsettings.Sessions.exceptions_enabled then
-                let ty = Types.make_pure_function_type [] (Types.empty_type) in
+                let ty = Types.make_operation_type [] (Types.empty_type) in
                 Types.row_with (Value.session_exception_operation, T.Present ty) inner_effects
               else
                 inner_effects in
@@ -3933,42 +3969,9 @@ let rec type_check : context -> phrase -> phrase * Types.datatype * Usage.t =
               then raise (Errors.disabled_extension
                             ~pos ~setting:("enable_handlers", true)
                             ~flag:"--enable-handlers" "Handlers"));
-           let rec pop_last = function
-             | [] -> assert false
-             | [x] -> x, []
-             | x' :: xs ->
-                let (x, xs') = pop_last xs in
-                x, x' :: xs'
-           in
-           (* allow_wild adds wild : () to the given effect row *)
            let allow_wild : Types.row -> Types.row
              = fun row ->
              Types.(row_with wild_present row)
-           in
-           (* returns a pair of lists whose first component is the
-               value clauses, while the second component is the
-               operation clauses *)
-           let split_handler_cases : (Pattern.with_pos * phrase) list -> (Pattern.with_pos * phrase) list * (Pattern.with_pos * phrase) list
-             = fun cases ->
-             let ret, ops =
-               List.fold_right
-                 (fun (pat, body) (val_cases, eff_cases) ->
-                   match pat.node with
-                   | Pattern.Variant ("Return", None) ->
-                      Gripers.die pat.pos "Improper pattern-matching on return value"
-                   | Pattern.Variant ("Return", Some pat) ->
-                      (pat, body) :: val_cases, eff_cases
-                   | _ -> val_cases, (pat, body) :: eff_cases)
-                 cases ([], [])
-             in
-             let ret = match ret with
-               | [] -> (* insert a synthetic value case: x -> x. *)
-                  let x = "x" in
-                  let id = (variable_pat x, var x) in
-                  [id]
-               | _ -> ret
-             in
-             ret, ops
            in
            (* type parameters *)
            let henv = context in
@@ -4025,26 +4028,11 @@ let rec type_check : context -> phrase -> phrase * Types.datatype * Usage.t =
                List.fold_right
                  (fun (pat, body) cases ->
                    let pat =
-                     let open Pattern in
                      match pat with
-                     | { node = Variant (opname, Some pat'); _ } ->
-                        begin match pat'.node with
-                        | Tuple [] ->
-                           with_dummy_pos (Operation (opname, [], with_dummy_pos Pattern.Any))
-                        | Tuple ps ->
-                           let kpat, pats = pop_last ps in
-                           with_dummy_pos (Operation (opname, pats, kpat))
-                        | _ -> with_pos pos (Operation (opname, [], pat'))
-                        end
-                     | { node = Variant (opname, None); pos } ->
-                        with_pos pos (Operation (opname, [], with_dummy_pos Pattern.Any))
-                     (* already compiled to an effect *)
-                     | { node = Operation _; pos = _ } ->
-                        pat
+                     | { node = Pattern.Operation _; pos = _ }
+                     | { node = Pattern.HasType _; pos = _ } -> pat
                      | { pos; _ } -> Gripers.die pos "Improper pattern matching" in
                    let pat = tpo pat in
-                   unify ~handle:Gripers.handle_effect_patterns
-                         (ppos_and_typ pat, no_pos (T.Effect inner_eff));
                    (* We may have to patch up the inferred resumption
                       type as `type_pattern' cannot infer the
                       principal type for a resumption in a
@@ -4052,12 +4040,22 @@ let rec type_check : context -> phrase -> phrase * Types.datatype * Usage.t =
                       to information which is not conveyed by
                       pattern. TODO: perhaps augment the pattern with
                       arity information. *)
-                   let (pat, env, effrow) = pat in
-                   let effname, kpat =
-                     match pat.node with
-                     | Pattern.Operation (name, _, kpat) -> name, kpat
+                   let (pat, env, efftyp) = pat in
+                   let pat =
+                     let rec erase_ann pat = match pat.node with
+                     | Pattern.Operation _ -> pat
+                     | Pattern.HasType (p, _) -> erase_ann p
+                     | _ -> assert false
+                     in
+                     erase_ann pat
+                   in
+                   let effname, kpat = match pat.node with
+                     | Pattern.Operation (name, _, k) -> name, k
                      | _ -> assert false
                    in
+                   let effrow = Types.Effect (Types.make_singleton_open_row (effname, Types.Present efftyp) (lin_any, res_any)) in
+                   unify ~handle:Gripers.handle_effect_patterns
+                         ((uexp_pos pat, effrow),  no_pos (T.Effect inner_eff));
                    let pat, kpat =
                      let rec find_effect_type eff = function
                        | (eff', t) :: _ when eff = eff' ->
@@ -4186,9 +4184,9 @@ let rec type_check : context -> phrase -> phrase * Types.datatype * Usage.t =
            in
            (* make_operations_presence_polymorphic makes the operations in the given row polymorphic in their presence *)
            let make_operations_presence_polymorphic : Types.row -> Types.row
-         = fun row ->
+            = fun row ->
              let (operations, rho, dual) = TypeUtils.extract_row_parts row in
-         let operations' =
+              let operations' =
                StringMap.mapi
                  (fun name p ->
                    if TypeUtils.is_builtin_effect name
@@ -4197,19 +4195,18 @@ let rec type_check : context -> phrase -> phrase * Types.datatype * Usage.t =
                                                                        make absent operations polymorphic in their presence. *)
                  operations
              in
-         T.Row (operations', rho, dual)
+            T.Row (operations', rho, dual)
            in
            let m_context = { context with effect_row = Types.make_empty_open_row default_effect_subkind } in
            let m = type_check m_context m in (* Type-check the input computation m under current context *)
            let m_effects = T.Effect m_context.effect_row in
            (* Most of the work is done by `type_cases'. *)
-           let (val_cases, eff_cases) =
-             (* The following is a slight hack until I get rid of the
-                 `handler' sugar. It is necessary because of "old
-                 fashioned" parameterised handlers. *)
-             match val_cases with
-             | [] -> split_handler_cases eff_cases
-             | _  -> val_cases, eff_cases
+           let val_cases = match val_cases with
+             | [] -> (* insert a synthetic value case: x -> x. *)
+                  let x = "x" in
+                  let id = (variable_pat x, var x) in
+                  [id]
+             | _  -> val_cases
            in
            let (val_cases, rt), eff_cases, body_type, inner_eff, outer_eff = type_cases val_cases eff_cases in
            (* Printf.printf "result: %s\ninner_eff: %s\nouter_eff: %s\n%!" (Types.string_of_datatype rt) (Types.string_of_row inner_eff) (Types.string_of_row outer_eff); *)
@@ -4245,31 +4242,69 @@ let rec type_check : context -> phrase -> phrase * Types.datatype * Usage.t =
                     sh_effect_cases = erase_cases eff_cases;
                     sh_value_cases = erase_cases val_cases;
                     sh_descr = descr }, body_type, usages
-        | DoOperation (opname, args, _) ->
-           (* Strategy:
-              1. List.map tc args
-              2. Construct operation type
-              3. Construct effect row where the operation name gets bound to the previously constructed operation type
-              4. Unify with current effect context
-           *)
-           if String.compare opname "Return" = 0 then
-             Gripers.die pos "The implicit effect Return is not invocable"
-           else if String.compare opname Value.session_exception_operation = 0 && not context.desugared then
+        | DoOperation (op, ps, _) ->
+          let op = tc op in
+          let ps = List.map (tc) ps in
+          let doop, rettyp, usage, opt  =
+            match Types.concrete_type (typ op) with
+            | T.ForAll (_, (T.Operation _)) as t ->
+              begin
+                match Instantiate.typ t with
+                | tyargs, T.Operation (pts, rettyp) ->
+                  (* quantifiers for the return type *)
+                  let rqs =
+                    (* the free type variables in the arguments (and effects) *)
+                    let arg_vars = Types.free_type_vars pts in
+                    (* return true if this quantifier appears free in the arguments (or effects) *)
+                    let free_in_arg q = Types.TypeVarSet.mem (Quantifier.to_var q) arg_vars in
+                    if Settings.get  dodgey_type_isomorphism then
+                      let rta, rqs =
+                        List.map (fun q -> (q, Types.quantifier_of_type_arg q)) tyargs
+                        |> List.filter (fun (_, q) -> free_in_arg q)
+                        |> List.split
+                      in
+                      List.iter Generalise.rigidify_type_arg rta;
+                      rqs
+                    else
+                      []
+                  in
+
+                  let rettyp = Types.for_all (rqs, rettyp) in
+                  let opt = T.Operation (pts, rettyp) in
+                  let op' = erase op in
+                  let sugar_rqs = List.map SugarQuantifier.mk_resolved rqs in
+                  let e = tabstr (sugar_rqs, DoOperation (with_dummy_pos (tappl (op'.node, tyargs)), List.map erase ps, Some rettyp)) in
+                    e, rettyp, Usage.combine_many (usages op :: List.map usages ps), opt
+                | _ -> assert false
+              end
+            | T.Operation (_, rettyp) as opt ->
+                DoOperation (erase op, List.map erase ps, Some rettyp), rettyp, Usage.combine_many (usages op :: List.map usages ps), opt
+            | opt ->
+              let rettyp = Types.fresh_type_variable (lin_unl, res_any) in
+                DoOperation (erase op, List.map erase ps, Some rettyp), rettyp, Usage.combine_many (usages op :: List.map usages ps), opt
+          in
+
+          let opname = find_opname (erase op) in
+          let infer_opt = no_pos (Types.make_operation_type (List.map typ ps) rettyp) in
+          let term = (exp_pos op, opt) in
+          let row = Types.make_singleton_open_row (opname, T.Present (typ op)) (lin_unl, res_effect) in
+          let p = Position.resolve_expression pos in
+          let () =
+            unify ~handle:Gripers.do_operation
+              (term, infer_opt) ;
+            unify ~handle:Gripers.do_operation
+              (no_pos (T.Effect context.effect_row), (p, T.Effect row))
+          in
+            doop, rettyp, usage
+        | Operation name ->
+           if String.compare name Value.session_exception_operation = 0 && not context.desugared then
              Gripers.die pos "The session failure effect SessionFail is not directly invocable (use `raise` instead)"
            else
-           let (row, return_type, args) =
-             let ps     = List.map tc args in
-             let inp_t  = List.map typ ps in
-             let out_t  = Types.fresh_type_variable (lin_unl, res_any) in
-             let optype = Types.make_pure_function_type inp_t out_t in
-             let effrow = Types.make_singleton_open_row (opname, T.Present optype) (lin_unl, res_effect) in
-             (effrow, out_t, ps)
-           in
-           let p = Position.resolve_expression pos in
-           let () = unify ~handle:Gripers.do_operation
-             (no_pos (T.Effect context.effect_row), (p, T.Effect row))
-           in
-             (DoOperation (opname, List.map erase args, Some return_type), return_type, Usage.combine_many (List.map usages args))
+             let t = match lookup_effect context name with
+               | Some t -> t
+               | None   -> Types.fresh_type_variable (lin_unl, res_any)
+             in
+             (Operation name, t, Usage.empty)
         | Switch (e, binders, _) ->
             let e = tc e in
             let binders, pattern_type, body_type = type_cases binders in
@@ -4286,7 +4321,7 @@ let rec type_check : context -> phrase -> phrase * Types.datatype * Usage.t =
                 (T.Row (StringMap.empty, rho, false)) in
             let try_effects =
               Types.row_with
-                (Value.session_exception_operation, T.Present (Types.make_pure_function_type [] Types.empty_type))
+                (Value.session_exception_operation, T.Present (Types.make_operation_type [] Types.empty_type))
                 (T.Row (StringMap.empty, rho, false)) in
 
             unify ~handle:Gripers.try_effect
@@ -4366,7 +4401,7 @@ let rec type_check : context -> phrase -> phrase * Types.datatype * Usage.t =
         | QualifiedVar _ -> assert false
         | Raise ->
             let effects = Types.make_singleton_open_row
-                            (Value.session_exception_operation, T.Present (Types.make_pure_function_type [] Types.empty_type))
+                            (Value.session_exception_operation, T.Present (Types.make_operation_type [] Types.empty_type))
                             default_effect_subkind
             in
             unify ~handle:Gripers.raise_effect

--- a/core/typeUtils.ml
+++ b/core/typeUtils.ml
@@ -126,6 +126,7 @@ let rec return_type ?(overstep_quantifiers=true) t = match (concrete_type t, ove
   | (ForAll (_, t), true) -> return_type t
   | (Function (_, _, t), _) -> t
   | (Lolli (_, _, t), _) -> t
+  | (Operation (_, t), _) -> t
   | (t, _) ->
       error ("Attempt to take return type of non-function: " ^ string_of_datatype t)
 
@@ -248,6 +249,7 @@ let rec primary_kind_of_type t =
   | ForAll _
   | Application _
   | RecursiveApplication _
+  | Operation _
   | Input _
   | Output _
   | Select _
@@ -357,6 +359,9 @@ let check_type_wellformedness primary_kind t : unit =
     | Effect row ->
        irow row;
        pk_row
+    | Operation (f, t) ->
+       idatatype f; idatatype t;
+       pk_type
     (* Presence *)
     | Present t ->
        idatatype t;

--- a/core/types.ml
+++ b/core/types.ml
@@ -153,6 +153,7 @@ and typ =
   | ForAll of (Quantifier.t list * typ)
   (* Effect *)
   | Effect of row
+  | Operation of (typ * typ)
   (* Row *)
   | Row of (field_spec_map * row_var * bool)
   | Closed
@@ -383,6 +384,10 @@ struct
       | Effect row ->
          let (o, row') = o#row row in
          (o, Effect row')
+      | Operation (dom, cod) ->
+         let (o, dom') = o#typ dom in
+         let (o, cod') = o#typ cod in
+         (o, Operation(dom', cod'))
       (* Row *)
       | Row (fsp, rv, d) ->
          let (o, fsp') = o#field_spec_map fsp in
@@ -594,7 +599,7 @@ class virtual type_predicate = object(self)
     | Absent -> true
     | Present t -> self#type_satisfies vars t
     | Select r | Choice r -> self#row_satisfies vars r
-    | Input (a, b) | Output (a, b) -> self#type_satisfies vars a && self#type_satisfies vars b
+    | Input (a, b) | Output (a, b) | Operation (a, b) -> self#type_satisfies vars a && self#type_satisfies vars b
     | Dual s -> self#type_satisfies vars s
     | End -> true
 
@@ -657,6 +662,7 @@ class virtual type_iter = object(self)
        self#visit_type (rec_appl, rec_vars, TypeVarSet.add_quantifiers qs quant_vars) t
     (* Effect *)
     | Effect r -> self#visit_row vars r
+    | Operation (a, b) -> self#visit_type vars a; self#visit_type vars b
     (* Row *)
     | Row (fields, row_var, _dual) ->
        self#visit_point self#visit_row vars row_var;
@@ -756,6 +762,7 @@ module Base : Constraint = struct
         | ForAll ([], t) -> super#type_satisfies vars t
         (* Effect *)
         | Effect _ as t -> super#type_satisfies vars t
+        | Operation _ -> failwith "TODO types.ml/766"
         (* Row *)
         | Row _ as t -> super#type_satisfies vars t
         (* Presence *)
@@ -803,6 +810,7 @@ module Unl : Constraint = struct
       | ForAll _ as t -> super#type_satisfies vars t
       (* Effect *)
       | Effect _  -> true
+      | Operation _ -> true
       (* Row *)
       | Row _ as t -> super#type_satisfies vars t
       (* Presence *)
@@ -850,6 +858,7 @@ module Unl : Constraint = struct
        | ForAll _ as t -> super#visit_type vars t
        (* Effect *)
        | Effect _ -> ()
+       | Operation _ -> ()
        (* Row *)
        | Row _ as t -> super#visit_type vars t
        (* Presence *)
@@ -897,6 +906,7 @@ module Session : Constraint = struct
         | Primitive _ | Function _ | Lolli _ | Record _ | Variant _ | Table _ | Lens _ | ForAll _ -> false
         (* Effect *)
         | Effect _  -> false
+        | Operation _ -> failwith "TODO types.ml/910"
     end
   end
 
@@ -1160,6 +1170,8 @@ let free_type_vars, free_row_type_vars, free_tyarg_vars =
     | Lolli (f, m, t)         ->
        S.union_all [free_type_vars' rec_vars f; free_row_type_vars' rec_vars m; free_type_vars' rec_vars t]
     | Effect row | Record row | Variant row -> free_row_type_vars' rec_vars row
+    | Operation (f, t) ->
+       S.union_all [free_type_vars' rec_vars f; free_type_vars' rec_vars t]
     | Table (_, r, w, n)         ->
        S.union_all
          [free_type_vars' rec_vars r; free_type_vars' rec_vars w; free_type_vars' rec_vars n]
@@ -1357,6 +1369,7 @@ and subst_dual_type : var_map -> datatype -> datatype =
   | Record row -> Record (sdr row)
   | Variant row -> Variant (sdr row)
   | Effect row -> Effect (sdr row)
+  | Operation (f, t) -> Operation (sdt f, sdt t)
   | Table (t, r, w, n) -> Table (t, sdt r, sdt w, sdt n)
   | Lens _sort -> t
   (* TODO: we could do a check to see if we can preserve aliases here *)
@@ -1562,6 +1575,7 @@ and normalise_datatype rec_names t =
   | Record row              -> Record (nr row)
   | Variant row             -> Variant (nr row)
   | Effect row              -> Effect (nr row)
+  | Operation (f, t)        -> Operation (nt f, nt t)
   | Table (t, r, w, n)      -> Table (t, nt r, nt w, nt n)
   | Lens sort               -> Lens sort
   | Alias (k, (name, qs, ts, is_dual), datatype) ->
@@ -1869,6 +1883,8 @@ struct
        (List.rev vars) @ (free_bound_type_vars bound_vars body)
     (* Effect *)
     | Effect row -> free_bound_row_type_vars bound_vars row
+    | Operation (f, t) ->
+       (fbtv f) @ (fbtv t)
     (* Row *)
     | Row (field_env, row_var, _) ->
        let field_type_vars =
@@ -2633,6 +2649,7 @@ struct
               "forall "^ mapstrcat "," (quantifier p) tyvars ^"."^ datatype { context with bound_vars } p body
          (* Effect *)
          | Effect r -> "{" ^ row "," context p r ^ "}"
+         | Operation (f, t) -> sd f ^ " => " ^ sd t
          (* Row *)
          | Row _ as t -> "{" ^ row "," context p t ^ "}"
          (* Presence *)
@@ -3107,7 +3124,7 @@ module RoundtripPrinter : PRETTY_PRINTER = struct
             method effect_row : row -> 'self_type * row_erasability * tid option
               = let maybe_contract : typ -> typ
                   = function
-                  | Function (d,_,c) as tp when ES.contract_operation_arrows policy ->
+                  | Operation (d,c) as tp when ES.contract_operation_arrows policy ->
                      (* we are in an operation fieldspec and it's an arrow, and we
                       want contractions: check if a contraction is possible here
                       *)
@@ -3782,7 +3799,7 @@ module RoundtripPrinter : PRETTY_PRINTER = struct
              StringBuffer.write buf ")"
         )
 
-  and func : (typ * row * typ) printer
+   and func : (typ * row * typ) printer
     = let open Printer in
       let func_arrow : row printer
         = let is_field_present fields lbl =
@@ -3904,6 +3921,15 @@ module RoundtripPrinter : PRETTY_PRINTER = struct
           StringBuffer.write buf " ";
 
 
+          Printer.apply datatype ctx range buf;
+        )
+
+  and op : (typ * typ) printer
+    = let open Printer in
+      Printer (fun ctx (domain, range) buf ->
+          (* build up the function type string: domain, arrow with effects, range *)
+          Printer.apply row (Context.set_ambient Context.Tuple ctx) domain buf; (* function domain is always a Record *)
+          StringBuffer.write buf " => ";
           Printer.apply datatype ctx range buf;
         )
 
@@ -4038,6 +4064,8 @@ module RoundtripPrinter : PRETTY_PRINTER = struct
 
             | Record _ | Variant _ | Effect _ | Row _ | Select _ | Choice _
               -> with_value row tp
+
+            | Operation o        -> with_value op o
 
             | _ -> raise (internal_error ("Printer for this type not implemented:\n" ^ show_datatype @@ DecycleTypes.datatype tp))
           in
@@ -4360,6 +4388,7 @@ let make_fresh_envs : datatype -> datatype IntMap.t * row IntMap.t * field_spec 
     | Function (f, m, t)      -> union [make_env boundvars f; make_env boundvars m; make_env boundvars t]
     | Lolli (f, m, t)         -> union [make_env boundvars f; make_env boundvars m; make_env boundvars t]
     | Effect row | Record row | Variant row -> make_env boundvars row
+    | Operation (f, t)        -> union [make_env boundvars f; make_env boundvars t]
     | Table (_, r, w, n)      -> union [make_env boundvars r; make_env boundvars w; make_env boundvars n]
     | Lens _                  -> empties
     | Alias (_, (_, _, ts, _), d) -> union (List.map (make_env_ta boundvars) ts @ [make_env boundvars d])
@@ -4666,6 +4695,10 @@ let make_function_type : ?linear:bool -> datatype list -> row -> datatype -> dat
     Lolli (make_tuple_type args, effs, range)
   else
     Function (make_tuple_type args, effs, range)
+
+let make_operation_type : datatype list -> datatype -> datatype
+  = fun args range ->
+  Operation (make_tuple_type args, range)
 
 let make_pure_function_type : datatype list -> datatype -> datatype
   = fun domain range -> make_function_type domain (make_empty_closed_row ()) range

--- a/core/types.mli
+++ b/core/types.mli
@@ -144,6 +144,7 @@ and typ =
   | ForAll of (Quantifier.t list * typ)
   (* Effect *)
   | Effect of row
+  | Operation of (typ * typ)
   (* Row *)
   | Row of (field_spec_map * row_var * bool)
   | Closed
@@ -429,6 +430,7 @@ val add_tyvar_names : ('a -> Vars.vars_list)
 (* Function type constructors *)
 val make_pure_function_type : datatype list -> datatype -> datatype
 val make_function_type      : ?linear:bool -> datatype list -> row -> datatype -> datatype
+val make_operation_type : datatype list -> datatype -> datatype
 val make_thunk_type : row -> datatype -> datatype
 
 

--- a/core/typevarcheck.ml
+++ b/core/typevarcheck.ml
@@ -87,6 +87,8 @@ let rec is_guarded : TypeVarSet.t -> StringSet.t -> int -> datatype -> bool =
               expanded_apps var t
         (* Effect *)
         | Effect row -> isgr row
+        | Operation (f, t) ->
+            isg f && isg t
         (* Row *)
         | Row (fields, row_var, _dual) ->
            let check_fields = false in
@@ -174,6 +176,8 @@ let rec is_negative : TypeVarSet.t -> StringSet.t -> int -> datatype -> bool =
               expanded_apps var t
         (* Effect *)
         | Effect row -> isnr row
+        | Operation (f, t) ->
+            isp f || isn t
         (* Row *)
         | Row (field_env, row_var, _dual) ->
            is_negative_field_env bound_vars expanded_apps var field_env
@@ -261,6 +265,8 @@ and is_positive : TypeVarSet.t -> StringSet.t -> int -> datatype -> bool =
               expanded_apps var t
         (* Effect *)
         | Effect row -> ispr row
+        | Operation (f, t) ->
+            isn f || isp t
         (* Row *)
         | Row (field_env, row_var, _dual) ->
            is_positive_field_env bound_vars expanded_apps var field_env

--- a/core/unify.ml
+++ b/core/unify.ml
@@ -160,6 +160,12 @@ let rec eq_types : (datatype * datatype) -> bool =
          | Effect r -> eq_rows (l, r)
          | _        -> false
          end
+      | Operation (lfrom, lto) ->
+          begin match unalias t2 with
+          | Operation (rfrom, rto) -> eq_types (lfrom, rfrom)
+                                         && eq_types (lto,   rto)
+          | _                          -> false
+          end
       (* Row *)
       | Row (lfield_env, lrow_var, ldual) ->
          begin match unalias t2 with
@@ -681,6 +687,9 @@ let rec unify' : unify_env -> (datatype * datatype) -> unit =
     | (Present _ | Absent), (Present _ | Absent) -> unify_presence' rec_env (t1, t2)
     (* Effect *)
     | Effect (Row l), Effect (Row r) -> ur (l, r)
+    | Operation (lfrom, lto), Operation (rfrom, rto) ->
+       (ut (lfrom, rfrom);
+        ut (lto, rto))
     (* Session *)
     | Input (t, s), Input (t', s')
     | Output (t, s), Output (t', s') -> unify' rec_env (t, t'); ut (s, s')

--- a/examples/handlers/aop.links
+++ b/examples/handlers/aop.links
@@ -3,7 +3,7 @@ typename Zero = [||];
 typename Comp(e::Row,a) = (() ~e~> a);
 
 sig runState :
-        (Comp ({Get:(()) {}-> s,Put:(s) {}-> ()|e}, a)) ->
+        (Comp ({Get:(()) => s,Put:(s) => ()|e}, a)) ->
   (s) -> Comp ({Get{_},         Put{_}         |e}, (a, s))
 fun runState(m)(s)() {
   (handle(m()) {
@@ -14,7 +14,7 @@ fun runState(m)(s)() {
 }
 
 sig evalState :
-        (Comp ({Get:(()) {}-> s,Put:(s) {}-> ()|e}, a)) ->
+        (Comp ({Get:(()) => s,Put:(s) => ()|e}, a)) ->
   (s) -> Comp ({Get{_},         Put{_}         |e}, a)
 fun evalState(m)(s)() {
   (handle(m()) {
@@ -25,7 +25,7 @@ fun evalState(m)(s)() {
 }
 
 sig runStringWriter :
-             (Comp ({Tell:(String) {}-> ()|e}, a)) ->
+             (Comp ({Tell:(String) => ()|e}, a)) ->
   (String) -> Comp ({Tell{_}              |e}, (a, String))
 fun runStringWriter(m)(s)() {
   (handle(m()) {
@@ -35,7 +35,7 @@ fun runStringWriter(m)(s)() {
 }
 
 sig printer :
-  (Comp ({Tell:(String) {}-> ()}, a)) {}~> a
+  (Comp ({Tell:(String) => ()}, a)) {}~> a
 fun printer(m) {
   handle(m()) {
      case x -> x
@@ -44,13 +44,13 @@ fun printer(m) {
 }
 
 
-sig get : () {Get:(()) {}-> s|_}~> s
+sig get : () {Get:(()) => s|_}~> s
 fun get() {do Get(())}
 
-sig put : (s) {Put:(s) {}-> ()|_}~> ()
+sig put : (s) {Put:(s) => ()|_}~> ()
 fun put(s) {do Put(s)}
 
-sig tell : (String) {Tell:(String) {}-> ()|_}~> ()
+sig tell : (String) {Tell:(String) => ()|_}~> ()
 fun tell(s) {do Tell(s)}
 
 typename Expr =
@@ -81,12 +81,12 @@ fun showExpr(e) {
   }
 }
 
-typename SComp(e::Row, a) = (() {Suspend:((Expr, SComp({ |e}, a))) {}-> a|e}~> a);
+typename SComp(e::Row, a) = (() {Suspend:((Expr, SComp({ |e}, a))) => a|e}~> a);
 
 sig suspend :
     (Expr) ->
       (SComp({ |e}, a))
-        {Suspend:((Expr, SComp({ |e}, a))) {}-> a|e}~> a
+        {Suspend:((Expr, SComp({ |e}, a))) => a|e}~> a
 fun suspend(e)(m) {do Suspend((e,m))}
 
 typename Env = [(String, Int)];
@@ -106,7 +106,7 @@ fun showEnv(env) {
 
 mutual {
   sig bevalStep :
-    (Expr) -> SComp ({Get:(()) {}-> Env, Put: (Env) {}-> ()|e}, Int)
+    (Expr) -> SComp ({Get:(()) => Env, Put: (Env) => ()|e}, Int)
   fun bevalStep(exp)() {
     switch(exp) {
       case Lit(x) -> x
@@ -133,10 +133,10 @@ mutual {
     }
   }
 
-  sig beval : (Expr) {Get:(()) {}-> Env,
-                      Put:(Env) {}-> (),
-                      Suspend:((Expr, SComp({Get:(()) {}-> Env,
-                                             Put:(Env) {}-> ()|e}, Int))) {}-> Int|e}~> Int
+  sig beval : (Expr) {Get:(()) => Env,
+                      Put:(Env) => (),
+                      Suspend:((Expr, SComp({Get:(()) => Env,
+                                             Put:(Env) => ()|e}, Int))) => Int|e}~> Int
   fun beval(e) {suspend(e)(bevalStep(e))}
 }
 
@@ -152,8 +152,8 @@ fun force(m)() {
   }
 }
 
-sig logger :  (SComp ({Tell:(String) {}-> ()|e}, Int)) ->
-  (String) -> (SComp ({Tell:(String) {}-> ()|e}, Int))
+sig logger :  (SComp ({Tell:(String) => ()|e}, Int)) ->
+  (String) -> (SComp ({Tell:(String) => ()|e}, Int))
 fun logger(m)(name)() {
   (handle(m()) {
      case x        -> fun (_) {x}
@@ -167,8 +167,8 @@ fun logger(m)(name)() {
    })(name)
 }
 
-sig dump : (SComp ({Get:(()) {}-> Env,Tell:(String) {}-> ()|e}, Int)) ->
-           (SComp ({Get:(()) {}-> Env,Tell:(String) {}-> ()|e}, Int))
+sig dump : (SComp ({Get:(()) => Env,Tell:(String) => ()|e}, Int)) ->
+           (SComp ({Get:(()) => Env,Tell:(String) => ()|e}, Int))
 fun dump(m)() {
   handle(m()) {
      case x        -> x

--- a/examples/handlers/aop2.links
+++ b/examples/handlers/aop2.links
@@ -3,7 +3,7 @@ typename Zero = [||];
 typename Comp(e::Eff,a) = (() ~e~> a);
 
 sig runState :
-        (Comp ({Get:s,  Put:(s) {}-> ()|e}, a)) ->
+        (Comp ({Get:s,  Put:(s) => ()|e}, a)) ->
   (s) -> Comp ({Get{_}, Put{_}         |e}, (a, s))
 fun runState(m)(s)() {
   (handle(m()) {
@@ -14,7 +14,7 @@ fun runState(m)(s)() {
 }
 
 sig evalState :
-        (Comp ({Get:s,  Put:(s) {}-> ()|e}, a)) ->
+        (Comp ({Get:s,  Put:(s) => ()|e}, a)) ->
   (s) -> Comp ({Get{_}, Put{_}         |e}, a)
 fun evalState(m)(s)() {
   (handle(m()) {
@@ -25,7 +25,7 @@ fun evalState(m)(s)() {
 }
 
 sig runStringWriter :
-             (Comp ({Tell:(String) {}-> ()|e}, a)) ->
+             (Comp ({Tell:(String) => ()|e}, a)) ->
   (String) -> Comp ({Tell{_}              |e}, (a, String))
 fun runStringWriter(m)(s)() {
   (handle(m()) {
@@ -35,7 +35,7 @@ fun runStringWriter(m)(s)() {
 }
 
 sig printer :
-  (Comp ({Tell:(String) {}-> ()}, a)) {}~> a
+  (Comp ({Tell:(String) => ()}, a)) {}~> a
 fun printer(m) {
   handle(m()) {
      case x -> x
@@ -46,10 +46,10 @@ fun printer(m) {
 sig get : () {Get:s|_}~> s
 fun get() {do Get}
 
-sig put : (s) {Put:(s) {}-> ()|_}~> ()
+sig put : (s) {Put:(s) => ()|_}~> ()
 fun put(s) {do Put(s)}
 
-sig tell : (String) {Tell:(String) {}-> ()|_}~> ()
+sig tell : (String) {Tell:(String) => ()|_}~> ()
 fun tell(s) {do Tell(s)}
 
 typename Expr =
@@ -81,12 +81,12 @@ fun showExpr(e) {
 }
 
 typename SComp(e::Eff, a) =
-  Comp ({Suspend:(Expr, SComp({ |e}, a)) {}-> a|e}, a);
+  Comp ({Suspend:(Expr, SComp({ |e}, a)) => a|e}, a);
 
 sig suspend :
     (Expr) ->
       (SComp({ |e}, a))
-        {Suspend:(Expr, SComp({ |e}, a)) {}-> a|e}~> a
+        {Suspend:(Expr, SComp({ |e}, a)) => a|e}~> a
 fun suspend(e)(m) {do Suspend(e, m)}
 
 typename Env = [(String, Int)];
@@ -105,7 +105,7 @@ fun showEnv(env) {
 
 mutual {
   sig bevalStep :
-    (Expr) -> SComp ({Get:Env, Put: (Env) {}-> ()|e}, Int)
+    (Expr) -> SComp ({Get:Env, Put: (Env) => ()|e}, Int)
   fun bevalStep(exp)() {
     switch(exp) {
       case Lit(x) -> x
@@ -133,9 +133,9 @@ mutual {
   }
 
   sig beval : (Expr) {Get:Env,
-                      Put:(Env) {}-> (),
+                      Put:(Env) => (),
                       Suspend:(Expr, SComp({Get:Env,
-                                            Put:(Env) {}-> ()|e}, Int)) {}-> Int|e}~> Int
+                                            Put:(Env) => ()|e}, Int)) => Int|e}~> Int
   fun beval(e) {suspend(e)(bevalStep(e))}
 }
 
@@ -151,8 +151,8 @@ fun force(m)() {
   }
 }
 
-sig logger :  (SComp ({Tell:(String) {}-> ()|e}, Int)) ->
-  (String) -> (SComp ({Tell:(String) {}-> ()|e}, Int))
+sig logger :  (SComp ({Tell:(String) => ()|e}, Int)) ->
+  (String) -> (SComp ({Tell:(String) => ()|e}, Int))
 fun logger(m)(name)() {
   (handle(m()) {
      case x        -> fun (_) {x}
@@ -166,8 +166,8 @@ fun logger(m)(name)() {
    })(name)
 }
 
-sig dump : (SComp ({Get:Env, Tell:(String) {}-> ()|e}, Int)) ->
-           (SComp ({Get:Env, Tell:(String) {}-> ()|e}, Int))
+sig dump : (SComp ({Get:Env, Tell:(String) => ()|e}, Int)) ->
+           (SComp ({Get:Env, Tell:(String) => ()|e}, Int))
 fun dump(m)() {
   handle(m()) {
      case x        -> x

--- a/examples/handlers/coins.links
+++ b/examples/handlers/coins.links
@@ -1,16 +1,16 @@
 typename Zero = [||];
 
 typename Comp(a) = (() ~> a);
-typename CF(a, e::Eff) = Comp(a, {Choice: (()) {}-> Bool,
-                                  Failure:(()) {}-> Zero|e});
+typename CF(a, e::Eff) = Comp(a, {Choice: (()) => Bool,
+                                  Failure:(()) => Zero|e});
 
-sig choice : Comp(Bool, {Choice:(()) {}-> Bool|_})
+sig choice : Comp(Bool, {Choice:(()) => Bool|_})
 fun choice() {do Choice(())}
 
-sig choose : (a, a) {Choice:(()) {}-> Bool|_}~> a
+sig choose : (a, a) {Choice:(()) => Bool|_}~> a
 fun choose(x,y) {if (choice()) {x} else {y}}
 
-sig fail : Comp(a, {Failure:(()) {}-> Zero|_})
+sig fail : Comp(a, {Failure:(()) => Zero|_})
 fun fail() {switch (do Failure(())) { }}
 
 sig allResults : (CF(a, {})) {}~> [a]
@@ -38,12 +38,12 @@ fun drunkTosses(n)() {
   for (_ <- [1..n]) [drunkToss()]
 }
 
-sig rand : Comp(Float, {Rand:(()) {}-> Float|_})
+sig rand : Comp(Float, {Rand:(()) => Float|_})
 fun rand() {do Rand(())}
 
 sig randomResult :
-  (Comp(a, {Choice:(()) {}-> Bool, Rand:(()) {}-> Float|e})) -f->
-   Comp(a, {Choice{_},             Rand:(()) {}-> Float|e})
+  (Comp(a, {Choice:(()) => Bool, Rand:(()) => Float|e})) -f->
+   Comp(a, {Choice{_},           Rand:(()) => Float|e})
 fun randomResult(m)() {
   handle(m()) {
     case x    -> x
@@ -51,8 +51,8 @@ fun randomResult(m)() {
   }
 }
 
-sig persevere : (Comp(a, {Failure:(()) {}-> Zero|e})) -f->
-                 Comp(a, {Failure{_}            |e})
+sig persevere : (Comp(a, {Failure:(()) => Zero|e})) -f->
+                 Comp(a, {Failure{_}          |e})
 fun persevere(m)() {
   handle(m()) {
     case x     -> x
@@ -60,8 +60,8 @@ fun persevere(m)() {
   }
 }
 
-sig maybeResult : (Comp(a,        {Failure:(()) {}-> Zero|e})) -f->
-                   Comp(Maybe(a), {Failure{_}            |e})
+sig maybeResult : (Comp(a,        {Failure:(()) => Zero|e})) -f->
+                   Comp(Maybe(a), {Failure{_}          |e})
 fun maybeResult(m)() {
   handle(m()) {
     case x     -> Just(x)
@@ -69,7 +69,7 @@ fun maybeResult(m)() {
   }
 }
 
-sig handleRandom : (Comp(a, {Rand:(()) {}-> Float})) {}~> a
+sig handleRandom : (Comp(a, {Rand:(()) => Float})) {}~> a
 fun handleRandom(m) {
   handle(m()) {
     case x  -> x

--- a/examples/handlers/concurrency.links
+++ b/examples/handlers/concurrency.links
@@ -3,11 +3,11 @@
 #
 
 # type of a concurrent computation
-typename Co(e::Eff) = Comp ((), {Fork  : (Co({ |e})) {}-> (),
+typename Co(e::Eff) = Comp ((), {Fork  : (Co({ |e})) => (),
                                  Yield : () | e});
 
 ## cooperative concurrency interface
-sig fork : (Co({ |e})) {Fork:(Co({ |e})) {}-> ()|_}~> ()
+sig fork : (Co({ |e})) {Fork:(Co({ |e})) => ()|_}~> ()
 fun fork(p) {do Fork(p)}
 
 sig yield : Comp((), {Yield:()|_})
@@ -28,7 +28,7 @@ fun test() {
 }
 
 ## queue interface
-sig enqueue : (a) {Enqueue:(a) {}-> b|e}-> b
+sig enqueue : (a) {Enqueue:(a) => b|e}-> b
 fun enqueue(x) {do Enqueue(x)}
 
 sig dequeue : () {Dequeue:a|e}-> a
@@ -38,12 +38,12 @@ fun dequeue() {do Dequeue}
 
 # process queue computations
 typename Proc(e::Eff) =
-  Comp ((), {Enqueue:(Proc({ |e})) {}-> (),
+  Comp ((), {Enqueue:(Proc({ |e})) => (),
              Dequeue:Maybe(Proc({ |e}))
             |e});
 
 # return true if the process queue is empty
-sig dequeueAndRun : Comp (Bool, {Enqueue:(Proc({ |e})) {}-> (),
+sig dequeueAndRun : Comp (Bool, {Enqueue:(Proc({ |e})) => (),
                                  Dequeue:Maybe(Proc({ |e}))
                                 |e})
 fun dequeueAndRun() {
@@ -67,7 +67,7 @@ fun runAll() {
 
 # defer forked processes
 sig scheduleBreadthFirst :
-  (Co({Enqueue:(Proc({Fork{p}, Yield{q} | e})) {}-> (),
+  (Co({Enqueue:(Proc({Fork{p}, Yield{q} | e})) => (),
        Dequeue:Maybe(Proc({Fork{p}, Yield{q} |e}))
       |e})) ->
    Proc ({Fork{p}, Yield{q} | e})
@@ -81,7 +81,7 @@ fun scheduleBreadthFirst(m)() {
 
 # eagerly run forked processes
 sig scheduleDepthFirst :
-  (Co({Enqueue:(Proc({Fork{p}, Yield{q} | e})) {}-> (),
+  (Co({Enqueue:(Proc({Fork{p}, Yield{q} | e})) => (),
        Dequeue:Maybe(Proc({Fork{p}, Yield{q} |e}))
       |e})) ->
    Proc ({Fork{p}, Yield{q} | e})
@@ -97,7 +97,7 @@ fun scheduleDepthFirst(m)() {
 
 # randomly choose when to run forked processes
 sig scheduleRandom :
-  (Co({Enqueue:(Proc({Fork{p}, Yield{q} | e})) {}-> (),
+  (Co({Enqueue:(Proc({Fork{p}, Yield{q} | e})) => (),
        Dequeue:Maybe(Proc({Fork{p}, Yield{q} |e}))
       |e})) ->
    Proc ({Fork{p}, Yield{q} | e})
@@ -117,7 +117,7 @@ fun scheduleRandom(m)() {
 
 ## queue implementation using a zipper
 sig zipQueue :
-  (Comp (a, {Enqueue:(s) {}-> (), Dequeue:Maybe(s)|e})) ->
+  (Comp (a, {Enqueue:(s) => (), Dequeue:Maybe(s)|e})) ->
    Comp (a, {Enqueue{_},          Dequeue{_}      |e})
 fun zipQueue(m)() {
   handle(m())((front, back) <- ([], [])) {

--- a/examples/handlers/deep_state.links
+++ b/examples/handlers/deep_state.links
@@ -15,16 +15,16 @@ fun run(m) {
 sig get : Comp({Get:a |_}, a)
 fun get() {do Get}
 
-sig put : (a) {Put:(a) {}-> ()|_}~> ()
+sig put : (a) {Put:(a) => ()|_}~> ()
 fun put(p) {do Put(p)}
 
 # Println line operation
-sig logVal : (a) {Log:(a) {}-> ()|_}~> ()
+sig logVal : (a) {Log:(a) => ()|_}~> ()
 fun logVal(p) {do Log(p)}
 
 # Stateful computation evaluator
 sig evalState : (s) ->
-                (Comp({Get:s,Put:(s) {}-> () |e}, a)) ->
+                (Comp({Get:s,Put:(s) => () |e}, a)) ->
                  Comp({Get{_},Put{_}         |e}, a)
 fun evalState(st)(m)() {
   (handle(m()) {
@@ -46,7 +46,7 @@ fun logState(m)() {
 }
 
 # Printlns integers to stdout
-sig logPrinter : (Comp({Log:(Int) {}-> () |e}, a)) ->
+sig logPrinter : (Comp({Log:(Int) => () |e}, a)) ->
                   Comp({Log{_}            |e}, a)
 fun logPrinter(m)() {
   handle(m()) {
@@ -58,7 +58,7 @@ fun logPrinter(m)() {
 
 # Log accumulator
 sig logAccumulator : ([a]) ->
-                     (Comp({Log:(a) {}-> () |e}, b)) ->
+                     (Comp({Log:(a) => () |e}, b)) ->
                       Comp({Log{_}          |e}, (b,[a]))
 fun logAccumulator(ps)(m)() {
   (handle(m()) {

--- a/examples/handlers/exceptions.links
+++ b/examples/handlers/exceptions.links
@@ -6,29 +6,29 @@
 #
 
 # Simulation of input via prompt
-sig input : (String) {Input:(String) {}-> a |_}~> a
+sig input : (String) {Input:(String) => a |_}~> a
 fun input(s) {println(s); do Input(s)}
 
 # Computation summing (simulated) user supplied integers
-sig sumUp : Comp(Int, {Input:(String) {}-> Int |_})
+sig sumUp : Comp(Int, {Input:(String) => Int |_})
 fun sumUp() {
   sum([input("10"), input("20"), input("MMXVII"), input("30")])
 }
 
 # Fail operation to signal conversion failure
-sig fail : (exn) {Fail:(exn) {}-> b |_}-> b
+sig fail : (exn) {Fail:(exn) => b |_}-> b
 fun fail(e) {do Fail(e)}
 
 # String to integer conversion
-sig parseInt : (String) {Fail:(String) {}-> Int|_}-> Int
+sig parseInt : (String) {Fail:(String) => Int|_}-> Int
 fun parseInt(s) {
   if (isInt(s)) stringToInt(s)
   else fail(s)
 }
 
 # Input handling
-sig prompt : (Comp(a, {Fail:(String) {}-> Int,Input:(String) {}-> Int |e})) ->
-              Comp(a, {Fail:(String) {}-> Int,Input{_}                |e})
+sig prompt : (Comp(a, {Fail:(String) => Int,Input:(String) => Int |e})) ->
+              Comp(a, {Fail:(String) => Int,Input{_}                |e})
 fun prompt(m)() {
   handle(m()) {
     case x   -> x
@@ -37,7 +37,7 @@ fun prompt(m)() {
 }
 
 # Standard exception handling
-sig catchFail : (Comp(a, {Fail:(String) {}-> a |e})) -> Comp(a, {Fail{_} |e})
+sig catchFail : (Comp(a, {Fail:(String) => a |e})) -> Comp(a, {Fail{_} |e})
 fun catchFail(m)() {
   handle(m()) {
     case x -> x
@@ -58,7 +58,7 @@ fun example1() {
 }
 
 # Resumable exceptions
-sig catchResume : (Comp(a, {Fail:(String) {}-> Int |e})) -> Comp(a, {Fail{_} |e})
+sig catchResume : (Comp(a, {Fail:(String) => Int |e})) -> Comp(a, {Fail{_} |e})
 fun catchResume(m)() {
   handle(m()) {
     case x -> x
@@ -72,7 +72,7 @@ fun example2() {
 }
 
 # Unit test
-sig sumUpSilently : Comp(Int, {Input:(String) {}-> Int |_})
+sig sumUpSilently : Comp(Int, {Input:(String) => Int |_})
 fun sumUpSilently() {
   fun input(s) {do Input(s)}
   sum([input("10"), input("20"), input("MMXVII"), input("30")])

--- a/examples/handlers/fringe.links
+++ b/examples/handlers/fringe.links
@@ -13,11 +13,11 @@ typename Tree(a) = [|Leaf:a
                     |Node:(Tree(a),Tree(a))|];
 
 # Yield operation for (leaf-)values
-sig yield : (a) {Yield:(a) {}-> ()|_}-> ()
+sig yield : (a) {Yield:(a) => ()|_}-> ()
 fun yield(v) {do Yield(v)}
 
 # Post-order tree traversal
-sig walkTree : (Tree(a)) -f-> Comp((), {Yield:(a) {}-> ()|e})
+sig walkTree : (Tree(a)) -f-> Comp((), {Yield:(a) => ()|e})
 fun walkTree(tree)() {
   switch (tree) {
     case Leaf(v)   -> yield(v)
@@ -31,7 +31,7 @@ typename Status(a) = mu r . [|Done:()
                             |Yielded:(a, Continuation((), r))|];
 
 # Pauses evaluation of a computation whenever Yield occurs
-sig step : (Comp((), { Yield:(a) {}-> () |_})) -> (()) { |_}~> Status(a)
+sig step : (Comp((), { Yield:(a) => () |_})) -> (()) { |_}~> Status(a)
 fun step(f)(()) {
   handle (f()) {
     case () -> Done(())

--- a/examples/handlers/lambda.links
+++ b/examples/handlers/lambda.links
@@ -43,12 +43,12 @@ fun freshVar(pre) {
 }
 
 ## Introduction forms
-sig lam : (Var) {Lam:(Var) -> () |_}-> ()
+sig lam : (Var) {Lam:(Var) => () |_}-> ()
 fun lam(x) {
   do Lam(x)
 }
 
-sig var_ : (Var) {Var:(Var) -> a |_}-> a
+sig var_ : (Var) {Var:(Var) => a |_}-> a
 fun var_(x) {
   do Var(x)
 }
@@ -60,14 +60,14 @@ fun lit(x)() { x }
 
 # Due to the (current) lack of multi-handlers in Links, we are going
 # simulate them by reifying operations.
-typename Expr(a) = Comp(a, {Var:(Var) -> Expr(a), Lam:(Var) -> ()});
+typename Expr(a) = Comp(a, {Var:(Var) => Expr(a), Lam:(Var) => ()});
 typename Step(a) = [|Val:a
                     |Lam:(Var, Expr(a))|];
 
 # The handler `step' big-steps a term to either a value or a
 # lambda-abstraction. Crucially, the handler is shallow such that the
 # effects of continuation of `Lam' can be handled by another handler.
-sig step : (Expr(a)) {Lam{_}, Var:(Var) -> Expr(a)}~> Step(a)
+sig step : (Expr(a)) {Lam{_}, Var:(Var) => Expr(a)}~> Step(a)
 fun step(f) {
   shallowhandle( f() ) {
      case x    -> Val(x)
@@ -76,7 +76,7 @@ fun step(f) {
 }
 
 # Substitution handler M[V/x]
-sig subst : (Expr(a), Expr(a), Var) {Var: (Var) -> Expr(a), Lam: (Var) -> ()}~> a
+sig subst : (Expr(a), Expr(a), Var) {Var: (Var) => Expr(a), Lam: (Var) => ()}~> a
 fun subst(m, v, x) {
   handle( m() ) {
     case <Var(y) => resume> ->

--- a/examples/handlers/light_switch.links
+++ b/examples/handlers/light_switch.links
@@ -2,7 +2,7 @@
 sig get : () {Get:s |_}-> s
 fun get() {do Get}
 
-sig put : (s) {Put:(s) {}-> ()|_}-> ()
+sig put : (s) {Put:(s) => ()|_}-> ()
 fun put(st) {do Put(st)}
 
 #
@@ -11,7 +11,7 @@ fun put(st) {do Put(st)}
 typename LState = [|On|Off|];
 
 # Toggle the light switch
-sig toggle : Comp((), {Get:LState,Put:(LState) {}-> ()|_})
+sig toggle : Comp((), {Get:LState,Put:(LState) => ()|_})
 fun toggle() {
   switch (get()) {
     case Off -> put(On)

--- a/examples/handlers/monadic_reflection.links
+++ b/examples/handlers/monadic_reflection.links
@@ -28,7 +28,7 @@ sig put : (s) -> State(Unit, s)
 fun put(s)(_) {(s, Unit)}
 
 # Reify reflect
-sig reify : (Comp(b, {Reflect:(State(a, s)) {}-> a |_})) { |_}~> State(b, s)
+sig reify : (Comp(b, {Reflect:(State(a, s)) => a |_})) { |_}~> State(b, s)
 fun reify(m) {
   handle(m()) {
     case x     -> return(x)
@@ -36,7 +36,7 @@ fun reify(m) {
   }
 }
 
-sig reflect : (State(a, s)) {Reflect:(State(a, s)) {}-> a |_}-> a
+sig reflect : (State(a, s)) {Reflect:(State(a, s)) => a |_}-> a
 fun reflect(m) {do Reflect(m)}
 
 # Example

--- a/examples/handlers/nim-webversion.links
+++ b/examples/handlers/nim-webversion.links
@@ -82,7 +82,7 @@ fun getField(id){
     domGetAttributeFromRef(getNodeById(id), "value")
 }
 
-sig move: (Player, Int) {Move:(Player, Int) -> Int|e}~> Int
+sig move: (Player, Int) {Move:(Player, Int) => Int|e}~> Int
 fun move(pl, n){
     do Move(pl, n)
 }
@@ -131,7 +131,7 @@ fun easy(pl, n){
 }
 # () for the suspended computation -> moveHandler returns a value so we need to thunk it. same as
 # var pId = spawnClient{runState(fun(){moveHandler(gameProcess)}, (player=(Alice,Bob), level=Easy, cheat=false))};
-sig moveHandler: (() {Move: (Player, Int) -> Int, Restart: Zero, hear:Cmd|e}~> a, (Player, Int) ~%~> Int) -> () {Move-, hear:Cmd, Restart: Zero|e}~> a
+sig moveHandler: (() {Move: (Player, Int) => Int, Restart: Zero, hear:Cmd|e}~> a, (Player, Int) ~%~> Int) -> () {Move-, hear:Cmd, Restart: Zero|e}~> a
 fun moveHandler(f, s)(){
     handle(f()){
         case x -> x
@@ -442,7 +442,7 @@ fun updateView(n, rest, cur){
     appendChildren(step, getNodeById("game-steps"))
 }
 
-sig turn: (Player, Player, Int) {Move: (Player, Int) -> Int|e}~> Player
+sig turn: (Player, Player, Int) {Move: (Player, Int) => Int|e}~> Player
 fun turn(cur, opp, n){
     if(n<= 0){
         cur                                 # Returns the winner
@@ -452,14 +452,14 @@ fun turn(cur, opp, n){
         turn(opp, cur, rest)
     }
 }
-sig game: () {Get: GameState, Move: (Player, Int) -> Int, hear: Cmd |e}~> Player
+sig game: () {Get: GameState, Move: (Player, Int) => Int, hear: Cmd |e}~> Player
 fun game(){
     var st = do Get;
     renderView(Game(st), self());
     turn(st.player.1, st.player.2, st.heap)
 }
 
-sig runState : (() {Get:s, Set:(s) -> () |e}~> a, s) -> () {Get-, Set- |e}~> (a, s)
+sig runState : (() {Get:s, Set:(s) => () |e}~> a, s) -> () {Get-, Set- |e}~> (a, s)
 fun runState(f, st0)(){
     handle(f())(st <- st0){
         case x -> (x, st)
@@ -516,19 +516,19 @@ mutual {
   }
 }
 #handler
-sig setPlayer : (Player, Player) {Get: GameState, Set: (GameState) -> () |e}~> ()
+sig setPlayer : (Player, Player) {Get: GameState, Set: (GameState) => () |e}~> ()
 fun setPlayer(pl1, pl2){
     var st = do Get;
     do Set((st with player=(pl1, pl2)))
 }
 
-sig setLevel : (Level) {Get:GameState, Set: (GameState) -> () |e}~> ()
+sig setLevel : (Level) {Get:GameState, Set: (GameState) => () |e}~> ()
 fun setLevel(lev){
     var st = do Get;
     do Set((st with level=lev))
 }
 
-sig setChecker : (Bool) {Get:GameState, Set: (GameState) -> () |e}~> ()
+sig setChecker : (Bool) {Get:GameState, Set: (GameState) => () |e}~> ()
 fun setChecker(check){
     var st = do Get;
     do Set((st with cheat=check))

--- a/examples/handlers/nim.links
+++ b/examples/handlers/nim.links
@@ -44,19 +44,19 @@ fun showPlayer(player) {
 # Abstract operation "Move"
 # Models a player picking a number of sticks
 # The operation takes the current game configuration as input
-sig move : (Player,Int) {Move:(Player,Int) {}-> Int|_}~> Int
+sig move : (Player,Int) {Move:(Player,Int) => Int|_}~> Int
 fun move(player,n) {do Move(player,n)}
 
 mutual {
   # We model the game as two mutual recursive functions
-  sig aliceTurn : (Int) {Move:(Player,Int) {}-> Int|_}~> Player
+  sig aliceTurn : (Int) {Move:(Player,Int) => Int|_}~> Player
   fun aliceTurn(n) {
     if (n == 0) {Bob} # Bob wins
     else {bobTurn( n - move(Alice,n) )}
   }
 
   # Similarly, we define bobTurn
-  sig bobTurn : (Int) {Move:(Player,Int) {}-> Int|_}~> Player
+  sig bobTurn : (Int) {Move:(Player,Int) => Int|_}~> Player
   fun bobTurn(n) {
     if (n == 0) {Alice} # Alice wins
     else {aliceTurn( n - move(Bob,n) )}
@@ -65,7 +65,7 @@ mutual {
 
 # A game is parameterised by the number of starting sticks,
 # moreover it enforces the rule that Alice always starts
-sig game : (Int) -> Comp(Player,{Move:(Player,Int) {}-> Int|_})
+sig game : (Int) -> Comp(Player,{Move:(Player,Int) => Int|_})
 fun game(n)() {aliceTurn(n)}
 
 #
@@ -79,7 +79,7 @@ sig ns : (Int, (Int) ~e~> a) ~e~> a
 fun ns(n,k) { k(1) }
 
 # The naive-strategy-handler assigns the naive-strategy to both players
-sig naive : (Comp(a, {Move:(Player,Int) -> Int})) {Move{_}}~> a
+sig naive : (Comp(a, {Move:(Player,Int) => Int})) {Move{_}}~> a
 fun naive(m) {
   handle(m()) {
    case <Move(_,n) => k> -> ns(n,k)
@@ -106,7 +106,7 @@ fun ps(n,k) {
 }
 
 # The perfect handler assigns the perfect strategy to both players
-sig perfect : (Comp(a,{Move:(Player,Int) {}-> Int})) {Move{_}}~> a
+sig perfect : (Comp(a,{Move:(Player,Int) => Int})) {Move{_}}~> a
 fun perfect(m) {
   handle(m()) {
     case <Move(_,n) => k> -> ps(n,k)
@@ -126,8 +126,8 @@ fun validMoves(n) {
 
 # The brute force strategy enumerates all future plays
 # if any particular play leads to a win, then play that strategy
-#sig bfs : (a,Int,(Int) {Move:(Player,Int) {}-> Int|e}~> a)
-#                       {Move:(Player,Int) {}-> Int|e}~> a
+#sig bfs : (a,Int,(Int) {Move:(Player,Int) => Int|e}~> a)
+#                       {Move:(Player,Int) => Int|e}~> a
 sig bfs : (a, Int, (Int) ~e~> a)
                          ~e~> a
 fun bfs(player,n,k) {
@@ -145,7 +145,7 @@ fun bfs(player,n,k) {
 # The perfect vs brute force handler assigns
 # Alice the perfect strategy and Bob the brute force strategy
 
-sig pvb : (Comp(Player,{Move:(Player,Int) {}-> Int})) {}~> Player
+sig pvb : (Comp(Player,{Move:(Player,Int) => Int})) {}~> Player
 fun pvb(m) {
   handle(m()) {
     case <Move(Alice,n) => k> -> ps(n,k)
@@ -181,7 +181,7 @@ fun reifyMove(player, n, k) {
 
 # Complete game tree generator
 # The Return-case lifts the result of the computation, m, into a leaf in the game tree
-sig gametree : (Comp(Player, {Move:(Player, Int) {}-> Int})) {}~> GameTree
+sig gametree : (Comp(Player, {Move:(Player, Int) => Int})) {}~> GameTree
 fun gametree(m) {
   handle(m()) {
     case x          -> Winner(x)
@@ -204,8 +204,8 @@ fun gametree(m) {
 #
 # Generate a game tree in which Bob plays a particular strategy
 #
-sig bobStrat : (Comp(Player  ,{Move:(Player, Int) {}-> Int|e})) ->
-                Comp(GameTree,{Move:(Player, Int) {}-> Int|e})
+sig bobStrat : (Comp(Player  ,{Move:(Player, Int) => Int|e})) ->
+                Comp(GameTree,{Move:(Player, Int) => Int|e})
 fun bobStrat(m)() {
   handle(m()) {
     case x          -> Winner(x)
@@ -238,7 +238,7 @@ fun bobStrat(m)() {
 
 # Abstract operation cheat
 # Invoked when a player cheats.
-sig cheat : (Player,Int) {Cheat:(Player,Int) {}-> Zero|_}~> a
+sig cheat : (Player,Int) {Cheat:(Player,Int) => Zero|_}~> a
 fun cheat(player, n) {switch(do Cheat(player,n)) { } }
 
 # Cheater's strategy is to take all sticks and thereby win in one move
@@ -253,8 +253,8 @@ fun cheater2(n,k) {
 
 # checkMove checks whether a given player p has cheated
 sig checkMove : (Player,Int,
-                (Int) {Move:(Player,Int) {}-> Int,Cheat:(Player,Int) {}-> Zero|e}~> a) # k signature
-                      {Move:(Player,Int) {}-> Int,Cheat:(Player,Int) {}-> Zero|e}~> a  # Effects + return type
+                (Int) {Move:(Player,Int) => Int,Cheat:(Player,Int) => Zero|e}~> a) # k signature
+                      {Move:(Player,Int) => Int,Cheat:(Player,Int) => Zero|e}~> a  # Effects + return type
 fun checkMove(p,n,k) {
   var take = move(p,n);
   if (not(elem(take,validMoves(n)))) {
@@ -265,8 +265,8 @@ fun checkMove(p,n,k) {
 }
 
 # The check handler detects cheating
-sig check : (Comp(a,{Move:(Player,Int) {}-> Int, Cheat:(Player,Int) {}-> Zero|e})) ->
-             Comp(a,{Move:(Player,Int) {}-> Int, Cheat:(Player,Int) {}-> Zero|e})
+sig check : (Comp(a,{Move:(Player,Int) => Int, Cheat:(Player,Int) => Zero|e})) ->
+             Comp(a,{Move:(Player,Int) => Int, Cheat:(Player,Int) => Zero|e})
 fun check(m)() {
   handle(m()) {
     case <Move(player, n) => k> -> checkMove(player, n, k)
@@ -276,13 +276,13 @@ fun check(m)() {
 
 # Convenient function to launch a checked game
 sig checkedGame : (Int) ->
-                  Comp (Player, {Move :(Player, Int) {}-> Int,
-                                 Cheat:(Player, Int) {}-> Zero|e})
+                  Comp (Player, {Move :(Player, Int) => Int,
+                                 Cheat:(Player, Int) => Zero|e})
 fun checkedGame(n) { check(game(n)) }
 
 # aliceCheats assigns Alice the cheater's strategy
-sig aliceCheats : (Comp(a, {Move:(Player,Int) {}-> Int|e})) ->
-                   Comp(a, {Move:(Player,Int) {}-> Int|e})
+sig aliceCheats : (Comp(a, {Move:(Player,Int) => Int|e})) ->
+                   Comp(a, {Move:(Player,Int) => Int|e})
 fun aliceCheats(m)() {
   handle(m()) {
     case <Move(Alice,n) => k> -> cheater(n,k)
@@ -290,8 +290,8 @@ fun aliceCheats(m)() {
   }
 }
 
-sig aliceCheats2 : (Comp(a, {Move:(Player,Int) {}-> Int|e})) ->
-                    Comp(a, {Move:(Player,Int) {}-> Int|e})
+sig aliceCheats2 : (Comp(a, {Move:(Player,Int) => Int|e})) ->
+                    Comp(a, {Move:(Player,Int) => Int|e})
 fun aliceCheats2(m)() {
   handle(m()) {
     case <Move(Alice,n) => k> -> cheater2(n,k)
@@ -304,7 +304,7 @@ fun aliceCheats2(m)() {
 
 # Interpreting cheating
 # Abandon the game and report the cheater
-sig cheatReport : (Comp(a, {Cheat:(Player,Int) {}-> Zero|e})) ->
+sig cheatReport : (Comp(a, {Cheat:(Player,Int) => Zero|e})) ->
                    Comp(a, {Cheat{_}|e})
 fun cheatReport(m)() {
   handle(m()) {
@@ -313,7 +313,7 @@ fun cheatReport(m)() {
 }
 
 # Alternatively, upon cheating the opponent is given the victory
-sig cheatLose : (Comp(Player, {Cheat:(Player,Int) {}-> Zero|e})) ->
+sig cheatLose : (Comp(Player, {Cheat:(Player,Int) => Zero|e})) ->
                  Comp(Player, {Cheat{_}|e})
 fun cheatLose(m)() {
   handle(m()) {
@@ -359,7 +359,7 @@ fun ms(n,k) {
 }
 
 # mixed strategy handler assigns a random strategy to both players
-sig mixed : (Comp(a, {Move:(Player,Int) {}-> Int,Rand:Float|e})) ->
+sig mixed : (Comp(a, {Move:(Player,Int) => Int,Rand:Float|e})) ->
              Comp(a, {Move{_},Rand:Float|e}                   )
 fun mixed(m)() {
   handle(m()) {
@@ -389,11 +389,11 @@ fun notReallyRandom(m)() {
 # Strategy handler factory
 # sig strategy : ( (Int, (Int) {Move{p} |e}~> a) {Move{p} |e}~> a
 #                , (Int, (Int) {Move{p} |e}~> a) {Move{p} |e}~> a) ->
-#                (Comp(a, {Move:(Player,Int) {}-> Int |e})) ->
+#                (Comp(a, {Move:(Player,Int) => Int |e})) ->
 #                 Comp(a, {Move{p}                    |e})
 sig strategy : ( (Int, (Int) -> a) {Move{p}|e}~> a
                , (Int, (Int) -> a) {Move{p}|e}~> a )
-            -> (Comp(a, {Move:(Player, Int) -> Int|e})) {Move{p}|e}~> a
+            -> (Comp(a, {Move:(Player, Int) => Int|e})) {Move{p}|e}~> a
 fun strategy(s1, s2)(m) {
   handle(m ()) {
     case <Move(Alice,n) => k> -> s1(n,k)
@@ -422,12 +422,12 @@ var initialState = [(Alice,0),(Bob,0)] : GameState;
 sig get : (Comp(s, {Get:s|_}))
 fun get() {do Get}
 
-sig put : (s) {Put:(s) {}-> ()|_}~> ()
+sig put : (s) {Put:(s) => ()|_}~> ()
 fun put(s) {do Put(s)}
 
 # The state handler is parameterised by a state s
 # which is threaded through the handler during evaluation
-sig state : (Comp(a, {Get:s,Put:(s) {}-> ()|e})) ->
+sig state : (Comp(a, {Get:s,Put:(s) => ()|e})) ->
             (s) ->                                  # Initial state
              Comp(a, {Get{_},Put{_}        |e})
 fun state(m)(s)() {
@@ -441,8 +441,8 @@ fun state(m)(s)() {
 
 # Next, we define a simple handler which records
 # the winner of a single game
-sig scorerecorder : (Comp(Player, {Get:GameState,Put:(GameState) {}-> ()|e})) ->
-                     Comp(()    , {Get:GameState,Put:(GameState) {}-> ()|e})
+sig scorerecorder : (Comp(Player, {Get:GameState,Put:(GameState) => ()|e})) ->
+                     Comp(()    , {Get:GameState,Put:(GameState) => ()|e})
 fun scorerecorder(m)() {
   # Increment the given player's number of wins by one
   sig updateScore : (Player, GameState) ~> GameState
@@ -507,8 +507,8 @@ fun boardPrinter(m)() {
 
 # Finally, we define repeatGame which repeats
 # a given game r times
-sig repeatGame : (Int, Comp( a ,{Move:(Player,Int) {}-> Int|e})) ->
-                       Comp([a],{Move:(Player,Int) {}-> Int|e})
+sig repeatGame : (Int, Comp( a ,{Move:(Player,Int) => Int|e})) ->
+                       Comp([a],{Move:(Player,Int) => Int|e})
 fun repeatGame(r, m)() {
     for (_ <- [1..r]) {
         [m()]

--- a/examples/handlers/number_games.links
+++ b/examples/handlers/number_games.links
@@ -5,7 +5,7 @@ typename Answer = [|Low|Correct|High|];
 sig readInt : () {Read:Int|_}~> Int
 fun readInt() {var n = do Read; print(" " ^^ intToString(n)); n}
 
-sig guess : () {Read:Int,Guess:(Int) -> Answer|_}~> ()
+sig guess : () {Read:Int,Guess:(Int) => Answer|_}~> ()
 fun guess() {
   print("Take a guess>");
   var number = readInt();
@@ -35,7 +35,7 @@ fun input(guesses, m) {
   }
 }
 
-sig mySecret : (Int, Comp({Guess:(Int) -> Answer|e}, a)) {Guess{_} |e}~> a
+sig mySecret : (Int, Comp({Guess:(Int) => Answer|e}, a)) {Guess{_} |e}~> a
 fun mySecret(secret, m) {
   handle(m()) {
     case x -> x
@@ -46,7 +46,7 @@ fun mySecret(secret, m) {
   }
 }
 
-sig logger : (Comp({Guess:(Int) -> Answer|e}, a)) {Guess:(Int) -> Answer|e}~> [(Int,Answer)]
+sig logger : (Comp({Guess:(Int) => Answer|e}, a)) {Guess:(Int) => Answer|e}~> [(Int,Answer)]
 fun logger(m) {
   handle(m())(log <- []) {
     case _ -> log

--- a/examples/handlers/pi.links
+++ b/examples/handlers/pi.links
@@ -1,7 +1,7 @@
 # Pi estimation
 
 # Operations
-sig yield : (a) {Yield: (a) -> () |_}-> ()
+sig yield : (a) {Yield: (a) => () |_}-> ()
 fun yield(x) { do Yield(x) }
 
 sig await : () {Await:a |_}-> a
@@ -25,7 +25,7 @@ fun insideUnitCircle(p) {
 }
 
 # Streams of random points
-sig randomPoints : () {Yield: (Point) -> () |_}~> a
+sig randomPoints : () {Yield: (Point) => () |_}~> a
 fun randomPoints() {
   var p = makePoint(random(), random());
   yield(p);
@@ -33,7 +33,7 @@ fun randomPoints() {
 }
 
 # Synchronous take operation
-sig take : (Int, Comp(b, {Yield: (a) -> () |e})) {Yield{_} |e}~> [a]
+sig take : (Int, Comp(b, {Yield: (a) => () |e})) {Yield{_} |e}~> [a]
 fun take(n, m) {
   handle(m())(n <- n, st <- []) {
     case _ -> st
@@ -45,7 +45,7 @@ fun take(n, m) {
 
 # Compute pi
 
-sig computePi : (Int) -> Comp(a, {Yield: (Float) -> () |_})
+sig computePi : (Int) -> Comp(a, {Yield: (Float) => () |_})
 fun computePi(n)() {
   fun loop(total, count) {
      # Synchronously take `n' random points
@@ -114,7 +114,7 @@ typename Step(a, e::Eff, r) =
                          |Awaits:Resumption(a, { |e}, b)
                          |]);
 
-sig step : (Comp(b, {Await:a, Yield: (a) -> () |e})) {Await{q}, Yield{p} |e}~> Step(a, { Await{q}, Yield{p} |e}, b)
+sig step : (Comp(b, {Await:a, Yield: (a) => () |e})) {Await{q}, Yield{p} |e}~> Step(a, { Await{q}, Yield{p} |e}, b)
 fun step(f) {
   handle(f()) {
     case x        -> Done(x)
@@ -123,7 +123,7 @@ fun step(f) {
   }
 }
 
-sig exchange : (Comp(b, {Await:a, Yield: (a) -> () |e}), Comp(b, {Await:a, Yield: (a) -> () |e})) { Await{_}, Yield{_} |e}~> b
+sig exchange : (Comp(b, {Await:a, Yield: (a) => () |e}), Comp(b, {Await:a, Yield: (a) => () |e})) { Await{_}, Yield{_} |e}~> b
 fun exchange(f, g) {
   fun exchange_aux(f, g) {
     switch( (f, g) ) {
@@ -138,7 +138,7 @@ fun exchange(f, g) {
 
 # Shallow handler
 typename Consumer(a, e::Eff, b) = (a) {Abort:Zero, Await:a |e}~> b;
-typename Producer(a, e::Eff, b) = () {Abort:Zero, Yield:(a) -> () |e}~> b;
+typename Producer(a, e::Eff, b) = () {Abort:Zero, Yield:(a) => () |e}~> b;
 
 mutual {
   sig copipe : (Consumer(a, { Yield{q} |e}, b), Producer(a, { Await{p} |e}, _)) {Abort:Zero, Await{p}, Yield{q} |e}~> b

--- a/examples/handlers/pipes.links
+++ b/examples/handlers/pipes.links
@@ -11,7 +11,7 @@ typename Comp(e::Eff,a) = () ~e~> a;
 sig await : () { Await: s |e}-> s
 fun await() { do Await }
 
-sig yield : (s) { Yield: (s) -> () |e}-> ()
+sig yield : (s) { Yield: (s) => () |e}-> ()
 fun yield(s) { do Yield(s) }
 
 sig forever : (Comp({ |e}, a)) ~e~> b
@@ -20,7 +20,7 @@ fun forever(f) { ignore(f()); forever(f) }
 sig blackhole : Comp({Await:s |e}, a)
 fun blackhole() { forever(await) }
 
-sig take1 : (Int) -> Comp({Await:s, Yield:(s) -> () |e}, ())
+sig take1 : (Int) -> Comp({Await:s, Yield:(s) => () |e}, ())
 fun take1(n)() {
   fun take0(n) {
     if (n <= 0) ()
@@ -33,7 +33,7 @@ fun take1(n)() {
  take0(n)
 }
 
-sig produceFrom : (Int) -> Comp({ Yield: (Int) -> () |e}, a)
+sig produceFrom : (Int) -> Comp({ Yield: (Int) => () |e}, a)
 fun produceFrom(n)() {
   fun produceFrom0(n) {
      yield(n);
@@ -76,11 +76,11 @@ module Deep {
                       (Producer({ Await{b}, Yield{c} |e}, s, a)) { Await{b}, Yield{c} |e}~> a;
 
   typename Copipe(e::Eff, s, a) = forall b::Presence, c::Presence.
-            (Comp({ Await{b}, Yield: (s) -> () |e}, a)) { Await{b}, Yield{c} |e}~>
+            (Comp({ Await{b}, Yield: (s) => () |e}, a)) { Await{b}, Yield{c} |e}~>
                    (Consumer({ Await{b}, Yield{c} |e}, s, a)) { Await{b}, Yield{c} |e}~> a;
 
 
-  sig expoPipe1 : (Pipe({ |e}, Int, a), Copipe({ |e}, Int, a)) -> (Int) -> Comp({ Await:Int, Yield: (Int) -> () |e}, a)
+  sig expoPipe1 : (Pipe({ |e}, Int, a), Copipe({ |e}, Int, a)) -> (Int) -> Comp({ Await:Int, Yield: (Int) => () |e}, a)
   fun expoPipe1(pipe, copipe)(n)() {
     fun expoPipe0(pipe, copipe, n) {
       if (n == 0) {
@@ -170,7 +170,7 @@ module Deep {
 }
 
 module Shallow {
-  typename Prod(e::Eff,o,a) = ()   {Yield:(o) {}-> () |e}~> a;
+  typename Prod(e::Eff,o,a) = ()   {Yield:(o) => () |e}~> a;
   typename Cons(e::Eff,i,a) = (i) {Await:i |e}~> a;
 
   module Direct {
@@ -184,7 +184,7 @@ module Shallow {
       }
 
       sig copipe : (Cons({ Yield{c} |e}, s, a),
-                    Comp({ Await{b}, Yield: (s) -> () |e}, a)) {Await{b}, Yield{c} |e}~> a
+                    Comp({ Await{b}, Yield: (s) => () |e}, a)) {Await{b}, Yield{c} |e}~> a
       fun copipe(cons, prod) {
         shallowhandle(prod()) {
           case <Yield(s) -> resume> -> pipe(fun() { resume(()) }, fun() { cons(s) })
@@ -211,7 +211,7 @@ module Shallow {
       }
 
       sig copipe : (Cons({ Yield{c} |e}, s, a),
-                    Comp({ Await{b}, Yield: (s) -> () |e}, a)) {Await{b}, Yield{c} |e}~> a
+                    Comp({ Await{b}, Yield: (s) => () |e}, a)) {Await{b}, Yield{c} |e}~> a
       fun copipe(cons, prod) {
         var (_,g) = handle(prod()) {
           case x -> (fun() { x }, fun() { x })
@@ -233,7 +233,7 @@ op producer >+> consumer {
   fun() { Deep.Direct.pipe(consumer)(fun() { Deep.Direct.copipe(producer) }) }
 }
 
-sig expoPipe : (Int) -> Comp({ Await: Int, Yield: (Int) -> () |e}, a)
+sig expoPipe : (Int) -> Comp({ Await: Int, Yield: (Int) => () |e}, a)
 fun expoPipe(n)() {
   fun expoPipe0(n) {
     if (n == 0) {

--- a/examples/handlers/racing-lines.links
+++ b/examples/handlers/racing-lines.links
@@ -24,9 +24,9 @@ typename Point = (x:Int, y:Int);
 typename Queue(a) = (rear: [a], front: [a]);
 typename PrioQueue(a) = (high: Queue(a), low: Queue(a));
 typename Priority = [|High|Low|];
-typename Co(e::Eff) = () {Fork: (Co({ |e}), Priority) -> (), Yield:() |e}~> ();
+typename Co(e::Eff) = () {Fork: (Co({ |e}), Priority) => (), Yield:() |e}~> ();
 typename Time = Int;
-typename Fiber0(e::Eff) = (prio: Priority, f: () {Fork: (Fiber0({ |e})) -> (), Yield:() |e}~> ());
+typename Fiber0(e::Eff) = (prio: Priority, f: () {Fork: (Fiber0({ |e})) => (), Yield:() |e}~> ());
 typename SchedulerState(a) = (runQ: PrioQueue(a), prio: Priority, startTime: Time);
 typename Fiber(e::Eff) = (prio:Priority, f: (SchedulerState(Fiber({ |e}))) ~e~> ());
 typename FiberQueue(e::Eff) = PrioQueue(Fiber({ |e}));
@@ -115,7 +115,7 @@ fun fiberQueueLength(q){
     length(q.low.rear) + length(q.high.front) + length(q.high.rear) + length(q.low.front)
 }
 
-sig fork : (Fiber0({ |e})) {Fork: (Fiber0({ |e})) -> (), Yield:() |e}~> ()
+sig fork : (Fiber0({ |e})) {Fork: (Fiber0({ |e})) => (), Yield:() |e}~> ()
 fun fork(f){
     do Fork(f)
 }
@@ -125,7 +125,7 @@ fun yield(){
     do Yield
 }
 
-sig makeFiber: (Priority, () {Fork: (Fiber0({ |e})) -> (), Yield:() |e}~> ()) -> Fiber0({ |e})
+sig makeFiber: (Priority, () {Fork: (Fiber0({ |e})) => (), Yield:() |e}~> ()) -> Fiber0({ |e})
 fun makeFiber(prio, f){
     (prio= prio, f=f)
 }

--- a/examples/handlers/sat.links
+++ b/examples/handlers/sat.links
@@ -258,7 +258,7 @@ fun literalPolarity(e,x) {
 ####
 
 # Parsing
-typename Parser(a) = () {Choose: Bool, Satisfies: ((Char) {}~> Bool) -> Char, Peek: Maybe(Char), Fail: Zero |_}~> a;
+typename Parser(a) = () {Choose: Bool, Satisfies: ((Char) {}~> Bool) => Char, Peek: Maybe(Char), Fail: Zero |_}~> a;
 typename ExprParser = Parser(Expr);
 
 sig satisfies : ((Char) {}~> Bool) -> Parser(Char)

--- a/examples/handlers/shallow_state.links
+++ b/examples/handlers/shallow_state.links
@@ -22,16 +22,16 @@ fun run(m) {
 sig get : Comp(a, {Get:a |_})
 fun get() {do Get}
 
-sig put : (a) {Put:(a) -> ()|_}~> ()
+sig put : (a) {Put:(a) => ()|_}~> ()
 fun put(p) {do Put(p)}
 
 # Print line operation
-sig logVal : (a) {Log:(a) -> ()|_}~> ()
+sig logVal : (a) {Log:(a) => ()|_}~> ()
 fun logVal(p) {do Log(p)}
 
 # Stateful computation evaluator
 sig evalState : (s) -f->
-                (Comp(a, {Get:s,Put:(s) -> () |e})) -f->
+                (Comp(a, {Get:s,Put:(s) => () |e})) -f->
                  Comp(a, { |e})
 fun evalState(st)(m)() {
   (shallowhandle(m()) {
@@ -55,7 +55,7 @@ fun logState(m)() {
 }
 
 # Prints integers to stdout
-sig logPrinter : (Comp(a, {Log:(Int) -> () |e})) -f-> Comp(a, { |e})
+sig logPrinter : (Comp(a, {Log:(Int) => () |e})) -f-> Comp(a, { |e})
 fun logPrinter(m)() {
   shallowhandle(m()) {
     case x -> x
@@ -67,7 +67,7 @@ fun logPrinter(m)() {
 
 # Log accumulator
 sig logAccumulator : ([a]) -f->
-                     (Comp(b,       {Log:(a) -> () |e})) -f->
+                     (Comp(b,       {Log:(a) => () |e})) -f->
                       Comp((b,[a]), { |e})
 fun logAccumulator(ps)(m)() {
   shallowhandle(m()) {

--- a/examples/handlers/shiftreset.links
+++ b/examples/handlers/shiftreset.links
@@ -1,6 +1,6 @@
 # Delimited continuations using handlers
 
-sig reset : (Comp(b, {Shift: (((a) ~e~> b) ~e~> b) {}-> a |e})) ~e~> b
+sig reset : (Comp(b, {Shift: (((a) ~e~> b) ~e~> b) => a |e})) ~e~> b
 fun reset(m) {
   handle(m()) {
     case x        -> x
@@ -8,7 +8,7 @@ fun reset(m) {
   }
 }
 
-sig shift : (((a) ~e~> b) ~e~> b) {Shift:(((a) ~e~> b) ~e~> b) -> a|e}~> a
+sig shift : (((a) ~e~> b) ~e~> b) {Shift:(((a) ~e~> b) ~e~> b) => a|e}~> a
 fun shift(f) { do Shift(f) }
 
 fun comp() {

--- a/examples/handlers/sierpinski-triangle.links
+++ b/examples/handlers/sierpinski-triangle.links
@@ -16,8 +16,8 @@ typename Point = (x:Int, y:Int);
 typename Queue(a) = (rear: [a], front: [a]);
 typename PrioQueue(a) = (high: Queue(a), low: Queue(a));
 typename Priority = [|High|Low|];
-typename Co(e::Eff) = () {Fork: (Co({ |e}), Priority) -> (), Yield:() |e}~> ();
-typename Fiber0(e::Eff) = (prio: Priority, f: () {Fork: (Fiber0({ |e})) -> (), Yield:()|e}~> ());
+typename Co(e::Eff) = () {Fork: (Co({ |e}), Priority) => (), Yield:() |e}~> ();
+typename Fiber0(e::Eff) = (prio: Priority, f: () {Fork: (Fiber0({ |e})) => (), Yield:()|e}~> ());
 typename SchedulerState(a) = (runQ: PrioQueue(a), prio: Priority, startTime: Int);
 typename Fiber(e::Eff) = (prio:Priority, f: (SchedulerState(Fiber({ |e}))) ~e~> ());
 typename FiberQueue(e::Eff) = PrioQueue(Fiber({ |e}));
@@ -115,7 +115,7 @@ fun fiberQueueLength(q){
     length(q.low.rear) + length(q.high.front) + length(q.high.rear) + length(q.low.front)
 }
 
-sig fork : (Fiber0({ |e})) {Fork: (Fiber0({ |e})) -> (), Yield:() |e}~> ()
+sig fork : (Fiber0({ |e})) {Fork: (Fiber0({ |e})) => (), Yield:() |e}~> ()
 fun fork(f){
     do Fork(f)
 }
@@ -125,7 +125,7 @@ fun yield(){
     do Yield
 }
 
-sig makeFiber: (Priority, () {Fork: (Fiber0({ |e})) -> (), Yield:() |e}~> ()) -> Fiber0({ |e})
+sig makeFiber: (Priority, () {Fork: (Fiber0({ |e})) => (), Yield:() |e}~> ()) -> Fiber0({ |e})
 fun makeFiber(prio, f){
     (prio= prio, f=f)
 }

--- a/examples/handlers/transaction.links
+++ b/examples/handlers/transaction.links
@@ -20,12 +20,12 @@ fun dequeue(q) {
 }
 
 # Concurrency API
-typename Co(e::Eff) = () {Fork:(Co({ |e})) -> (), Yield:() |e}~> ();
+typename Co(e::Eff) = () {Fork:(Co({ |e})) => (), Yield:() |e}~> ();
 
 sig yield : () { Yield:() |e}~> ()
 fun yield() { do Yield }
 
-sig fork : (Co({ |e})) {Fork: (Co({ |e})) -> () |_}~> ()
+sig fork : (Co({ |e})) {Fork: (Co({ |e})) => () |_}~> ()
 fun fork(f) { do Fork(f) }
 
 sig schedule : (Co({ |e})) {Fork{_}, Yield{_} |e}~> ()
@@ -54,7 +54,7 @@ fun schedule(main) {
 fun get() { do Get }
 fun put(st) { do Put(st) }
 
-sig runState : (Comp(a, {Get:s, Put: (s) -> () |e}), s) {Get{_}, Put{_} |e}~> (a, s)
+sig runState : (Comp(a, {Get:s, Put: (s) => () |e}), s) {Get{_}, Put{_} |e}~> (a, s)
 fun runState(m, st) {
   handle(m())(st <- st) {
     case x      -> (x, st)
@@ -88,7 +88,7 @@ typename Bank = [Account];
 var accounts = [("Alice", 100), ("Bob", 25)];
 
 # Transfer
-sig transfer : (Bool, Int, String, String) {Abort:Zero, Yield:(), Get:Bank, Put: (Bank) -> () |_}~> ()
+sig transfer : (Bool, Int, String, String) {Abort:Zero, Yield:(), Get:Bank, Put: (Bank) => () |_}~> ()
 fun transfer(delay, amount, src, dest) {
   fun upd(account) {
     var accounts = filter(fun(a) { a.1 <> account.1 }, get());

--- a/examples/handlers/u2_puzzle.links
+++ b/examples/handlers/u2_puzzle.links
@@ -76,7 +76,7 @@ fun compareMembers(x, y) {
 typename Side = [U2];
 
 # Non-determinstic choice.
-sig choose : ([a]) {Choose:([a]) -> a|_}-> a
+sig choose : ([a]) {Choose:([a]) => a|_}-> a
 fun choose(xs) { do Choose(xs) }
 
 # Failure.
@@ -84,7 +84,7 @@ sig fail : () {Fail:Zero|_}-> a
 fun fail() { switch (do Fail) { } }
 
 # Selects one or two to cross the bridge.
-sig selectParty : (Side) {Choose:(Side) -> U2, Fail:Zero|_}~> [U2]
+sig selectParty : (Side) {Choose:(Side) => U2, Fail:Zero|_}~> [U2]
 fun selectParty(side) {
   var m1 = choose(side);
   var m2 = choose(side);
@@ -111,7 +111,7 @@ fun without(xs, ys) {
 }
 
 # The main loop.
-sig solve : (Bool, Int, ([U2], [U2])) {Choose:([U2]) -> U2, Fail:Zero|_}~> [([U2], Bool)]
+sig solve : (Bool, Int, ([U2], [U2])) {Choose:([U2]) => U2, Fail:Zero|_}~> [([U2], Bool)]
 fun solve(forward, timeLeft, sides) {
   fun step(sideFrom, sideTo) {
     var party = selectParty(sideFrom);

--- a/links-mode.el
+++ b/links-mode.el
@@ -145,6 +145,7 @@
      (2 font-lock-function-name-face))
    ;; type operators
    '("\\(-\\|~\\)\\(>\\|@\\)" . font-lock-function-name-face)
+   '("\\(=>\\)" . font-lock-function-name-face)
    '("\\(-\\|~\\)\\([a-z]+\\)\\(-\\|~\\)\\(>\\|@\\)"
      (1 font-lock-function-name-face)
      (2 font-lock-variable-name-face)

--- a/tests/desugar_datatypes.tests
+++ b/tests/desugar_datatypes.tests
@@ -121,7 +121,7 @@ stdout : A(fun) : Either (())
 args : --set=types_pretty_printer_engine=old --set=effect_sugar=true
 
 Type names with effect arrows are not considered
-typename X = Comp((), {Var:() -> ()}); fun() { } : X({ |_})
+typename X = Comp((), {Var:() => ()}); fun() { } : X({ |_})
 exit : 1
 stderr : @.*Arity mismatch: Type X expects 0 type arguments, but 1 arguments were provided.*
 args : --set=effect_sugar=true

--- a/tests/effect_sugar.tests
+++ b/tests/effect_sugar.tests
@@ -35,7 +35,7 @@ args : --enable-handlers --set=effect_sugar=true --set=effect_sugar_policy=final
 
 Sugar off [1]
 sig f : (() {E:()|e}~> ()) -> () {E{_}|e}~> () fun f(g) { fun() { handle(g()) { case <E => res> -> res(()) }}} f
-stdout : fun : (() {E:() {}-> ()|a}~> ()) -> () {E{_}|a}~> ()
+stdout : fun : (() {E:() => ()|a}~> ()) -> () {E{_}|a}~> ()
 args : --enable-handlers --set=effect_sugar=false
 
 Sugar off [2], implicit not unifying, no propagation
@@ -46,12 +46,12 @@ args : --enable-handlers --set=effect_sugar=false
 
 Printer: none [1], signature with explicit shared effect
 sig f : (() {E:()|e}~> ()) -> () {E{_}|e}~> () fun f(g) { fun() { handle(g()) { case <E => res> -> res(()) }}} f
-stdout : fun : (() {E:() {}-> ()|_}~> ()) -_-> () {E{_}|_}~> ()
+stdout : fun : (() {E:() => ()|_}~> ()) -_-> () {E{_}|_}~> ()
 args : --enable-handlers --set=effect_sugar=true --set=effect_sugar_policy=none
 
 Printer: none [2], signature with implicit shared effect
 sig f : (() {E:()|_}~> ()) -> () {E{_}|_}~> () fun f(g) { fun() { handle(g()) { case <E => res> -> res(()) }}} f
-stdout : fun : (() {E:() {}-> ()|_}~> ()) -_-> () {E{_}|_}~> ()
+stdout : fun : (() {E:() => ()|_}~> ()) -_-> () {E{_}|_}~> ()
 args : --enable-handlers --set=effect_sugar=true --set=effect_sugar_policy=none
 
 Printer: none [3], type alias
@@ -97,17 +97,17 @@ args : --enable-handlers --set=prelude=tests/empty_prelude.links --set=effect_su
 
 Printer: presence_omit [1]: signature with implicit shared effect, handler
 sig f : (() {E:()|_}~> ()) -> () {E{_}|_}~> () fun f(g) { fun() { handle(g()) { case <E => res> -> res(()) }}} f
-stdout : fun : (() {E:() {}-> ()|_}~> ()) -_-> () ~> ()
+stdout : fun : (() {E:() => ()|_}~> ()) -_-> () ~> ()
 args : --enable-handlers --set=effect_sugar=true --set=effect_sugar_policy=presence_omit
 
 Printer: presence_omit [2]: signature with implicit shared effect, handler, propagation
 sig f : (() {E:()|_}~> ()) -> () { |_}~> () fun f(g) { fun() { handle(g()) { case <E => res> -> res(()) }}} f
-stdout : fun : (() {E:() {}-> ()|_}~> ()) -_-> () ~> ()
+stdout : fun : (() {E:() => ()|_}~> ()) -_-> () ~> ()
 args : --enable-handlers --set=effect_sugar=true --set=effect_sugar_policy=presence_omit
 
 Printer: presence_omit [3]: multiple shared effect rows
-sig f : (() {E:() {}-> ()|e}~> (), () {F:() {}-> ()|f}~> ()) -> (() {E{_}|e}~> (), () {F{_}|f}~> ()) fun f(p,q) { var p = fun() { handle(p()) { case v -> v case <E => res> -> res(()) }}; var q = fun() { handle(q()) { case v -> v case <F => res> -> res(()) }}; (p,q) } f
-stdout : fun : (() {E:() {}-> ()|a}~> (), () {F:() {}-> ()|b}~> ()) -> (() ~a~> (), () ~b~> ())
+sig f : (() {E:() => ()|e}~> (), () {F:() => ()|f}~> ()) -> (() {E{_}|e}~> (), () {F{_}|f}~> ()) fun f(p,q) { var p = fun() { handle(p()) { case v -> v case <E => res> -> res(()) }}; var q = fun() { handle(q()) { case v -> v case <F => res> -> res(()) }}; (p,q) } f
+stdout : fun : (() {E:() => ()|a}~> (), () {F:() => ()|b}~> ()) -> (() ~a~> (), () ~b~> ())
 args : --enable-handlers --set=effect_sugar=true --set=effect_sugar_policy=presence_omit
 
 Printer: alias_omit [1], printer only
@@ -127,12 +127,12 @@ args : --enable-handlers --set=effect_sugar=true --set=effect_sugar_policy=alias
 
 Printer: presence_omit, alias_omit [1], handler (TODO fix #1041 and make effect vars implicit in Comps)
 sig f : (Comp ((), {E:()|e})) -> Comp ((), {E{_}|e}) fun f(x)() { handle(x()) { case () -> () case <E => res> -> () }} f
-stdout : fun : (Comp ((),{E:() {}-> ()|_})) -_-> Comp (())
+stdout : fun : (Comp ((),{E:() => ()|_})) -_-> Comp (())
 args : --enable-handlers --set=effect_sugar=true --set=effect_sugar_policy=presence_omit,alias_omit,final_arrow
 
 Printer: presence_omit, alias_omit, chf [1], handler (TODO fix #1041 and make effect vars implicit in Comps)
 sig f : (Comp ((), {E:()|e})) -> Comp ((), {E{_}|e}) fun f(x)() { handle(x()) { case () -> () case <E => res> -> () }} f
-stdout : fun : (Comp ((),{E:() {}-> ()|_})) -> Comp (())
+stdout : fun : (Comp ((),{E:() => ()|_})) -> Comp (())
 args : --enable-handlers --set=effect_sugar=true --set=effect_sugar_policy=presence_omit,alias_omit,chf
 
 Printer: pres, alias, chf, contract [1], handler (TODO fix #1041 and make effect vars implicit in Comps)
@@ -141,23 +141,23 @@ stdout : fun : (Comp ((),{E:()|_})) -> Comp (())
 args : --enable-handlers --set=effect_sugar=true --set=effect_sugar_policy=pres,alias,chf,contract
 
 Printer: contract_operation_arrows [1]
-sig f : (a) {E:(a) {}-> b}-> b fun f(x) { do E(x) } f
-stdout : fun : (a) {E:(a) -> b}-> b
+sig f : (a) {E:(a) => b}-> b fun f(x) { do E(x) } f
+stdout : fun : (a) {E:(a) => b}-> b
 args : --enable-handlers --set=effect_sugar=true --set=effect_sugar_policy=contract
 
 Printer: contract_operation_arrows [2]
-sig f : () {E:() {}-> a}-> a fun f() { do E } f
+sig f : () {E:() => a}-> a fun f() { do E } f
 stdout : fun : () {E:a}-> a
 args : --enable-handlers --set=effect_sugar=true --set=effect_sugar_policy=contract
 
 Printer: contract_operation_arrows [3]
-sig f : () {E:() {}-> ()}-> () fun f() { do E } f
+sig f : () {E:() => ()}-> () fun f() { do E } f
 stdout : fun : () {E:()}-> ()
 args : --enable-handlers --set=effect_sugar=true --set=effect_sugar_policy=contract
 
 Printer: contract_operation_arrows [4]
-sig f : (a) {E:(a) {}-> ()}-> () fun f(x) { do E(x) } f
-stdout : fun : (a) {E:(a) -> ()}-> ()
+sig f : (a) {E:(a) => ()}-> () fun f(x) { do E(x) } f
+stdout : fun : (a) {E:(a) => ()}-> ()
 args : --enable-handlers --set=effect_sugar=true --set=effect_sugar_policy=contract
 
 Printer: chf [1]
@@ -182,12 +182,12 @@ args : --enable-handlers --set=effect_sugar=true --set=effect_sugar_policy=arrow
 
 Printer: open_default [1], open
 sig ask : () {Ask:a}-> a fun ask() { do Ask } ask
-stdout : fun : () {Ask:() { | .}-> a}-> a
+stdout : fun : () {Ask:() => a}-> a
 args : --enable-handlers --set=prelude=tests/empty_prelude.links --set=effect_sugar=true --set=effect_sugar_policy=open_default
 
 Printer: open_default [2], closed
 sig ask : () {Ask:a| .}-> a fun ask() { do Ask } ask
-stdout : fun : () {Ask:() { | .}-> a| .}-> a
+stdout : fun : () {Ask:() => a| .}-> a
 args : --enable-handlers --set=prelude=tests/empty_prelude.links --set=effect_sugar=true --set=effect_sugar_policy=open_default
 
 Printer: contract_operation_arrows, open_default [1], open
@@ -201,21 +201,21 @@ stdout : fun : () {Ask:a| .}-> a
 args : --enable-handlers --set=prelude=tests/empty_prelude.links --set=effect_sugar=true --set=effect_sugar_policy=open_default,contract
 
 Printer: contract_operation_arrows, open_default [3], open
-sig ask : (a) {Ask:(a) { | .}-> b}-> b fun ask(x) { do Ask(x) } ask
-stdout : fun : (a) {Ask:(a) -> b}-> b
+sig ask : (a) {Ask:(a) => b}-> b fun ask(x) { do Ask(x) } ask
+stdout : fun : (a) {Ask:(a) => b}-> b
 args : --enable-handlers --set=prelude=tests/empty_prelude.links --set=effect_sugar=true --set=effect_sugar_policy=open_default,contract
 
 Printer: contract_operation_arrows, open_default [4], closed
-sig ask : (a) {Ask:(a) { | .}-> b| .}-> b fun ask(x) { do Ask(x) } ask
-stdout : fun : (a) {Ask:(a) -> b| .}-> b
+sig ask : (a) {Ask:(a) => b| .}-> b fun ask(x) { do Ask(x) } ask
+stdout : fun : (a) {Ask:(a) => b| .}-> b
 args : --enable-handlers --set=prelude=tests/empty_prelude.links --set=effect_sugar=true --set=effect_sugar_policy=open_default,contract
 
 Printer: contract_operation_arrows, open_default [5], open, include desugaring
-sig ask : (a) {Ask:(a) -> b}-> b fun ask(x) { do Ask(x) } ask
-stdout : fun : (a) {Ask:(a) -> b}-> b
+sig ask : (a) {Ask:(a) => b}-> b fun ask(x) { do Ask(x) } ask
+stdout : fun : (a) {Ask:(a) => b}-> b
 args : --enable-handlers --set=prelude=tests/empty_prelude.links --set=effect_sugar=true --set=effect_sugar_policy=open_default,contract
 
 Printer: contract_operation_arrows, open_default [6], closed, include desugaring
-sig ask : (a) {Ask:(a) -> b| .}-> b fun ask(x) { do Ask(x) } ask
-stdout : fun : (a) {Ask:(a) -> b| .}-> b
+sig ask : (a) {Ask:(a) => b| .}-> b fun ask(x) { do Ask(x) } ask
+stdout : fun : (a) {Ask:(a) => b| .}-> b
 args : --enable-handlers --set=prelude=tests/empty_prelude.links --set=effect_sugar=true --set=effect_sugar_policy=open_default,contract

--- a/tests/effectname.tests
+++ b/tests/effectname.tests
@@ -11,17 +11,17 @@ stdout : fun : () {}-> ()
 Declaration and instanciation [2]
 ./tests/effectname/one.links
 filemode : true
-stdout : fun : () {E:() {}-> ()}-> ()
+stdout : fun : () {E:() => ()}-> ()
 
 Declaration and instanciation [3]
 ./tests/effectname/two.links
 filemode : true
-stdout : fun : () {E:() {}-> ()}-> ()
+stdout : fun : () {E:() => ()}-> ()
 
 Twice the same effectname in one row
 ./tests/effectname/two-nested.links
 filemode : true
-stdout : fun : () {E:() {}-> ()}-> ()
+stdout : fun : () {E:() => ()}-> ()
 
 Mixed typename and effectname aliases
 ./tests/effectname/typenames.links
@@ -31,7 +31,7 @@ stdout : fun : T' (Bool,Int,{})
 Nested declaration and instanciation
 ./tests/effectname/nested-decl.links
 filemode : true
-stdout : fun : () {E:() {}-> Int,E':(Int) {}-> ()}-> ()
+stdout : fun : () {E:() => Int,E':(Int) => ()}-> ()
 
 Recursive alias
 ./tests/effectname/recursive.links
@@ -48,7 +48,7 @@ stdout : (((), 42), (0, 42), (0, 42)) : (((), Int), (Int, Int), (Int, Int))
 Twice the same effect label in the row
 ./tests/effectname/effect-same-name.links
 filemode : true
-stdout : fun : () {E:() {}-> Int}-> Int
+stdout : fun : () {E:() => Int}-> Int
 
 Mutual declaration
 ./tests/effectname/mutual.links

--- a/tests/effectname/effect-same-name.links
+++ b/tests/effectname/effect-same-name.links
@@ -1,4 +1,4 @@
-effectname A(a,b,e::Eff) = { E: () {}-> a, E: () {}-> b | e } ;
+effectname A(a,b,e::Eff) = { E: () => a, E: () => b | e } ;
 
 sig f : () -A(Int, Bool, {})-> Int
 fun f () {

--- a/tests/effectname/handler.links
+++ b/tests/effectname/handler.links
@@ -1,4 +1,4 @@
-effectname State(a,e::Eff) = { Get:() {}-> a, Put:(a) {}-> () | e } ;
+effectname State(a,e::Eff) = { Get:() => a, Put:(a) => () | e } ;
 
 sig hstate : (() ~State(a,{ |e})~> b) -> () {Get{_}, Put{_} | e}~> (a) ~e~> (b,a)
 fun hstate (m)() {
@@ -17,7 +17,7 @@ fun f () {
     ()
 }
 
-effectname Reader(a,e::Eff) = {Ask:() {}-> a | e } ;
+effectname Reader(a,e::Eff) = {Ask:() => a | e } ;
 
 sig hreader : (() ~Reader(Int,{ |e})~> a) -> () {Ask{_}|e}~> a
 fun hreader (m)() {

--- a/tests/effectname/nested-decl.links
+++ b/tests/effectname/nested-decl.links
@@ -1,6 +1,6 @@
 effectname A = {} ;
-effectname B(a,e::Eff) = { E: () -e-> a | A } ;
-effectname C = { E': (Int) -> () | B(Int, { | A })  } ;
+effectname B(a,e::Eff) = { E:a | e } ;
+effectname C = { E': (Int) => () | B(Int, { | A })  } ;
 
 sig f : () -C-> ()
 fun f () { do E'(do E()) }

--- a/tests/effectname/one.links
+++ b/tests/effectname/one.links
@@ -1,4 +1,4 @@
-effectname A = {E: () {}-> ()} ;
+effectname A = {E: () => ()} ;
 
 sig f : () -A-> ()
 fun f () { do E() }

--- a/tests/effectname/recursive.links
+++ b/tests/effectname/recursive.links
@@ -1,4 +1,4 @@
-effectname A = { E: ( () -A-> () ) {}-> () } ;
+effectname A = { E: ( () -A-> () ) => () } ;
 
 sig f : () -A-> ()
 fun f () {}

--- a/tests/effectname/two-nested.links
+++ b/tests/effectname/two-nested.links
@@ -1,7 +1,7 @@
-effectname A(e::Eff) = { E: () {}-> () | e } ;
+effectname A(e::Eff) = { E: () => () | e } ;
 # effectname B = A({ | A({}) }) ;
 
-sig f : () -A({}) -> ()
+sig f : () -A({})-> ()
 fun f () {
     do E()
 }

--- a/tests/effectname/two.links
+++ b/tests/effectname/two.links
@@ -1,5 +1,5 @@
 effectname A = {} ;
-effectname B(a,e::Eff) = { E: () {}-> a | e } ;
+effectname B(a,e::Eff) = { E: () => a | e } ;
 
 sig f : () -B((),{ |A})-> ()
 fun f () { do E() }

--- a/tests/effectname/typenames.links
+++ b/tests/effectname/typenames.links
@@ -1,8 +1,8 @@
 typename T = forall e::Eff. (Int) -e-> Int ;
 
-effectname A(a,e::Eff) = { E1: T, E2: (Int) {}-> a | e } ;
+effectname A(a,e::Eff) = { E1: T, E2: (Int) => a | e } ;
 
-typename T'(a,b,e::Eff) = (a) { E: (a) {}-> Int | A(b,{ |e}) }-> b ;
+typename T'(a,b,e::Eff) = (a) { E: (a) => Int | A(b,{ |e}) }-> b ;
 
 sig f : T'(Bool, Int, {})
 fun f (x) {

--- a/tests/effectname/underscore.links
+++ b/tests/effectname/underscore.links
@@ -1,4 +1,4 @@
-effectname A(e::Eff) = { FEct : () {}-> Bool | e } ;
+effectname A(e::Eff) = { FEct : () => Bool | e } ;
 
 sig callF : () -A({ |_})-> Bool      # with _ => error, with e => no error
 fun callF () {  do FEct  }

--- a/tests/handlers.tests
+++ b/tests/handlers.tests
@@ -36,32 +36,32 @@ args : --enable-handlers
 
 Operation invocation sugar (1)
 { fun() { do Foo } }
-stdout : fun : () {Foo:() {}-> a|_}-> a
+stdout : fun : () {Foo:() => a|_}-> a
 args : --enable-handlers
 
 Operation invocation sugar (2)
 { fun() { do Foo() } }
-stdout : fun : () {Foo:() {}-> a|_}-> a
+stdout : fun : () {Foo:() => a|_}-> a
 args : --enable-handlers
 
 Operation invocation sugar (3)
 { fun() { do Foo(()) } }
-stdout : fun : () {Foo:(()) {}-> a|_}-> a
+stdout : fun : () {Foo:(()) => a|_}-> a
 args : --enable-handlers
 
 Operation invocation sugar (4)
 fun() { do Foo }
-stdout : fun : () {Foo:() {}-> a|_}-> a
+stdout : fun : () {Foo:() => a|_}-> a
 args : --enable-handlers
 
 Operation invocation sugar (5)
 fun() { do Foo() }
-stdout : fun : () {Foo:() {}-> a|_}-> a
+stdout : fun : () {Foo:() => a|_}-> a
 args : --enable-handlers
 
 Operation invocation sugar (6)
 fun() { do Foo(()) }
-stdout : fun : () {Foo:(()) {}-> a|_}-> a
+stdout : fun : () {Foo:(()) => a|_}-> a
 args : --enable-handlers
 
 Exception handling (1)
@@ -150,7 +150,7 @@ args : --enable-handlers
 
 Type inference for deep handler
 fun() { handle({do A; do B}) { case <A => k> -> k(()) case x -> x } }
-stdout : fun : () {A{_},B:() {}-> b|_}~> b
+stdout : fun : () {A{_},B:() => b|_}~> b
 args : --enable-handlers
 
 Soundness
@@ -231,7 +231,7 @@ args : --enable-handlers
 
 Operation parameter pattern-matching (7)
 fun(m) { handle(m()) { case <Move(Alice)> -> 'A' case <Move(Bob)> -> 'B' case <Move(_)> -> 'U' case x -> x } }
-stdout : fun : (() {Move:([|Alice|Bob|_|]) {}-> _::Any|c}~> Char) {Move{_}|c}~> Char
+stdout : fun : (() {Move:([|Alice|Bob|_|]) => _::Any|c}~> Char) {Move{_}|c}~> Char
 args : --enable-handlers
 
 Operation parameter pattern-matching (8)
@@ -369,12 +369,12 @@ args : --enable-handlers
 
 Type ascription, parameterised handlers (1)
 { fun(a : Int)(b : Float)(c : String)(m)() { handle (m())(x <- a, y <- b, z <- c) { case <Op(p) => k> -> k(c,42,p,"Foo") case _ -> x } } }
-stdout : fun : (Int) -> (Float) -> (String) -> (() {Op:(Float) {}-> String|d}~> _) -> () {Op{_}|d}~> Int
+stdout : fun : (Int) -> (Float) -> (String) -> (() {Op:(Float) => String|d}~> _) -> () {Op{_}|d}~> Int
 args : --enable-handlers
 
 Type ascription, parameterised handlers (2)
 { fun(a : Float, b : String, c : Int)(m)() { handle(m())(x <- a, y <- b, z <- c) { case <Op(p) => k> -> k(x,p,"Bar",99) case _ -> y } } }
-stdout : fun : (Float, String, Int) -> (() {Op:(Float) {}-> Float|b}~> _) -> () {Op{_}|b}~> String
+stdout : fun : (Float, String, Int) -> (() {Op:(Float) => Float|b}~> _) -> () {Op{_}|b}~> String
 args : --enable-handlers
 
 Instantiate.ArityMismatch #132 (RESOLVED)
@@ -382,9 +382,19 @@ sig f : (() {Foo:Int|a}~> b) {Foo{_}|a}~> b fun f(m) { error("N/A") } fun g(m) {
 stdout : () : ()
 args : --enable-handlers
 
-Operation polymorphism
-sig catch : (() {Fail:forall a.a |e}~> b) {Fail{_} |e}~> Maybe(b) fun catch(m) { handle(m()) { case <Fail => k> -> Nothing case x -> Just(x) } } catch(fun() { 42 })
+Operation polymorphism (1)
+sig catch : (() {Fail:forall a.a |e}~> b) {Fail{_} |e}~> Maybe(b) fun catch(m) { handle(m()) { case <Fail => k> : (forall a. () => a) -> Nothing case x -> Just(x) } } catch(fun() { 42 })
 stdout : Just(42) : Maybe (Int)
+args : --enable-handlers
+
+Operation polymorphism (2)
+sig catch : (() {Fail:forall a.a |e}~> b) {Fail{_} |e}~> Maybe(b) fun catch(m) { handle(m()) { case <Fail => k> : (forall a. () => a) -> Nothing case x -> Just(x) } } sig f : () {Fail:forall a.a}~> Int fun f () { if (do Fail) 42 else do Fail } catch (f)
+stdout : Nothing : Maybe (Int)
+args : --enable-handlers
+
+Operation polymorphism (3)
+sig h : (() {Switch:forall a,b. (a,b) => (b,a) |e}~> c) {Switch{_} |e}~> c fun h(m) { handle(m()) { case <Switch(x,y) => k> : (forall a,b. (a,b) => (b,a)) -> k ((y,x)) } } sig f : () {Switch:forall a,b. (a,b) => (b,a)}~> Int fun f () { var (d,u) = do Switch(2,4) ; 10*d+u } h(f)
+stdout : 42 : Int
 args : --enable-handlers
 
 Generalise (1)
@@ -413,8 +423,8 @@ stdout : (1, true, (false, 1), "Hello World") : (Int, Bool, (Bool, Int), String)
 args : --enable-handlers
 
 Effect type sugar (1)
-fun(g : (() {A:a,B:(a) -> b|_}~> b)) { g }(fun(){error("N/A")})
-stdout : fun : () {A:() {}-> a,B:(a) {}-> b|_}~> b
+fun(g : (() {A:a,B:(a) => b|_}~> b)) { g }(fun(){error("N/A")})
+stdout : fun : () {A:() => a,B:(a) => b|_}~> b
 args : --enable-handlers
 
 Effect type sugar (2)
@@ -449,7 +459,22 @@ args : --enable-handlers
 
 Omission of resumption for nullary operations (3)
 fun(m) { handle(m()) { case <Foo> -> 5 } }
-stdout : fun : (() {Foo:() {}-> _::Any|b}~> Int) {Foo{_}|b}~> Int
+stdout : fun : (() {Foo:() => _::Any|b}~> Int) {Foo{_}|b}~> Int
+args : --enable-handlers
+
+Operation annotation (1)
+fun(m) { handle(m()) { case <Foo(x) => k> : ((Int) => Int) -> k (x) } }
+stdout : fun : (() {Foo:(Int) => Int|a}~> b::Any) {Foo{_}|a}~> b::Any
+args : --enable-handlers
+
+Operation annotation (2)
+fun(f)(m) { handle(m()) { case <Foo(x : Bool) => k> -> k (f (x)) } }
+stdout : fun : ((Bool) {Foo{a}|b}~> c::Any) -> (() {Foo:(Bool) => c::Any|b}~> e::Any) {Foo{a}|b}~> e::Any
+args : --enable-handlers
+
+Operation annotation (3)
+fun(m) { handle(m()) { case <Foo(x) => k> : ((a) => (() {}-> (a,a))) -> k ( fun () { (x,x) } ) } }
+stdout : fun : (() {Foo:(a) => () {}-> (a, a)|b}~> c::Any) {Foo{_}|b}~> c::Any
 args : --enable-handlers
 
 Examples

--- a/tests/parser.tests
+++ b/tests/parser.tests
@@ -29,8 +29,8 @@ sig f : Comp ((),{ |(mu a . Bar,Foo:(() { |a}~> _) {}-> ()|_) }) fun f() { () } 
 stdout : fun : Comp ((),{ |(mu a.Bar:(),Foo:(() { |a}~> _) {}-> ()|_)})
 
 Recursive row variable in effect signature [1]
-sig w : (() { |(mu a . F:(() { |a}~> ()) {}-> _|e)}~> ()) {F{_}|e}~> () fun w(g) { handle(g()) { case () -> () case <F(h) => res> -> w(h) }} w
-stdout : fun : (() { |(mu a.F:(() { |a}~> ()) {}-> _|c)}~> ()) {F{_}|c}~> ()
+sig w : (() { |(mu a . F:(() { |a}~> ()) => _|e)}~> ()) {F{_}|e}~> () fun w(g) { handle(g()) { case () -> () case <F(h) => res> -> w(h) }} w
+stdout : fun : (() { |(mu a.F:(() { |a}~> ()) => _|c)}~> ()) {F{_}|c}~> ()
 args : --enable-handlers
 
 Recursive row variable in effect signature [2]

--- a/tests/roundtrippable_types.tests
+++ b/tests/roundtrippable_types.tests
@@ -14,7 +14,7 @@ stdout : (q = [3, 1, 2]) : Q
 Recursive effect
 fun w(g) { handle(g()) { case () -> () case <F(h) => res> -> w(h) }} w
 args : --enable-handlers
-stdout : fun : (() { |(mu a.F:(() { |a}-> ()) {}-> _::Any,wild:()|c)}-> ()) {F{_}|c}~> ()
+stdout : fun : (() { |(mu a.F:(() { |a}-> ()) => _::Any,wild:()|c)}-> ()) {F{_}|c}~> ()
 
 Row with no fields, but with nested wild row in its row variable
 fun f() { error("") } f

--- a/tests/type_print.tests
+++ b/tests/type_print.tests
@@ -15,7 +15,7 @@ args : --set=types_pretty_printer_engine=old --set=effect_sugar=true
 
 Effect sugar: Implicit effect variables (4)
 fun(_) {} : (() {F:()|_}-> ()) {F:()|_} -> ()
-stdout : fun : (() {F:() {}-> ()|_}-> ()) {F:() {}-> ()|_}-> ()
+stdout : fun : (() {F:() => ()|_}-> ()) {F:() => ()|_}-> ()
 args : --set=types_pretty_printer_engine=old --set=effect_sugar=true
 
 Effect sugar: Single-use variables


### PR DESCRIPTION
Clean-up of #1158.

This patch adds support for polymorphic operations.

For this we have to annotate the cases in the handler with polymorphic operation types.

Example
```links
sig h : (Comp(b, {A:forall a. (a) => a, Fail:forall a. a|c})) {A{_}, Fail{_}|c}~> Maybe(b)
fun h (m) {
    handle(m()) {
        case <A(x) => k> : (forall a.  (a) => a) -> k (x)
        case <Fail> : (forall a. () => a) -> Nothing
        case x -> Just(x)
    }
 }

sig f : () {A:forall a. (a) => a|_}-> Int
fun f () {
    if (do A(true)) do A(1) else
    do A(42)
}
```
This is done by having actual operation patterns and using the type annotation system associated with it.