### PR TITLE
User-definable abstract types

### DIFF
--- a/core/desugarDatatypes.ml
+++ b/core/desugarDatatypes.ml
@@ -79,6 +79,7 @@ module Desugar = struct
       let open Datatype in
       (* let z = *)
       match t with
+        | Datatype.Abstract abs -> Types.Abstract abs
         | TypeVar stv ->
            let point = SugarTypeVar.get_resolved_type_exn stv in
            Meta point

--- a/core/generalise.ml
+++ b/core/generalise.ml
@@ -30,6 +30,7 @@ let rec get_type_args : gen_kind -> TypeVarSet.t -> datatype -> type_arg list =
         | Not_typed -> raise (internal_error "Not_typed encountered in get_type_args")
         | (Var _ | Recursive _) ->
            failwith ("freestanding Var / Recursive not implemented yet (must be inside Meta)")
+        | Abstract _abs -> []
         | Alias (_, (_, _, ts, _), t) ->
            concat_map (get_type_arg_type_args kind bound_vars) ts @ gt t
         | Application (_, args) ->

--- a/core/instantiate.ml
+++ b/core/instantiate.ml
@@ -43,6 +43,7 @@ let instantiates : instantiation_maps -> (datatype -> datatype) * (row -> row) *
     match datatype with
         | Not_typed -> raise (internal_error "Not_typed' passed to `instantiate'")
         | Primitive _  -> datatype
+        | Abstract _abs -> datatype
         | Meta point ->
             let t = Unionfind.find point in
               begin

--- a/core/irCheck.ml
+++ b/core/irCheck.ml
@@ -344,6 +344,11 @@ let eq_types occurrence : type_eq_context -> (Types.datatype * Types.datatype) -
             else false
          | _ -> false
          end
+      | Abstract abs ->
+         begin match t2 with
+         | Abstract abs' -> abs == abs' (* pointer equality *)
+         | _ -> false
+         end
       (* Effect *)
       | Effect l ->
          begin match t2 with

--- a/core/parser.mly
+++ b/core/parser.mly
@@ -247,6 +247,9 @@ let make_effect_var : is_dot:bool -> ParserPosition.t -> Datatype.row_var
 
 let dummy_phrase pos = with_pos pos (Sugartypes.RecordLit ([], None))
 
+let fresh_abstract_identity : unit -> exn
+  = fun () -> let exception E in E
+
 module MutualBindings = struct
 
   type mutual_bindings =
@@ -539,6 +542,7 @@ signature:
 | SIG sigop COLON datatype                                     { with_pos $loc ($2, datatype $4) }
 
 typedecl:
+| TYPENAME CONSTRUCTOR typeargs_opt                             { alias $loc $2 $3 (Typename   ( WithPos.make (Datatype.Abstract (fresh_abstract_identity ())), None)) }
 | TYPENAME CONSTRUCTOR typeargs_opt EQ datatype                 { alias $loc $2 $3 (Typename   ( $5     , None)) }
 | EFFECTNAME CONSTRUCTOR typeargs_opt EQ LBRACE erow RBRACE     { alias $loc $2 $3 (Effectname ( $6     , None)) }
 | EFFECTNAME CONSTRUCTOR typeargs_opt EQ effect_app             { alias $loc $2 $3 (Effectname (([], $5), None)) }

--- a/core/sugarTraversals.ml
+++ b/core/sugarTraversals.ml
@@ -659,6 +659,7 @@ class map =
     method datatypenode : Datatype.t -> Datatype.t =
       let open Datatype in
       function
+      | Abstract abs -> Abstract abs
       | TypeVar _x ->
           let _x = o#type_variable _x in TypeVar _x
       | QualifiedTypeApplication (ns, args) ->
@@ -1450,6 +1451,7 @@ class fold =
     method datatypenode : Datatype.t -> 'self_type =
       let open Datatype in
       function
+      | Abstract _abs -> o
       | TypeVar _x ->
           let o = o#type_variable _x in o
       | QualifiedTypeApplication (ns, args) ->
