### PR TITLE
Synchronise `links.opam`

### DIFF
--- a/dune-project
+++ b/dune-project
@@ -31,8 +31,8 @@
  (name links)
  (synopsis "The Links Programming Language")
  (description "Links is a functional programming language designed to make web programming easier.")
- (depends (ocaml (>= : 5.1.1))
-          (dune-configurator (>= : 3.8))
+ (depends (ocaml (>= 5.1.1))
+          (dune-configurator (>= 3.8))
            ppx_deriving
           (ppx_deriving_yojson (>= 3.3))
            base64

--- a/links.opam
+++ b/links.opam
@@ -23,8 +23,8 @@ doc: "https://links-lang.org/quick-help.html"
 bug-reports: "https://github.com/links-lang/links/issues"
 depends: [
   "dune" {>= "2.7"}
-  "ocaml" { >= "5.1.0"}
-  "dune-configurator" { >= "3.8"}
+  "ocaml" {":" >= "5.1.1"}
+  "dune-configurator" {":" >= "3.8"}
   "ppx_deriving"
   "ppx_deriving_yojson" {>= "3.3"}
   "base64"

--- a/links.opam
+++ b/links.opam
@@ -23,8 +23,8 @@ doc: "https://links-lang.org/quick-help.html"
 bug-reports: "https://github.com/links-lang/links/issues"
 depends: [
   "dune" {>= "2.7"}
-  "ocaml" {":" >= "5.1.1"}
-  "dune-configurator" {":" >= "3.8"}
+  "ocaml" {>= "5.1.1"}
+  "dune-configurator" {>= "3.8"}
   "ppx_deriving"
   "ppx_deriving_yojson" {>= "3.3"}
   "base64"


### PR DESCRIPTION
This small patch updates the `links.opam` file as generated by the specification in `dune-project`. Note the changes are generated by `dune`.