### PR TITLE
Update ocamlformat

### DIFF
--- a/.github/workflows/default.yml
+++ b/.github/workflows/default.yml
@@ -17,7 +17,7 @@ jobs:
         os:
           - ubuntu-20.04
         ocaml-compiler:
-          - 4.08.1
+          - 4.14.1
 
     runs-on: ${{ matrix.os }}
 
@@ -33,7 +33,7 @@ jobs:
         with:
           ocaml-compiler: ${{ matrix.ocaml-compiler }}
 
-      - run: opam install -y ocamlformat.0.19.0
+      - run: opam install -y ocamlformat.0.25.1
 
       - name: Ad-hoc rule check
         run: |

--- a/tests/unit/lens/database_utility_test.ml
+++ b/tests/unit/lens/database_utility_test.ml
@@ -5,7 +5,8 @@ module H = LensTestHelpers
 let test_create_table test_ctx =
   let module DB = (val TestUtility.Table.create test_ctx) in
   let module MyTable =
-  (val DB.drop_create_easy ~table:"MyTable" "key1 key2 -> value1 value2 value3")
+    (val DB.drop_create_easy ~table:"MyTable"
+           "key1 key2 -> value1 value2 value3")
   in
   let testData = [ [ 1; 1; 1; 1; 1 ]; [ 1; 2; 3; 1; 2 ]; [ 3; 3; 3; 3; 3 ] ] in
   MyTable.insert_ints testData;
@@ -15,8 +16,8 @@ let test_create_table test_ctx =
 let test_create_table_rand test_ctx =
   let module DB = (val TestUtility.Table.create test_ctx) in
   let module MyTableRand =
