### PR TITLE
Better workaround for issue #1187 (warning 40 due to @@deriving sexp)

### DIFF
--- a/lens/column.ml
+++ b/lens/column.ml
@@ -3,7 +3,8 @@ module Type = Phrase_type
 
 (* Workaround for issue #1187 (i.e., the @@deriving sexp clause on t
    below creates code triggering warning 40 otherwise) *)
-open Sexplib0.Sexp_conv
+open Sexplib0.Sexp_conv_record.Fields
+open Sexplib0.Sexp_conv_record.Kind
 
 type t = {
   table : string;

--- a/lens/column.ml
+++ b/lens/column.ml
@@ -1,22 +1,18 @@
 open Lens_utility
 module Type = Phrase_type
 
-include struct
-  (* Workaround for issue #1187 (i.e., the @@deriving sexp clause on t
-     below creates code triggering warning 40):
-     We disable warning 40 within this module, and immediately include it. *)
+(* Workaround for issue #1187 (i.e., the @@deriving sexp clause on t
+   below creates code triggering warning 40 otherwise) *)
+open Sexplib0.Sexp_conv
 
-  [@@@ocaml.warning "-40"]
-
-  type t = {
-    table : string;
-    name : string;
-    alias : string;
-    typ : Type.t;
-    present : bool;
-  }
-  [@@deriving show, sexp]
-end
+type t = {
+  table : string;
+  name : string;
+  alias : string;
+  typ : Type.t;
+  present : bool;
+}
+[@@deriving show, sexp]
 
 let make ~table ~name ~alias ~typ ~present =
   { table; name; alias; typ; present }

--- a/lens/column.ml
+++ b/lens/column.ml
@@ -1,14 +1,22 @@
 open Lens_utility
 module Type = Phrase_type
 
-type t = {
-  table : string;
-  name : string;
-  alias : string;
-  typ : Type.t;
-  present : bool;
-}
-[@@deriving show, sexp]
+include struct
+  (* Workaround for issue #1187 (i.e., the @@deriving sexp clause on t
+     below creates code triggering warning 40):
+     We disable warning 40 within this module, and immediately include it. *)
+
+  [@@@ocaml.warning "-40"]
+
+  type t = {
+    table : string;
+    name : string;
+    alias : string;
+    typ : Type.t;
+    present : bool;
+  }
+  [@@deriving show, sexp]
+end
 
 let make ~table ~name ~alias ~typ ~present =
   { table; name; alias; typ; present }

--- a/lens/database.ml
+++ b/lens/database.ml
@@ -4,7 +4,8 @@ module LPV = Phrase_value
 
 (* Workaround for issue #1187 (i.e., the @@deriving sexp clause on t
    below creates code triggering warning 40 otherwise) *)
-open Sexplib0.Sexp_conv
+open Sexplib0.Sexp_conv_record.Fields
+open Sexplib0.Sexp_conv_record.Kind
 
 type t = {
   serialize : unit -> string;

--- a/lens/database.ml
+++ b/lens/database.ml
@@ -2,23 +2,19 @@ open Operators
 open Lens_utility
 module LPV = Phrase_value
 
-include struct
-  (* Workaround for issue #1187 (i.e., the @@deriving sexp clause on t
-     below creates code triggering warning 40):
-     We disable warning 40 within this module, and immediately include it. *)
+(* Workaround for issue #1187 (i.e., the @@deriving sexp clause on t
+   below creates code triggering warning 40 otherwise) *)
+open Sexplib0.Sexp_conv
 
-  [@@@ocaml.warning "-40"]
-
-  type t = {
-    serialize : unit -> string;
-    driver_name : unit -> string;
-    escape_string : string -> string;
-    quote_field : string -> string;
-    execute : string -> unit;
-    execute_select :
-      string -> field_types:(string * Phrase_type.t) list -> Phrase_value.t list;
-  }
-end
+type t = {
+  serialize : unit -> string;
+  driver_name : unit -> string;
+  escape_string : string -> string;
+  quote_field : string -> string;
+  execute : string -> unit;
+  execute_select :
+    string -> field_types:(string * Phrase_type.t) list -> Phrase_value.t list;
+}
 
 module E = struct
   type t =
@@ -56,13 +52,7 @@ let show _ = "<db_driver>"
 let pp f v = Format.fprintf f "%s" (show v)
 
 module Table = struct
-  include struct
-    (* Defining t withing a module and immediately including it as a way to
-       disable warning 40 exactly on the code generated for the
-       @@deriving clauses below *)
-    [@@@ocaml.warning "-40"]
-    type t = { name : string; keys : string list list } [@@deriving sexp]
-  end
+  type t = { name : string; keys : string list list } [@@deriving sexp]
 
   let name t = t.name
 end

--- a/lens/database.ml
+++ b/lens/database.ml
@@ -2,15 +2,23 @@ open Operators
 open Lens_utility
 module LPV = Phrase_value
 
