### PR TITLE
Compatibility with OCaml 5.3.0

### DIFF
--- a/core/irCheck.ml
+++ b/core/irCheck.ml
@@ -1053,11 +1053,11 @@ struct
           (* For each case branch, the corresponding entry goes directly into the field spec map of the inner effect row *)
           let inner_effects_map_from_branches = StringMap.map (fun x -> Present x) branch_presence_spec_types in
           (* We now add all entries from the outer effects that were not touched by the handler to the inner effects *)
-          let inner_effects_map = StringMap.fold (fun effect outer_presence_spec map ->
-              if StringMap.mem effect inner_effects_map_from_branches then
+          let inner_effects_map = StringMap.fold (fun effect_ outer_presence_spec map ->
+              if StringMap.mem effect_ inner_effects_map_from_branches then
                 map
               else
-                StringMap.add effect outer_presence_spec map
+                StringMap.add effect_ outer_presence_spec map
             )  inner_effects_map_from_branches outer_effects_map in
           let inner_effects = Row (inner_effects_map, outer_effects_var, outer_effects_dualized) in
 


### PR DESCRIPTION
This patch makes it possible to compile Links with the recently released OCaml 5.3.0 compiler. In OCaml 5.3.0 the token `effect` has become a keyword, and thus cannot be used as the name of a binder anymore.

We ought to make a new Links release on OPAM imminently.