-  (val DB.drop_create_easy ~table:"MyTableRand"
-         "key1 key2 -> value1 value2 value3")
+    (val DB.drop_create_easy ~table:"MyTableRand"
+           "key1 key2 -> value1 value2 value3")
   in
   let testData =
     H.gen_data [ `Seq; `Constant 1; `RandTo 15; `Rand; `Rand ] 100
@@ -28,8 +29,8 @@ let test_create_table_rand test_ctx =
 let test_drop_create_and_populate test_ctx =
   let module DB = (val TestUtility.Table.create test_ctx) in
   let module TestTable =
-  (val DB.drop_create_easy_populate ~table:"test_table" ~fd:"a -> b c" ~n:500
-         [ `Seq; `RandTo 15; `Rand ])
+    (val DB.drop_create_easy_populate ~table:"test_table" ~fd:"a -> b c" ~n:500
+           [ `Seq; `RandTo 15; `Rand ])
   in
   assert_equal 500 (TestTable.count ());
   TestTable.drop ()

--- a/tests/unit/lens/lens_primitives_tests.ml
+++ b/tests/unit/lens/lens_primitives_tests.ml
@@ -165,8 +165,8 @@ let test_select_lens_1 n test_ctx =
   let behaviour = behaviour test_ctx in
   let module DB = (val Table.create test_ctx) in
   let module T1 =
-  (val DB.drop_create_easy_populate ~table:"t1" ~fd:"a -> b c" ~n
-         [ `Seq; `RandTo (n / 15); `Rand ])
+    (val DB.drop_create_easy_populate ~table:"t1" ~fd:"a -> b c" ~n
+           [ `Seq; `RandTo (n / 15); `Rand ])
   in
   let db = DB.db in
   let l1 = T1.lens () in
@@ -307,8 +307,8 @@ let template_put_delta ~n ~upto ~put test_ctx =
   let module DB = (val Table.create test_ctx) in
   let db = DB.db in
   let module T1 =
-  (val DB.drop_create_easy_populate ~table:"t1" ~fd:"a -> b c" ~n
-         [ `Seq; `RandTo (n / 10); `RandTo 100 ])
+    (val DB.drop_create_easy_populate ~table:"t1" ~fd:"a -> b c" ~n
+           [ `Seq; `RandTo (n / 10); `RandTo 100 ])
   in
   let l1 = T1.lens () in
   let res = Lens.Value.lens_get ~db l1 in
@@ -449,7 +449,8 @@ let test_join_lens_dr_2 n test_ctx =
   in
   let l2 =
     H.drop_create_populate_table test_ctx db "t2" "b -> d" "b d"
-      [ `Seq; `RandTo 40 ] 50
+      [ `Seq; `RandTo 40 ]
+      50
   in
   let l3 = H.join_lens_dr l1 l2 [ ("b", "b", "b") ] in
   let res =

--- a/tests/unit/lens/unitTestsLensPerformance.ml
+++ b/tests/unit/lens/unitTestsLensPerformance.ml
@@ -30,22 +30,22 @@ let test_join_five test_ctx n =
   skip_long_performance test_ctx;
   let module DB = (val TestUtility.Table.create test_ctx) in
   let module L1 =
-  (val DB.drop_create_easy_populate ~table:"t1" ~fd:"a -> b c" ~n
-         [ `Seq; `RandTo (n / 15); `Rand ])
+    (val DB.drop_create_easy_populate ~table:"t1" ~fd:"a -> b c" ~n
+           [ `Seq; `RandTo (n / 15); `Rand ])
   in
   let module L2 =
-  (val DB.drop_create_easy_populate ~table:"t2" ~fd:"b -> d e" ~n:(n / 15)
-         [ `Seq; `RandTo (n / 15 / 15); `Rand ])
+    (val DB.drop_create_easy_populate ~table:"t2" ~fd:"b -> d e" ~n:(n / 15)
+           [ `Seq; `RandTo (n / 15 / 15); `Rand ])
   in
   let module L3 =
-  (val DB.drop_create_easy_populate ~table:"t3" ~fd:"d -> f g"
-         ~n:(n / 15 / 15)
-         [ `Seq; `RandTo (n / 15 / 15 / 15); `Rand ])
+    (val DB.drop_create_easy_populate ~table:"t3" ~fd:"d -> f g"
+           ~n:(n / 15 / 15)
+           [ `Seq; `RandTo (n / 15 / 15 / 15); `Rand ])
   in
   let module L4 =
-  (val DB.drop_create_easy_populate ~table:"t4" ~fd:"f -> h"
-         ~n:(n / 15 / 15 / 15)
-         [ `Seq; `Rand ])
+    (val DB.drop_create_easy_populate ~table:"t4" ~fd:"f -> h"
+           ~n:(n / 15 / 15 / 15)
+           [ `Seq; `Rand ])
   in
   let l1 = L1.lens () in
   let l2 = L2.lens () in

--- a/tools/rules/tabs.sh
+++ b/tools/rules/tabs.sh
@@ -16,7 +16,7 @@ if has_gnu_find ; then
       TAB_REGEX=$'\t'
       EVAL_CMD="find \""$dir"\" \
         -type f \( ${FIND_STR} \) \
-        -exec egrep -l \"$TAB_REGEX\" {} \; "
+        -exec grep -E -l \"$TAB_REGEX\" {} \; "
       for file in $(eval "$EVAL_CMD"); do
           echo "Tab character found in $file, alerting authorities."
           exit 1

--- a/tools/rules/trailing_whitespace.sh
+++ b/tools/rules/trailing_whitespace.sh
@@ -19,7 +19,7 @@ ERRORS=0
 
 for dir in ${DIRS[@]}; do
     for file in $(eval "find \""$dir"\" -type f \( ${FIND_STR} \) \
-      -exec egrep -l \" +$\" {} \;"); do
+      -exec grep -E -l \" +$\" {} \;"); do
           echo -n "$file"
           if [[ $STRIP -eq 1 ]]; then
               echo -n "..."


### PR DESCRIPTION
This PR updates the version of `ocamlformat` that is used when running `make rule-check` as part of our CI. The previously used version was not compatible with recent versions of OCaml. Updating to a newer version of `ocamlformat` therefore  also allows us to use a newer version of OCaml in that particular part of the CI.
 
Some files have been slightly reformatted as part of this.