-type t = {
-  serialize : unit -> string;
-  driver_name : unit -> string;
-  escape_string : string -> string;
-  quote_field : string -> string;
-  execute : string -> unit;
-  execute_select :
-    string -> field_types:(string * Phrase_type.t) list -> Phrase_value.t list;
-}
+include struct
+  (* Workaround for issue #1187 (i.e., the @@deriving sexp clause on t
+     below creates code triggering warning 40):
+     We disable warning 40 within this module, and immediately include it. *)
+
+  [@@@ocaml.warning "-40"]
+
+  type t = {
+    serialize : unit -> string;
+    driver_name : unit -> string;
+    escape_string : string -> string;
+    quote_field : string -> string;
+    execute : string -> unit;
+    execute_select :
+      string -> field_types:(string * Phrase_type.t) list -> Phrase_value.t list;
+  }
+end
 
 module E = struct
   type t =
@@ -48,7 +56,13 @@ let show _ = "<db_driver>"
 let pp f v = Format.fprintf f "%s" (show v)
 
 module Table = struct
-  type t = { name : string; keys : string list list } [@@deriving sexp]
+  include struct
+    (* Defining t withing a module and immediately including it as a way to
+       disable warning 40 exactly on the code generated for the
+       @@deriving clauses below *)
+    [@@@ocaml.warning "-40"]
+    type t = { name : string; keys : string list list } [@@deriving sexp]
+  end
 
   let name t = t.name
 end

--- a/lens/sort.ml
+++ b/lens/sort.ml
@@ -2,13 +2,21 @@ open Lens_utility
 open Lens_utility.O
 module Column = Column
 
-type t = {
-  fds : Fun_dep.Set.t;
-  predicate : Phrase.t option;
-  query : Phrase.t option;
-  cols : Column.t list;
-}
-[@@deriving show, sexp]
+include struct
+  (* Workaround for issue #1187 (i.e., the @@deriving sexp clause on t
+     below creates code triggering warning 40):
+     We disable warning 40 within this module, and immediately include it. *)
+
+  [@@@ocaml.warning "-40"]
+
+  type t = {
+    fds : Fun_dep.Set.t;
+    predicate : Phrase.t option;
+    query : Phrase.t option;
+    cols : Column.t list;
+  }
+  [@@deriving show, sexp]
+end
 
 let fds t = t.fds
 

--- a/lens/sort.ml
+++ b/lens/sort.ml
@@ -2,21 +2,17 @@ open Lens_utility
 open Lens_utility.O
 module Column = Column
 
-include struct
-  (* Workaround for issue #1187 (i.e., the @@deriving sexp clause on t
-     below creates code triggering warning 40):
-     We disable warning 40 within this module, and immediately include it. *)
+(* Workaround for issue #1187 (i.e., the @@deriving sexp clause on t
+   below creates code triggering warning 40 otherwise) *)
+open Sexplib0.Sexp_conv
 
-  [@@@ocaml.warning "-40"]
-
-  type t = {
-    fds : Fun_dep.Set.t;
-    predicate : Phrase.t option;
-    query : Phrase.t option;
-    cols : Column.t list;
-  }
-  [@@deriving show, sexp]
-end
+type t = {
+  fds : Fun_dep.Set.t;
+  predicate : Phrase.t option;
+  query : Phrase.t option;
+  cols : Column.t list;
+}
+[@@deriving show, sexp]
 
 let fds t = t.fds
 

--- a/lens/sort.ml
+++ b/lens/sort.ml
@@ -4,7 +4,8 @@ module Column = Column
 
 (* Workaround for issue #1187 (i.e., the @@deriving sexp clause on t
    below creates code triggering warning 40 otherwise) *)
-open Sexplib0.Sexp_conv
+open Sexplib0.Sexp_conv_record.Fields
+open Sexplib0.Sexp_conv_record.Kind
 
 type t = {
   fds : Fun_dep.Set.t;

--- a/lens/value.ml
+++ b/lens/value.ml
@@ -1,33 +1,29 @@
 open Lens_utility
 
-include struct
-  (* Workaround for issue #1187 (i.e., the @@deriving sexp clause on t
-     below creates code triggering warning 40):
-     We disable warning 40 within this module, and immediately include it. *)
+(* Workaround for issue #1187 (i.e., the @@deriving sexp clause on t
+   below creates code triggering warning 40 otherwise) *)
+open Sexplib0.Sexp_conv
 
