### PR TITLE
Compile with OCaml 5.0.0

### DIFF
--- a/.github/workflows/default.yml
+++ b/.github/workflows/default.yml
@@ -17,7 +17,8 @@ jobs:
         os:
           - ubuntu-20.04
         ocaml-compiler:
-          - 4.08.0
+          - 4.14.1
+          - 5.0.0
 
     runs-on: ${{ matrix.os }}
 
@@ -71,7 +72,8 @@ jobs:
         os:
           - ubuntu-20.04
         ocaml-compiler:
-          - 4.08.0
+          - 4.14.1
+          - 5.0.0
 
     runs-on: ${{ matrix.os }}
 
@@ -112,7 +114,8 @@ jobs:
         os:
           - ubuntu-20.04
         ocaml-compiler:
-          - 4.08.0
+          - 4.14.1
+          - 5.0.0
 
     runs-on: ${{ matrix.os }}
 
@@ -200,7 +203,8 @@ jobs:
         os:
           - ubuntu-20.04
         ocaml-compiler:
-          - 4.08.0
+          - 4.14.1
+          - 5.0.0
 
     runs-on: ${{ matrix.os }}
 
@@ -278,7 +282,8 @@ jobs:
         os:
           - ubuntu-18.04
         ocaml-compiler:
-          - 4.08.0
+          - 4.14.1
+          - 5.0.0
 
     runs-on: ${{ matrix.os }}
 

--- a/.github/workflows/default.yml
+++ b/.github/workflows/default.yml
@@ -17,8 +17,7 @@ jobs:
         os:
           - ubuntu-20.04
         ocaml-compiler:
-          - 4.14.1
-          - 5.0.0
+          - 4.08.1
 
     runs-on: ${{ matrix.os }}
 

--- a/bin/dune
+++ b/bin/dune
@@ -3,4 +3,4 @@
   (public_name linx)
   (package links)
   (modes native)
-  (libraries threads.posix dynlink ANSITerminal linenoise links.core))
+  (libraries unix threads.posix dynlink ANSITerminal linenoise links.core))

--- a/bin/repl.ml
+++ b/bin/repl.ml
@@ -61,16 +61,16 @@ let print_value rtype value =
     pp_set_margin std_formatter width;
     pp_set_tags std_formatter (Settings.get print_colors);
     pp_set_mark_tags std_formatter (Settings.get print_colors);
-    begin [@alert "-deprecated"] pp_set_formatter_tag_functions
+    begin pp_set_formatter_stag_functions
       std_formatter
-      {mark_open_tag = (function
-                        | "constructor" -> "\x1b[32m"
-                        | "recordlabel" -> "\x1b[35m"
-                        (* | "string" -> "\x1b[36m" *)
+      {mark_open_stag = (function
+                        | String_tag "constructor" -> "\x1b[32m"
+                        | String_tag "recordlabel" -> "\x1b[35m"
+                        (* | String_tag "string" -> "\x1b[36m" *)
                         | _ -> "");
-       mark_close_tag  = (fun _ -> "\x1b[39m");
-       print_open_tag  = ignore;
-       print_close_tag = ignore;
+       mark_close_stag  = (fun _ -> "\x1b[39m");
+       print_open_stag  = ignore;
+       print_close_stag = ignore;
       }
     end;
     fprintf std_formatter "@[%a@;<1 4>: %s@]"

--- a/core/debug.ml
+++ b/core/debug.ml
@@ -22,7 +22,7 @@ let print_l message =
      prerr_endline (Lazy.force message); flush stderr)
 
 (** Print a formatted debugging message if debugging is enabled *)
-let f fmt = Printf.kprintf print fmt
+let f fmt = Printf.ksprintf print fmt
 
 (** Print a debugging message if debugging is enabled and setting is on.
     [message] is a thunk returning the string to print.

--- a/core/dune
+++ b/core/dune
@@ -17,7 +17,8 @@
              cohttp cohttp-lwt-unix cohttp-lwt
              conduit-lwt-unix uri
              websocket websocket-lwt-unix.cohttp
-             findlib menhirLib links.lens calendar)
+             findlib menhirLib links.lens calendar
+             dynlink)
   (preprocess (pps ppx_deriving.std ppx_deriving_yojson)))
 
 

--- a/core/query/queryLang.ml
+++ b/core/query/queryLang.ml
@@ -26,7 +26,7 @@ let runtime_type_error error =
 
 let query_error fmt =
   let error msg = raise (DbEvaluationError msg) in
-    Printf.kprintf error fmt
+    Printf.ksprintf error fmt
 
 type base_type = | Bool | Char | Float | Int | String | DateTime
 

--- a/database/mysql-driver/dune
+++ b/database/mysql-driver/dune
@@ -3,7 +3,7 @@
   (public_name links-mysql)
   (synopsis "MySQL database backend for Links")
   (optional)
-  (libraries mysql links.core))
+  (libraries str unix mysql links.core))
 
 
 (install

--- a/database/mysql8-driver/dune
+++ b/database/mysql8-driver/dune
@@ -3,7 +3,7 @@
   (public_name links-mysql8)
   (synopsis "MySQL8 database backend for Links")
   (optional)
-  (libraries mysql8 links.core))
+  (libraries str unix mysql8 links.core))
 
 
 (install

--- a/database/pg-driver/dune
+++ b/database/pg-driver/dune
@@ -3,7 +3,7 @@
   (public_name links-postgresql)
   (synopsis "PostgreSQL database backend for Links")
   (optional)
-  (libraries postgresql links.core))
+  (libraries unix str postgresql links.core))
 
 
 (install

--- a/database/sqlite3-driver/dune
+++ b/database/sqlite3-driver/dune
@@ -3,7 +3,7 @@
   (public_name links-sqlite3)
   (synopsis "SQLite 3 database backend for Links")
   (optional)
-  (libraries sqlite3 links.core))
+  (libraries str sqlite3 links.core))
 
 
 (install

--- a/lens/dune
+++ b/lens/dune
@@ -2,5 +2,5 @@
   (name links_lens)
   (public_name links.lens)
   (modes native)
-  (libraries result sexplib sexplib0)
+  (libraries str unix result sexplib sexplib0)
   (preprocess (pps ppx_deriving.std ppx_sexp_conv)))

--- a/linkspath/dune
+++ b/linkspath/dune
@@ -1,3 +1,3 @@
 (executable
  (name gen_linkspath)
- (libraries dune.configurator))
+ (libraries unix dune.configurator))


### PR DESCRIPTION
This patch makes our code base compile with OCaml 5.0.0, whilst maintaining compatibility with OCaml 4.08+.

This patch also changes the CI to use OCaml 4.14.1 and OCaml 5.0.0.