### PR TITLE
Hide session fail

### DIFF
--- a/core/basicsettings.ml
+++ b/core/basicsettings.ml
@@ -41,6 +41,16 @@ module Sessions = struct
               |> convert parse_bool
               |> CLI.(add (long "session-exceptions"))
               |> sync)
+
+  let expose_session_fail =
+    Settings.(flag "expose_session_fail" ~default:true
+              |> synopsis "Exposes the SessionFail effect"
+              |> depends Handlers.enabled
+              |> depends exceptions_enabled
+              |> privilege `System
+              |> convert parse_bool
+              |> CLI.(add (long "session-fail-exposed"))
+              |> sync)
 end
 
 module System = struct

--- a/core/basicsettings.ml
+++ b/core/basicsettings.ml
@@ -49,7 +49,7 @@ module Sessions = struct
               |> depends exceptions_enabled
               |> privilege `System
               |> convert parse_bool
-              |> CLI.(add (long "session-fail-exposed"))
+              |> CLI.(add (long "expose-session-fail"))
               |> sync)
 end
 

--- a/core/compilePatterns.ml
+++ b/core/compilePatterns.ml
@@ -646,7 +646,15 @@ and match_variant
                    if StringSet.mem name names then
                      (cases, cs)
                    else
-                     let case_type = TypeUtils.variant_at name t in
+                     let case_type =
+                       if Settings.get Basicsettings.Sessions.exceptions_enabled &&
+                          not (Settings.get Basicsettings.Sessions.expose_session_fail) &&
+                          String.compare name Value.session_exception_operation = 0
+                       then
+                         Types.empty_type
+                       else
+                         TypeUtils.variant_at name t
+                     in
 (*                     let inject_type = TypeUtils.inject_type name case_type in *)
                      let (case_binder, case_variable) = Var.fresh_var_of_type case_type in
                      let match_env = bind_type case_variable case_type env in
@@ -668,7 +676,13 @@ and match_variant
             let default_type =
               StringSet.fold
                 (fun name t ->
-                   let _, t = TypeUtils.split_variant_type name t in t) cs t in
+                   if Settings.get Basicsettings.Sessions.exceptions_enabled &&
+                      not (Settings.get Basicsettings.Sessions.expose_session_fail) &&
+                      String.compare name Value.session_exception_operation = 0
+                   then
+                     t
+                   else
+                     let _, t = TypeUtils.split_variant_type name t in t) cs t in
               begin
                 match default_type with
                   | Types.Variant row

