### PR TITLE
Redirect command

### DIFF
--- a/examples/mvu/changePage.links
+++ b/examples/mvu/changePage.links
@@ -1,0 +1,46 @@
+import Mvu;
+import MvuHTML;
+import MvuAttrs;
+open import MvuCommands;
+typename Message = [| Navigate |];
+
+fun updt(msg, _) {
+  switch (msg) {
+    case Navigate -> ((), changePage("/2"))
+  }
+}
+
+fun view(_) {
+  open MvuHTML;
+  open MvuAttrs;
+  button(onClick(fun() { Navigate }), textNode("Navigate to second page"))
+}
+
+fun page1(_) {
+  Mvu.runCmd("placeholder", (),
+    view, updt, MvuCommands.empty);
+  page
+    <html>
+      <body>
+      <div id="placeholder"></div>
+      </body>
+    </html>
+}
+
+fun page2(_) {
+  page
+    <html>
+      <body>
+      <h1>Successfully redirected</h1>
+      </body>
+    </html>
+}
+
+
+fun main() {
+  addRoute("/", page1);
+  addRoute("/2", page2);
+  servePages()
+}
+
+main()

--- a/lib/stdlib/mvuCommands.links
+++ b/lib/stdlib/mvuCommands.links
@@ -4,9 +4,14 @@ typename Command(a :: Type(Any, Any)) =
   [| NoCommand
    | CommandAppend : (Command(a), Command(a))
    | Spawn: (() {}~> a)
+   | Redirect: String
    |];
 
 var empty = NoCommand;
+
+
+sig changePage : (String) -> Command(a)
+fun changePage(url) { Redirect(url) }
 
 sig spawnProc:
   forall a :: Type(Any, Any) .
@@ -39,6 +44,7 @@ fun processCommand(cmd, ap) {
     case CommandAppend(c1, c2) ->
       processCommand(c1, ap);
       processCommand(c2, ap)
+    case Redirect(url) -> redirect(url)
     case Spawn(f) ->
       ignore(
         spawn {

--- a/links.opam
+++ b/links.opam
@@ -23,7 +23,7 @@ doc: "https://links-lang.org/quick-help.html"
 bug-reports: "https://github.com/links-lang/links/issues"
 depends: [
   "dune" {>= "2.7"}
-  "ocaml" { >= "5.1.0"}
+  "ocaml" { >= "5.1.1"}
   "dune-configurator" { >= "3.8"}
   "ppx_deriving"
   "ppx_deriving_yojson" {>= "3.3"}

--- a/links.opam
+++ b/links.opam
@@ -23,7 +23,7 @@ doc: "https://links-lang.org/quick-help.html"
 bug-reports: "https://github.com/links-lang/links/issues"
 depends: [
   "dune" {>= "2.7"}
-  "ocaml" { >= "5.1.1"}
+  "ocaml" { >= "5.1.0"}
   "dune-configurator" { >= "3.8"}
   "ppx_deriving"
   "ppx_deriving_yojson" {>= "3.3"}

--- a/tests/typecheck_examples.tests
+++ b/tests/typecheck_examples.tests
@@ -764,3 +764,8 @@ filemode : true
 Typecheck example file examples/mvu/dispatch.links
 examples/mvu/dispatch.links
 filemode : true
+
+Typecheck example file examples/mvu/changePage.links
+examples/mvu/changePage.links
+filemode : true
+


### PR DESCRIPTION
It's often the case that we want to change page as a result of, say, clicking a button in an MVU application. Currently we just use `redirect` directly as Links is impure, but this isn't a particularly idiomatic way of doing things and has led to a weird race condition in a student project.

This patch introduces a `Redirect` command, which can be accessed through `MvuCommands.changePage(url)`. The redirect is then processed in the MVU event loop as would be expected.