### PR TITLE
SessionFail should be hidden by default

### DIFF
--- a/core/basicsettings.ml
+++ b/core/basicsettings.ml
@@ -54,7 +54,7 @@ module Sessions = struct
               |> sync)
 
   let expose_session_fail =
-    Settings.(flag "expose_session_fail" ~default:true
+    Settings.(flag "expose_session_fail" ~default:false
               |> synopsis "Exposes the SessionFail effect"
               |> depends Handlers.enabled
               |> depends exceptions_enabled


### PR DESCRIPTION
The SessionFail effect makes life difficult, even if it is morally correct. This patch hides it. Fixes #1201 .