--- a/core/compilePatterns.ml
+++ b/core/compilePatterns.ml
@@ -678,7 +678,7 @@ and match_variant
                 (fun name t ->
                    if Settings.get Basicsettings.Sessions.exceptions_enabled &&
                       not (Settings.get Basicsettings.Sessions.expose_session_fail) &&
-                      String.compare name Value.session_exception_operation = 0
+                      String.equal name Value.session_exception_operation
                    then
                      t
                    else

--- a/core/compilePatterns.ml
+++ b/core/compilePatterns.ml
@@ -649,7 +649,7 @@ and match_variant
                      let case_type =
                        if Settings.get Basicsettings.Sessions.exceptions_enabled &&
                           not (Settings.get Basicsettings.Sessions.expose_session_fail) &&
-                          String.compare name Value.session_exception_operation = 0
+                          String.equal name Value.session_exception_operation
                        then
                          Types.empty_type
                        else

--- a/core/desugarSessionExceptions.ml
+++ b/core/desugarSessionExceptions.ml
@@ -111,9 +111,12 @@ object (o : 'self_type)
           Types.make_pure_function_type [] (Types.empty_type) in
 
         let inner_effects =
-          effect_row
+          if Settings.get Basicsettings.Sessions.expose_session_fail then
+            effect_row
             |> Types.row_with (failure_op_name, Types.Present fail_cont_ty)
-            |> Types.flatten_row in
+            |> Types.flatten_row
+          else
+            effect_row in
 
         let cont_pat = variable_pat ~ty:(Types.make_function_type [] inner_effects (Types.empty_type))
           (Utility.gensym ~prefix:"dsh" ()) in

--- a/core/lib.ml
+++ b/core/lib.ml
@@ -399,7 +399,8 @@ let env : (string * (located_primitive * Types.datatype * pure)) list = [
   "spawn",
   (`PFun (fun _ -> assert false),
     begin
-    if Settings.get Basicsettings.Sessions.exceptions_enabled then
+    if Settings.get Basicsettings.Sessions.exceptions_enabled &&
+       Settings.get Basicsettings.Sessions.expose_session_fail then
       datatype "(() { SessionFail:[||] |e}~@ _) ~> Process ({ |e })"
     else
       datatype "(() ~e~@ _) ~> Process ({ |e })"
@@ -409,7 +410,8 @@ let env : (string * (located_primitive * Types.datatype * pure)) list = [
   "spawnAt",
   (`PFun (fun _ -> assert false),
     begin
-    if Settings.get Basicsettings.Sessions.exceptions_enabled then
+    if Settings.get Basicsettings.Sessions.exceptions_enabled &&
+       Settings.get Basicsettings.Sessions.expose_session_fail then
       datatype "(Location, () {SessionFail:[||] |e}~@ _) ~> Process ({ |e })"
     else
       datatype "(Location, () ~e~@ _) ~> Process ({ |e })"
@@ -419,7 +421,8 @@ let env : (string * (located_primitive * Types.datatype * pure)) list = [
   "spawnClient",
   (`PFun (fun _ -> assert false),
     begin
-    if Settings.get Basicsettings.Sessions.exceptions_enabled then
+    if Settings.get Basicsettings.Sessions.exceptions_enabled &&
+       Settings.get Basicsettings.Sessions.expose_session_fail then
       datatype "(() { SessionFail:[||] |e}~@ _) ~> Process ({ |e })"
     else
       datatype "(() ~e~@ _) ~> Process ({ |e })"
@@ -429,7 +432,8 @@ let env : (string * (located_primitive * Types.datatype * pure)) list = [
   "spawnAngel",
   (`PFun (fun _ -> assert false),
     begin
-    if Settings.get Basicsettings.Sessions.exceptions_enabled then
+    if Settings.get Basicsettings.Sessions.exceptions_enabled &&
+       Settings.get Basicsettings.Sessions.expose_session_fail then
       datatype "(() { SessionFail:[||] |e}~@ _) ~> Process ({ |e })"
     else
       datatype "(() ~e~@ _) ~> Process ({ |e })"
@@ -439,7 +443,8 @@ let env : (string * (located_primitive * Types.datatype * pure)) list = [
   "spawnAngelAt",
   (`PFun (fun _ -> assert false),
     begin
-    if Settings.get Basicsettings.Sessions.exceptions_enabled then
+    if Settings.get Basicsettings.Sessions.exceptions_enabled &&
+       Settings.get Basicsettings.Sessions.expose_session_fail then
       datatype "(Location, () { SessionFail:[||] |e}~@ _) ~> Process ({ |e })"
     else
       datatype "(Location, () ~e~@ _) ~> Process ({ |e })"

--- a/core/typeSugar.ml
+++ b/core/typeSugar.ml
@@ -4313,7 +4313,7 @@ let rec type_check : context -> phrase -> phrase * Types.datatype * Usage.t =
           in
             doop, rettyp, usage
         | Operation name ->
-           if String.compare name Value.session_exception_operation = 0 then
+           if String.equal name Value.session_exception_operation then
              if not context.desugared then
                Gripers.die pos "The session failure effect SessionFail is not directly invocable (use `raise` instead)"
              else

--- a/core/typeSugar.ml
+++ b/core/typeSugar.ml
@@ -3401,7 +3401,9 @@ let rec type_check : context -> phrase -> phrase * Types.datatype * Usage.t =
              *)
             let inner_effects = Types.row_with Types.wild_present pid_effects in
             let inner_effects =
-              if Settings.get  Basicsettings.Sessions.exceptions_enabled then
+              if Settings.get Basicsettings.Sessions.exceptions_enabled &&
+                 Settings.get Basicsettings.Sessions.expose_session_fail
+              then
                 let ty = Types.make_operation_type [] (Types.empty_type) in
                 Types.row_with (Value.session_exception_operation, T.Present ty) inner_effects
               else
@@ -4053,7 +4055,14 @@ let rec type_check : context -> phrase -> phrase * Types.datatype * Usage.t =
                      | Pattern.Operation (name, _, k) -> name, k
                      | _ -> assert false
                    in
-                   let effrow = Types.Effect (Types.make_singleton_open_row (effname, Types.Present efftyp) (lin_any, res_any)) in
+                   let effrow =
+                     if Settings.get Basicsettings.Sessions.exceptions_enabled &&
+                        not (Settings.get Basicsettings.Sessions.expose_session_fail) &&
+                        String.compare effname Value.session_exception_operation = 0
+                     then
+                       Types.Effect (Types.make_empty_open_row (lin_any, res_any))
+                     else
+                       Types.Effect (Types.make_singleton_open_row (effname, Types.Present efftyp) (lin_any, res_any)) in
                    unify ~handle:Gripers.handle_effect_patterns
                          ((uexp_pos pat, effrow),  no_pos (T.Effect inner_eff));
                    let pat, kpat =
@@ -4287,7 +4296,14 @@ let rec type_check : context -> phrase -> phrase * Types.datatype * Usage.t =
           let opname = find_opname (erase op) in
           let infer_opt = no_pos (Types.make_operation_type (List.map typ ps) rettyp) in
           let term = (exp_pos op, opt) in
-          let row = Types.make_singleton_open_row (opname, T.Present (typ op)) (lin_unl, res_effect) in
+          let row =
+            if Settings.get Basicsettings.Sessions.exceptions_enabled &&
+               not (Settings.get Basicsettings.Sessions.expose_session_fail) &&
+               String.compare opname Value.session_exception_operation = 0
+            then
+               Types.make_empty_open_row (lin_unl, res_effect)
+            else
+              Types.make_singleton_open_row (opname, T.Present (typ op)) (lin_unl, res_effect) in
           let p = Position.resolve_expression pos in
           let () =
             unify ~handle:Gripers.do_operation
@@ -4297,10 +4313,14 @@ let rec type_check : context -> phrase -> phrase * Types.datatype * Usage.t =
           in
             doop, rettyp, usage
         | Operation name ->
-           if String.compare name Value.session_exception_operation = 0 && not context.desugared then
-             Gripers.die pos "The session failure effect SessionFail is not directly invocable (use `raise` instead)"
+           if String.compare name Value.session_exception_operation = 0 then
+             if not context.desugared then
+               Gripers.die pos "The session failure effect SessionFail is not directly invocable (use `raise` instead)"
+             else
+               (Operation name, Types.empty_type, Usage.empty)
            else
-             let t = match lookup_effect context name with
+             let t =
+               match lookup_effect context name with
                | Some t -> t
                | None   -> Types.fresh_type_variable (lin_unl, res_any)
              in
@@ -4316,13 +4336,21 @@ let rec type_check : context -> phrase -> phrase * Types.datatype * Usage.t =
               outer effects *)
             let rho = Types.fresh_row_variable default_effect_subkind in
             let outer_effects =
-              Types.row_with
-                (Value.session_exception_operation, Types.fresh_presence_variable default_subkind)
-                (T.Row (StringMap.empty, rho, false)) in
+              if Settings.get Basicsettings.Sessions.expose_session_fail then
+                Types.row_with
+                  (Value.session_exception_operation, Types.fresh_presence_variable default_subkind)
+                  (T.Row (StringMap.empty, rho, false))
+              else
+                T.Row (StringMap.empty, rho, false)
+            in
             let try_effects =
-              Types.row_with
-                (Value.session_exception_operation, T.Present (Types.make_operation_type [] Types.empty_type))
-                (T.Row (StringMap.empty, rho, false)) in
+              if Settings.get Basicsettings.Sessions.expose_session_fail then
+                Types.row_with
+                  (Value.session_exception_operation, T.Present (Types.make_operation_type [] Types.empty_type))
+                  (T.Row (StringMap.empty, rho, false))
+              else
+                T.Row (StringMap.empty, rho, false)
+            in
 
             unify ~handle:Gripers.try_effect
               (no_pos (T.Effect context.effect_row), no_pos (T.Effect outer_effects));
@@ -4400,9 +4428,13 @@ let rec type_check : context -> phrase -> phrase * Types.datatype * Usage.t =
                 erase unless_phrase, Some return_type), return_type, usages_res
         | QualifiedVar _ -> assert false
         | Raise ->
-            let effects = Types.make_singleton_open_row
-                            (Value.session_exception_operation, T.Present (Types.make_operation_type [] Types.empty_type))
-                            default_effect_subkind
+            let effects =
+              if Settings.get Basicsettings.Sessions.expose_session_fail then
+                Types.make_singleton_open_row
+                  (Value.session_exception_operation, T.Present (Types.make_operation_type [] Types.empty_type))
+                  default_effect_subkind
+              else
+                Types.make_empty_open_row default_effect_subkind
             in
             unify ~handle:Gripers.raise_effect
               (no_pos (T.Effect context.effect_row), (Position.resolve_expression pos, T.Effect effects));

--- a/core/typeSugar.ml
+++ b/core/typeSugar.ml
@@ -4058,7 +4058,7 @@ let rec type_check : context -> phrase -> phrase * Types.datatype * Usage.t =
                    let effrow =
                      if Settings.get Basicsettings.Sessions.exceptions_enabled &&
                         not (Settings.get Basicsettings.Sessions.expose_session_fail) &&
-                        String.compare effname Value.session_exception_operation = 0
+                        String.equal effname Value.session_exception_operation
                      then
                        Types.Effect (Types.make_empty_open_row (lin_any, res_any))
                      else

--- a/core/typeSugar.ml
+++ b/core/typeSugar.ml
@@ -4299,7 +4299,7 @@ let rec type_check : context -> phrase -> phrase * Types.datatype * Usage.t =
           let row =
             if Settings.get Basicsettings.Sessions.exceptions_enabled &&
                not (Settings.get Basicsettings.Sessions.expose_session_fail) &&
-               String.compare opname Value.session_exception_operation = 0
+               String.equal opname Value.session_exception_operation
             then
                Types.make_empty_open_row (lin_unl, res_effect)
             else

--- a/lib/stdlib/monitorConnection.links
+++ b/lib/stdlib/monitorConnection.links
@@ -1,0 +1,54 @@
+# This module provides a simple API for creating a connection between
+# a client and a server in which cleanup code will automatically be
+# called as soon as the connection is broken (e.g. because the client
+# closes the browser window).
+
+# Required settings:
+#
+#   enable_handlers=true
+#   session_exceptions=true
+#   expose_session_fail=false
+
+# Typical mode of use. For each client:
+#
+# * Create a new connection object `conn` by calling `newConnection()`
+#
+# * Initialise the client by calling `clientInit(conn)` on the client.
+#
+# * Initialise the server by calling `serverInit(conn, cleanup)` on
+# the server. The `cleanup` function be called as soon as the
+# connection is closed.
+#
+# The `clientInit` and `serverInit` functions should be called exactly
+# once for each new connection object.
+
+# The implementation represents connection objects as access points
+# and relies on session exceptions in order to detect broken
+# connections.
+
+typename Connection = AP(?().End);
+
+sig newConnection : () ~> Connection
+fun newConnection() {
+  new()
+}
+
+sig clientInit : (Connection) ~> ()
+fun clientInit(conn) {
+  ignore(spawn {var c = request(conn); ignore(recv()); close(send((), c))})
+}
+
+sig serverInit : (Connection, () ~e~> ()) ~e~> ()
+fun serverInit(conn, cleanup) {
+  ignore(spawn {
+    var c = accept(conn);
+    try {
+      var ((), c) = receive(c);
+      close(c)
+    } as () in {
+      ()
+    } otherwise {
+      cleanup()
+    }
+  })
+}


### PR DESCRIPTION
Session exceptions are compiled into effects and handlers. A practical difficulty with this is that code can become polluted with the `SessionFail` effect. Moreover, if session exceptions are switched on then the typing rules for all of the spawn operators change to take into the `SessionFail` effect (see core/lib.ml). This PR adds an experimental setting `expose_session_fail` which defaults to `true` (giving the old behaviour), but when set to `false` will hide the `SessionFail` effect as part of the built-in `wild` effect.

The PR is technically incomplete as it does not include special cases for treating `SessionFail` in the IR type checker when `expose_session_fail` is disabled, but it is safely hidden behind an experimental setting and is already sufficient to use for practical examples - and in particular makes it possible to implement functionality for detecting when a browser window closes in MVU applications which are not compatible with the `SessionFail` effect appearing explicitly in types.
