### PR TITLE
Robust build infrastructure

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -43,7 +43,7 @@ ROOT:=$(shell dirname $(firstword $(MAKEFILE_LIST)))
 BUILD_DIR:=$(ROOT)/_build
 
 # The build command and some standard build system flags
-BUILD=dune build
+BUILD=opam exec dune -- build
 MAIN=links
 SOURCES=$(MAIN)
 DB_STABLE=links-postgresql,links-sqlite3,links-mysql8
@@ -148,7 +148,7 @@ database-tests: links
 # Cleans the project directory.
 .PHONY: clean
 clean:
-	dune clean
+	opam exec dune -- clean
 	rm -rf *.install
 	rm -rf links linx
 	rm -rf doc/_build

--- a/Makefile
+++ b/Makefile
@@ -125,7 +125,7 @@ include-db-sources:
 # Auxiliary rule used by `opam install` to build Links
 .PHONY: opam-build-links.opam
 opam-build-links.opam: links.opam
-	$(shell LINKS_BUILT_BY_OPAM=1 dune build -p links)
+	$(shell LINKS_BUILT_BY_OPAM=1 opam exec dune -- build -p links)
 
 # Runs the test suite. We reset the variables CAMLRUNPARAM and
 # OCAMLRUNPARAM, because some of the tests are sensitive to the
@@ -175,8 +175,8 @@ open-doc: doc/_build/html
 
 # Release Links
 opam-release:
-	dune-release tag
-	dune-release distrib -p $(RELEASE_PKGS)
-	dune-release publish -p $(RELEASE_PKGS) distrib
-	dune-release opam -p $(RELEASE_PKGS) pkg
-	dune-release opam -p $(RELEASE_PKGS) submit
+	opam exec dune-release -- tag
+	opam exec dune-release -- distrib -p $(RELEASE_PKGS)
+	opam exec dune-release -- publish -p $(RELEASE_PKGS) distrib
+	opam exec dune-release -- opam -p $(RELEASE_PKGS) pkg
+	opam exec dune-release -- opam -p $(RELEASE_PKGS) submit

--- a/linkspath/gen_linkspath.ml
+++ b/linkspath/gen_linkspath.ml
@@ -15,13 +15,13 @@
 module C = Configurator.V1
 
 let is_git_repository () =
-  try
-    let ic = Unix.open_process_in "git rev-parse --is-inside-work-tree 2> /dev/null" in
-    let ans = String.equal "true" (input_line ic) in
-    match Unix.close_process_in ic with
-    | Unix.WEXITED 0 -> ans
-    | _ -> false
-  with End_of_file -> false
+  let ic = Unix.open_process_in "git rev-parse --is-inside-work-tree 2> /dev/null" in
+  let ans =
+    try String.equal "true" (input_line ic) with _ -> false
+  in
+  match Unix.close_process_in ic with
+  | Unix.WEXITED 0 -> ans
+  | _ -> false
 
 let check_opam =
   Option.is_some (Sys.getenv_opt "LINKS_BUILT_BY_OPAM")
@@ -55,7 +55,7 @@ let _ =
          let cwd = Sys.getcwd () in
          let config = "None" in
          let paths =
-           List.map (Filename.concat cwd) ["lib/js"; "examples"; "lib/stdlib"; "prelude.links"]
+           List.map (Filename.concat cwd) ["../lib/js"; "../examples"; "../lib/stdlib"; "../prelude.links"]
          in
          config :: paths
   in

--- a/linkspath/gen_linkspath.ml
+++ b/linkspath/gen_linkspath.ml
@@ -14,29 +14,55 @@
 
 module C = Configurator.V1
 
+let is_git_repository () =
+  try
+    let ic = Unix.open_process_in "git rev-parse --is-inside-work-tree 2> /dev/null" in
+    let ans = String.equal "true" (input_line ic) in
+    match Unix.close_process_in ic with
+    | Unix.WEXITED 0 -> ans
+    | _ -> false
+  with End_of_file -> false
+
 let check_opam =
   Option.is_some (Sys.getenv_opt "LINKS_BUILT_BY_OPAM")
 
 let _ =