@@ -2372,6 +2374,7 @@ class fold_map =
     method datatypenode : Datatype.t -> ('self_type * Datatype.t) =
       let open Datatype in
       function
+      | Abstract abs -> (o, Abstract abs)
       | TypeVar _x ->
           let (o, _x) = o#type_variable _x in (o, (TypeVar _x))
       | QualifiedTypeApplication (ns, args) ->

--- a/core/sugartypes.ml
+++ b/core/sugartypes.ml
@@ -191,7 +191,9 @@ type fieldconstraint = Readonly | Default
     [@@deriving show]
 
 module Datatype = struct
+  let pp_exn fmt _ = Format.fprintf fmt "exn"
   type t =
+    | Abstract        of exn
     | TypeVar         of SugarTypeVar.t
     | QualifiedTypeApplication of Name.t list * type_arg list
     | Function        of with_pos list * row * with_pos

--- a/core/typeSugar.ml
+++ b/core/typeSugar.ml
@@ -2224,6 +2224,7 @@ let close_pattern_type : Pattern.with_pos list -> Types.datatype -> Types.dataty
           let pats = concat_map unwrap pats in
             Application (Types.list, [cpta pats t])
       | ForAll (qs, t) -> ForAll (qs, cpt pats t)
+      | Abstract abs -> Abstract abs
       | Meta point ->
           begin
             match Unionfind.find point with

--- a/core/typeUtils.ml
+++ b/core/typeUtils.ml
@@ -232,6 +232,7 @@ let rec primary_kind_of_type t =
   match concrete_type t with
   | Not_typed ->
      failwith "Not_typed has no kind"
+  | Abstract _ -> PrimaryKind.Type
   | Var (_, kind, _) ->
      Kind.primary_kind kind
   | Recursive _ ->
@@ -325,6 +326,7 @@ let check_type_wellformedness primary_kind t : unit =
     | (Var _ | Recursive _ | Closed) ->
        (* freestanding Var / Recursive / Closed not implemented yet (must be inside Meta) *)
        raise tag_expectation_mismatch
+    | Abstract _abs -> pk_type
     | Alias (_, (_name, qs, ts, _), d) ->
        List.iter2 (compare_kinds rec_env) qs ts;
        typ rec_env d

--- a/core/types.mli
+++ b/core/types.mli
@@ -143,6 +143,7 @@ and typ =
   | Table of (Temporality.t * typ * typ * typ)
   | Lens of Lens.Type.t
   | ForAll of (Quantifier.t list * typ)
+  | Abstract of exn
   (* Effect *)
   | Effect of row
   | Operation of (typ * typ * DeclaredLinearity.t)
@@ -453,6 +454,7 @@ val pp_row' : Format.formatter -> row' -> unit
 val pp_type_arg : Format.formatter -> type_arg -> unit
 val pp_tycon_spec: Format.formatter -> tycon_spec -> unit
 val pp_field_spec: Format.formatter -> field_spec -> unit
+val pp_exn : Format.formatter -> exn -> unit
 
 (* Recursive type applications *)
 val recursive_applications : datatype -> string list

--- a/core/typevarcheck.ml
+++ b/core/typevarcheck.ml
@@ -85,6 +85,7 @@ let rec is_guarded : TypeVarSet.t -> StringSet.t -> int -> datatype -> bool =
             is_guarded
               (TypeVarSet.add_quantifiers qs bound_vars)
               expanded_apps var t
+        | Abstract _abs -> true (* TODO(dhil): could be unguarded... *)
         (* Effect *)
         | Effect row -> isgr row
         | Operation (f, t, _) ->
@@ -174,6 +175,7 @@ let rec is_negative : TypeVarSet.t -> StringSet.t -> int -> datatype -> bool =
             is_negative
               (TypeVarSet.add_quantifiers qs bound_vars)
               expanded_apps var t
+        | Abstract _abs -> false
         (* Effect *)
         | Effect row -> isnr row
         | Operation (f, t, _) ->
@@ -263,6 +265,7 @@ and is_positive : TypeVarSet.t -> StringSet.t -> int -> datatype -> bool =
             is_positive
               (TypeVarSet.add_quantifiers qs bound_vars)
               expanded_apps var t
+        | Abstract _abs -> false
         (* Effect *)
         | Effect row -> ispr row
         | Operation (f, t, _) ->

--- a/tests/abstract_types.tests
+++ b/tests/abstract_types.tests
@@ -1,0 +1,38 @@
+Abstract type declaration
+typename Foo;
+stdout : () : ()
+
+Abstract type unification
+typename Foo; sig foo : (Foo) -> Foo fun foo(x) { x }
+stdout : () : ()
+
+Abstract type identities (1)
+typename Foo; typename Bar; sig foobar : (Foo) -> Bar fun foobar(x) { x }
+stderr : @.
+exit : 1
+
+Abstract type identities (2)
+typename Foo; sig foo : () -> Foo fun foo() { error("I cannot materialise a foo") }; typename Foo; sig foo' : (Foo) -> () fun foo'(_) { () }; foo'(foo())
+stderr : @.
+exit : 1
+
+Parameterised abstract types (1)
+typename Foo(a,b,c); sig foo : (Foo(a,b,c)) -> Foo(String,Int,Float) fun foo(x) { x }
+stderr : @.
+exit : 1
+
+Parameterised abstract types (2)
+typename Foo(a,b); sig foo : (Foo(Int,String)) -> Foo(Int,String) fun foo(x) { x }
+stdout : () : ()
+
+Parameterised abstract types (3)
+typename Foo(a,b); sig foo : (a, b) ~> Foo(a,b) fun foo(_,_) { error("cannot materialise Foo") }
+stdout : () : ()
+
+Parameterised abstract types (4)
+typename Foo(a,b); sig foo : (Foo(a,b)) ~> Foo(b,a) fun foo(_) { error("cannot materialise Foo") }
+stdout : () : ()
+
+Alien
+typename A; alien javascript "" f : () -> A;
+stdout : () : ()


### PR DESCRIPTION
This patch makes it possible to declare abstract types in Links, e.g.

```links
typename MyAbstractType;
```

The primary motivation for adding them to be able to give types to alien data objects.

The representation of user-definable abstract types is distinct from the built-in abstract types. In a future patch we ought to reconcile these two representations.