-  [@@@ocaml.warning "-40"]
-
-  type t =
-    | Lens of { table : Database.Table.t; sort : Sort.t }
-    | LensMem of { records : Phrase_value.t list; sort : Sort.t }
-    | LensSelect of { lens : t; predicate : Phrase.t; sort : Sort.t }
-    | LensJoin of {
-        left : t;
-        right : t;
-        on : (string * string * string) list;
-        del_left : Phrase.t;
-        del_right : Phrase.t;
-        sort : Sort.t;
-      }
-    | LensDrop of {
-        lens : t;
-        drop : string;
-        key : string;
-        default : Phrase_value.t;
-        sort : Sort.t;
-      }
-  [@@deriving sexp]
-end
+type t =
+  | Lens of { table : Database.Table.t; sort : Sort.t }
+  | LensMem of { records : Phrase_value.t list; sort : Sort.t }
+  | LensSelect of { lens : t; predicate : Phrase.t; sort : Sort.t }
+  | LensJoin of {
+      left : t;
+      right : t;
+      on : (string * string * string) list;
+      del_left : Phrase.t;
+      del_right : Phrase.t;
+      sort : Sort.t;
+    }
+  | LensDrop of {
+      lens : t;
+      drop : string;
+      key : string;
+      default : Phrase_value.t;
+      sort : Sort.t;
+    }
+[@@deriving sexp]
 
 let serialize v =
   let sexp = sexp_of_t v in

--- a/lens/value.ml
+++ b/lens/value.ml
@@ -1,25 +1,33 @@
 open Lens_utility
 
-type t =
-  | Lens of { table : Database.Table.t; sort : Sort.t }
-  | LensMem of { records : Phrase_value.t list; sort : Sort.t }
-  | LensSelect of { lens : t; predicate : Phrase.t; sort : Sort.t }
-  | LensJoin of {
-      left : t;
-      right : t;
-      on : (string * string * string) list;
-      del_left : Phrase.t;
-      del_right : Phrase.t;
-      sort : Sort.t;
-    }
-  | LensDrop of {
-      lens : t;
-      drop : string;
-      key : string;
-      default : Phrase_value.t;
-      sort : Sort.t;
-    }
-[@@deriving sexp]
+include struct
+  (* Workaround for issue #1187 (i.e., the @@deriving sexp clause on t
+     below creates code triggering warning 40):
+     We disable warning 40 within this module, and immediately include it. *)
+
+  [@@@ocaml.warning "-40"]
+
+  type t =
+    | Lens of { table : Database.Table.t; sort : Sort.t }
+    | LensMem of { records : Phrase_value.t list; sort : Sort.t }
+    | LensSelect of { lens : t; predicate : Phrase.t; sort : Sort.t }
+    | LensJoin of {
+        left : t;
+        right : t;
+        on : (string * string * string) list;
+        del_left : Phrase.t;
+        del_right : Phrase.t;
+        sort : Sort.t;
+      }
+    | LensDrop of {
+        lens : t;
+        drop : string;
+        key : string;
+        default : Phrase_value.t;
+        sort : Sort.t;
+      }
+  [@@deriving sexp]
+end
 
 let serialize v =
   let sexp = sexp_of_t v in

--- a/lens/value.ml
+++ b/lens/value.ml
@@ -2,7 +2,8 @@ open Lens_utility
 
 (* Workaround for issue #1187 (i.e., the @@deriving sexp clause on t
    below creates code triggering warning 40 otherwise) *)
-open Sexplib0.Sexp_conv
+open Sexplib0.Sexp_conv_record.Fields
+open Sexplib0.Sexp_conv_record.Kind
 
 type t =
   | Lens of { table : Database.Table.t; sort : Sort.t }

--- a/links.opam
+++ b/links.opam
@@ -35,7 +35,7 @@ depends: [
   "result"
   "ocamlfind"
   "menhir" {>= "20210419"}
-  "ppx_sexp_conv"
+  "ppx_sexp_conv" {>= "v0.16.0"}
   "calendar" {>= "2.0.4"}
   "rdf_lwt" {>= "0.13.0"}
 ]

--- a/links.opam
+++ b/links.opam
@@ -35,7 +35,7 @@ depends: [
   "result"
   "ocamlfind"
   "menhir" {>= "20210419"}
-  "ppx_sexp_conv" {<= "v0.15.1"}
+  "ppx_sexp_conv"
   "calendar" {>= "2.0.4"}
   "rdf_lwt" {>= "0.13.0"}
 ]


### PR DESCRIPTION
This PR implements a better workaround for #1187.

The previous workaround was to force using an older version of  the `ppx_sexp_conv`, which did not exhibit issue #1187. As such a version constraint may inconvenience users, this PR removes the version constraint and touches the problematic uses of `@@deriving sexp` directly.

Unforutnately, locally suppressing the warning code 40 triggered by the code generated for `@@deriving sexp` is somewhat tricky, as there is no AST node in the original source file to attach an `ocaml.warning` attribute to.

This PR circumvents this problem by wrapping the affected type definitions in an anonymous module, disabling warning 40 within that whole module, and then immediately `include`ing said module.

This limits the scope in which we actually disable warning 40 to exactly where it is needed.