+
+  let[@warning "-8"] [config; jslib; examples; stdlib; prelude]  =
+    if check_opam (* If Links is being built by OPAM *)
+    then let lib = input_line (Unix.open_process_in "opam var lib") in
+         let etc = input_line (Unix.open_process_in "opam var etc") in
+         let share = input_line (Unix.open_process_in "opam var share") in
+         let[@warning "-8"] [etc; lib; share] =
+           List.map (fun dir -> Filename.concat dir "links") [etc; lib; share]
+         in
+         let config = Printf.sprintf "Some \"%s\"" (Filename.concat etc "config") in
+         let jslib = Filename.concat lib "js" in
+         let examples = Filename.concat share "examples" in
+         let stdlib = Filename.concat lib "stdlib" in
+         let prelude = Filename.concat lib "prelude.links" in
+         [config; jslib; examples; stdlib; prelude]
+    else if is_git_repository () (* If Links is being built from the git repository sources *)
+    then let root = input_line (Unix.open_process_in "git rev-parse --show-toplevel") in
+         let config = "None" in
+         let paths =
+           List.map (Filename.concat root) ["lib/js"; "examples"; "lib/stdlib"; "prelude.links"]
+         in
+         config :: paths
+    else (* If Links is being built from other sources, then we do a
+            best effort guess based of the current working
+            directory. *)
+         let cwd = Sys.getcwd () in
+         let config = "None" in
+         let paths =
+           List.map (Filename.concat cwd) ["lib/js"; "examples"; "lib/stdlib"; "prelude.links"]
+         in
+         config :: paths
+  in
   let oc = open_out "linkspath.ml" in
-      if check_opam
-      then
-        (* If Links is built by OPAM *)
-        let lib_path = input_line (Unix.open_process_in "opam var lib") in
-        let etc_path = input_line (Unix.open_process_in "opam var etc") in
-        let share_path = input_line (Unix.open_process_in "opam var share") in
-          Printf.fprintf oc "let config = Some \"%s/links/config\"\n" etc_path;
-          Printf.fprintf oc "let jslib = \"%s/links/js\"\n" lib_path;
-          Printf.fprintf oc "let examples = \"%s/links/examples\"\n" share_path;
-          Printf.fprintf oc "let stdlib = \"%s/links/stdlib\"\n" lib_path;
-          Printf.fprintf oc "let prelude = \"%s/links/prelude.links\"\n" lib_path;
-          close_out oc
-      else
-        (* If Links is complied from source *)
-        let git_path =  input_line (Unix.open_process_in "git rev-parse --show-toplevel") in
-          Printf.fprintf oc "let config = %s\n" "None";
-          Printf.fprintf oc "let jslib = \"%s/lib/js\"\n" git_path;
-          Printf.fprintf oc "let examples = \"%s/examples\"\n" git_path;
-          Printf.fprintf oc "let stdlib = \"%s/lib/stdlib\"\n" git_path;
-          Printf.fprintf oc "let prelude = \"%s/prelude.links\"\n" git_path;
-        close_out oc
+  Printf.fprintf oc "let config = %s\n" config;
+  Printf.fprintf oc "let jslib = \"%s\"\n" jslib;
+  Printf.fprintf oc "let examples = \"%s\"\n" examples;
+  Printf.fprintf oc "let stdlib = \"%s\"\n" stdlib;
+  Printf.fprintf oc "let prelude = \"%s\"\n" prelude;
+  close_out oc


### PR DESCRIPTION
This patch makes the build infrastructure for Links more robust. Previously, the build infrastructure would assume that it is running in an environment populated by OPAM. This assumption is too optimistic; for example a Docker container will give you a blank environment by default. To make it easier to install Links in such environments we now prefix dune build commands with `opam exec`. This command resolves the installation directory of dune and makes sure it is invoked with a suitable environment.

Furthermore, the `gen_linkspath.exe` install helper would only test whether Links is being built by OPAM, and if that was not the case then it would assume Links was being built from sources in a local checkout of the git repository. This assumption is a tad optimistic too. So now, if we cannot detect either an OPAM installation or the git repository, then we fall back to a best effort guess based off the current working directory.