### PR TITLE
Term-level type annotations for effectful operations.

### DIFF
--- a/core/desugarSessionExceptions.ml
+++ b/core/desugarSessionExceptions.ml
@@ -88,7 +88,14 @@ object (o : 'self_type)
           Types.fresh_type_variable (CommonTypes.lin_any, CommonTypes.res_any) in
         let with_pos x = SourceCode.WithPos.make ~pos x in
         (* FIXME: WT: I don't know whether should it be lindo or not *)
-        let doOp = DoOperation (with_pos (Operation failure_op_name), [], Some (Types.empty_type), DeclaredLinearity.Lin) in
+        let op =
+          let syntype = Datatype.Operation ([with_pos Datatype.Unit], with_pos (Datatype.Variant ([], Datatype.Closed)), DeclaredLinearity.Lin) in
+          let semtype = Types.Operation (Types.unit_type, Types.empty_type, DeclaredLinearity.Lin) in
+          Operation (failure_op_name,
+                     Some (with_pos syntype
+                          , Some semtype), Some semtype)
+        in
+        let doOp = DoOperation (with_pos op, [], Some (Types.empty_type), DeclaredLinearity.Lin) in
         (o, with_pos (Switch (with_pos doOp, [], Some ty)), ty)
     | { node = TryInOtherwise (_, _, _, _, None); _} -> assert false
     | { node = TryInOtherwise (try_phr, pat, as_phr, otherwise_phr, (Some dt)); pos }

--- a/core/parser.mly
+++ b/core/parser.mly
@@ -708,8 +708,10 @@ unary_expression:
 | MINUSDOT unary_expression                                    { unary_appl ~ppos:$loc UnaryOp.FloatMinus $2 }
 | OPERATOR unary_expression                                    { unary_appl ~ppos:$loc (UnaryOp.Name $1)  $2 }
 | postfix_expression | constructor_expression                  { $1 }
-| DOOP CONSTRUCTOR loption(arg_spec)                           { with_pos $loc (DoOperation (with_pos $loc($2) (Operation $2), $3, None, DeclaredLinearity.Unl)) }
-| LINDOOP CONSTRUCTOR loption(arg_spec)                        { with_pos $loc (DoOperation (with_pos $loc($2) (Operation $2), $3, None, DeclaredLinearity.Lin)) }
+| DOOP CONSTRUCTOR loption(arg_spec)                           { with_pos $loc (DoOperation (with_pos $loc($2) (Operation ($2, None, None)), $3, None, DeclaredLinearity.Unl)) }
+| LINDOOP CONSTRUCTOR loption(arg_spec)                        { with_pos $loc (DoOperation (with_pos $loc($2) (Operation ($2, None, None)), $3, None, DeclaredLinearity.Lin)) }
+| DOOP LPAREN CONSTRUCTOR COLON datatype RPAREN loption(arg_spec) { with_pos $loc (DoOperation (with_pos $loc($3) (Operation ($3, Some (datatype $5), None)), $7, None, DeclaredLinearity.Unl)) }
+| LINDOOP LPAREN CONSTRUCTOR COLON datatype RPAREN loption(arg_spec)  { with_pos $loc (DoOperation (with_pos $loc($3) (Operation ($3, Some (datatype $5), None)), $7, None, DeclaredLinearity.Lin)) }
 
 infix_appl:
 | unary_expression                                             { $1 }

--- a/core/sugarTraversals.ml
+++ b/core/sugarTraversals.ml
@@ -322,11 +322,14 @@ class map =
       | DoOperation (op, ps, t, b) ->
           let op  = o#phrase op in
           let ps  = o#list (fun o -> o#phrase) ps in
-          let t   = o#option (fun o -> o#typ) t in
+          let t   = o#option (fun o -> o#unknown) t in
+          let b   = o#linearity b in
           DoOperation (op, ps, t, b)
-      | Operation _x ->
+      | Operation (_x, t, t') ->
           let _x = o#name _x in
-          Operation _x
+          let t = o#option (fun o -> o#datatype') t in
+          let t' = o#option (fun o -> o#unknown) t' in
+          Operation (_x, t, t')
       | Linlet _x ->
           let _x = o#phrase _x in Linlet _x
       | Unlet _x ->
@@ -1146,13 +1149,15 @@ class fold =
       | ConstructorLit ((_x, _x_i1, _x_i2)) ->
           let o = o#name _x in
           let o = o#option (fun o -> o#phrase) _x_i1 in o
-      | DoOperation (op,ps,t,b) ->
+      | DoOperation (op, ps, t, b) ->
          let o = o#phrase op in
-         let o = o#option (fun o -> o#unknown) t in
          let o = o#list (fun o -> o#phrase) ps in
+         let o = o#option (fun o -> o#unknown) t in
          let o = o#linearity b in o
-      | Operation (_x) ->
-          let o = o#name _x in o
+      | Operation (_x, t, t') ->
+         let o = o#name _x in
+         let o = o#option (fun o -> o#datatype') t in
+         let o = o#option (fun o -> o#unknown) t' in o
       | Linlet _x ->
           let o = o#phrase _x in o
       | Unlet _x ->
@@ -1975,12 +1980,15 @@ class fold_map =
           (o, (ConstructorLit ((_x, _x_i1, _x_i2))))
       | DoOperation (op, ps, t, b) ->
           let (o, op) = o#phrase op in
-          let (o, t) = o#option (fun o -> o#typ) t in
           let (o, ps) = o#list (fun o -> o#phrase) ps in
+          let (o, t) = o#option (fun o -> o#unknown) t in
+          let (o, b)  = o#linearity b in
           (o, DoOperation (op, ps, t, b))
-      | Operation _x ->
+      | Operation (_x, t, t') ->
           let (o, _x) = o#name _x in
-          (o, Operation _x)
+          let (o, t) = o#option (fun o -> o#datatype') t in
+          let (o, t') = o#option (fun o -> o#unknown) t' in
+          (o, Operation (_x, t, t'))
       | Linlet _x ->
           let (o, _x) = o#phrase _x in
           (o, Linlet _x)

--- a/core/sugartoir.ml
+++ b/core/sugartoir.ml
@@ -993,7 +993,7 @@ struct
                   | None -> failwith "Operation with no name"
 
                 method! phrasenode = function
-                  | Operation name -> opname <- Some name ; o
+                  | Operation (name, _, _) -> opname <- Some name ; o
                   | p -> super#phrasenode p
               end)#phrase op in
               o#opname

--- a/core/sugartypes.ml
+++ b/core/sugartypes.ml
@@ -483,7 +483,7 @@ and phrasenode =
   | Generalise       of phrase
   | ConstructorLit   of Name.t * phrase option * Types.datatype option
   | DoOperation      of phrase * phrase list * Types.datatype option * DeclaredLinearity.t
-  | Operation        of Name.t
+  | Operation        of Name.t * datatype' option * Types.datatype option
   | Handle           of handler
   | Unlet            of phrase
   | Linlet           of phrase

--- a/core/transformSugar.ml
+++ b/core/transformSugar.ml
@@ -491,9 +491,15 @@ class transform (env : Types.typing_environment) =
           let (o, e, _) = option o (fun o -> o#phrase) e in
           let (o, t) = o#datatype t in
           (o, ConstructorLit (name, e, Some t), t)
-      | DoOperation (name, ps, Some t, b) ->
+      | DoOperation (p, ps, t, b) ->
+         let (o, p, _) = o#phrase p in
          let (o, ps, _) = list o (fun o -> o#phrase) ps in
-         (o, DoOperation (name, ps, Some t, b), t)
+         let (o, t) = optionu o (fun o -> o#datatype) t in
+         (o, DoOperation (p, ps, t, b), val_of t)
+      | Operation (name, t, t') ->
+         let (o, t) = optionu o (fun o -> o#datatype') t in
+         let (o, t') = optionu o (fun o -> o#datatype) t' in
+         (o, Operation (name, t, t'), val_of t')
       | Handle { sh_expr; sh_effect_cases; sh_value_cases; sh_descr } ->
          let (input_row, input_t, output_row, output_t) = sh_descr.shd_types in
          let (o, expr, _) = o#phrase sh_expr in

--- a/core/typeUtils.ml
+++ b/core/typeUtils.ml
@@ -136,6 +136,8 @@ let rec arg_types ?(overstep_quantifiers=true) t = match (concrete_type t, overs
       extract_tuple row
   | (Lolli (Record row, _, _), _) ->
      extract_tuple row
+  | (Operation (Record row, _, _), _) ->
+     extract_tuple row
 (*   | Function (t', _, _) when is_thunk_type t' -> [Types.unit_type] (\* THIS IS A HACK. TODO: Trace down cause of bug. At some point during the compilation process the formal parameter to (() {Op: a -> b} -> c) -> d gets unwrapped yielding a function type composed internally as *)
 (*  Function ((Function (), {Op: a -> b}, c) *)
 (*            , <empty effects>, d) *)

--- a/examples/handlers/tests.links
+++ b/examples/handlers/tests.links
@@ -44,7 +44,6 @@ fun deep_state() {
 }
 
 # Pipes tests
-
 import Pipes;
 fun deep_pipes() {
   assert((==), [256, 256, 256, 256], Pipes.unitTest(), listToString(intToString), "Deep_pipes")

--- a/tests/handlers.tests
+++ b/tests/handlers.tests
@@ -477,6 +477,26 @@ fun(m) { handle(m()) { case <Foo(x) => k> : ((a) => (() {}-> (a,a))) -> k ( fun 
 stdout : fun : (() {Foo:(a) => () {}-> (a, a)|b}~> c::Any) {Foo{_}|b}~> c::Any
 args : --enable-handlers
 
+Operation term-level annotation (1)
+fun() { handle({ do (Throw : forall a. () => a) }) { case <Throw> : (forall a. () => a) -> () } }
+stdout : fun : () {Throw{_}|_}~> ()
+args : --enable-handlers
+
+Operation term-level annotation (2)
+fun() { do (Swap : forall a, b. (a, b) => (b, a))(2, "hello") }
+stdout : fun : () {Swap:forall a,b.(a, b) => (b, a)|_}-> (String, Int)
+args : --enable-handlers
+
+Operation term-level annotation (3)
+fun(x,y) { do (Swap : forall a, b. (a, b) => (b, a))(x, y) }
+stdout : fun : (a, b) {Swap:forall c,d.(c, d) => (d, c)|_}-> (b, a)
+args : --enable-handlers
+
+Operation term-level annotation (4)
+sig catch : ((() {Throw: forall a. () => a |e}~> a) {Throw: forall a. () => a |e}~> b) {Throw{_} |e}~> Maybe(b) fun catch(f) {  handle(f(fun(){ do (Throw : forall a. () => a) })) {    case ans -> Just(ans)    case <Throw> : (forall a. () => a) -> Nothing  }}
+stdout : () : ()
+args : --enable-handlers
+
 Examples
 ./examples/handlers/tests.links
 filemode : true


### PR DESCRIPTION
This patch makes it possible to annotate effectful operations at the term-level. Type annotations are crucial when operations are polymorphic. Prior to this patch, it was only possible to annotate polymorphic operations in signatures. As a consequence it was impossible to make the following kind of program type-check.

```links
handle(do Throw) {
  case ans -> Just(ans)
  case <Throw> : (forall a. () => a) -> Nothing
}
```

The problem is that Links does not infer polymorphism (rightly so), so the inferred type of `Throw` will fail to check against the pattern type in the `Throw`-case. With this patch we can annotate the invocation to make the program type check.

```links
handle(do (Throw : forall a. () => a)) {
  case ans -> Just(ans)
  case <Throw> : (forall a. () => a) -> Nothing
}
```