### PR TITLE
Update CI workflow

### DIFF
--- a/.github/workflows/default.yml
+++ b/.github/workflows/default.yml
@@ -15,9 +15,9 @@ jobs:
       fail-fast: false
       matrix:
         os:
-          - ubuntu-20.04
+          - ubuntu-latest
         ocaml-compiler:
-          - 5.1.1
+          - 5.3.0
 
     runs-on: ${{ matrix.os }}
 
@@ -29,7 +29,7 @@ jobs:
         shell: bash
 
       - name: Use OCaml ${{ matrix.ocaml-compiler }}
-        uses: ocaml/setup-ocaml@v2
+        uses: ocaml/setup-ocaml@v3
         with:
           ocaml-compiler: ${{ matrix.ocaml-compiler }}
 
@@ -46,7 +46,7 @@ jobs:
       fail-fast: false
       matrix:
         os:
-          - ubuntu-20.04
+          - ubuntu-latest
 
     runs-on: ${{ matrix.os }}
 
@@ -69,9 +69,9 @@ jobs:
       fail-fast: false
       matrix:
         os:
-          - ubuntu-20.04
+          - ubuntu-latest
         ocaml-compiler:
-          - 5.1.1
+          - 5.3.0
 
     runs-on: ${{ matrix.os }}
 
@@ -80,7 +80,7 @@ jobs:
         uses: actions/checkout@v2
 
       - name: Use OCaml ${{ matrix.ocaml-compiler }}
-        uses: ocaml/setup-ocaml@v2
+        uses: ocaml/setup-ocaml@v3
         with:
           ocaml-compiler: ${{ matrix.ocaml-compiler }}
 
@@ -110,9 +110,9 @@ jobs:
       fail-fast: false
       matrix:
         os:
-          - ubuntu-20.04
+          - ubuntu-latest
         ocaml-compiler:
-          - 5.1.1
+          - 5.3.0
 
     runs-on: ${{ matrix.os }}
 
@@ -198,9 +198,9 @@ jobs:
       fail-fast: false
       matrix:
         os:
-          - ubuntu-20.04
+          - ubuntu-latest
         ocaml-compiler:
-          - 5.1.1
+          - 5.3.0
 
     runs-on: ${{ matrix.os }}
 
@@ -236,7 +236,7 @@ jobs:
         shell: bash
 
       - name: Use OCaml ${{ matrix.ocaml-compiler }}
-        uses: ocaml/setup-ocaml@v2
+        uses: ocaml/setup-ocaml@v3
         with:
           ocaml-compiler: ${{ matrix.ocaml-compiler }}
 


### PR DESCRIPTION
Github is deprecating the CI image `ubuntu-20.04`:

> The Ubuntu 20.04 runner image will be fully unsupported by April 1, 2025. To raise awareness of the upcoming removal, we will temporarily fail jobs using Ubuntu 20.04. Builds that are scheduled to run during the brownout periods will fail. The brownouts are scheduled for the following dates and times:
>
>    March 4 14:00 UTC – 22:00 UTC
>    March 11 13:00 UTC – 21:00 UTC
>    March 18 13:00 UTC – 21:00 UTC
>    March 25 13:00 UTC – 21:00 UTC
>
> What you need to do
>
> Jobs using the ubuntu-20.04 YAML workflow label should be updated to ubuntu-22.04, ubuntu-24.04 or ubuntu-latest. You can always get up-to-date information on our tools by reading about the software in the runner images repository. Please contact GitHub Support if you run into any problems or need help. 

This patch updates the CI to use the `ubuntu-latest` image. 

In addition, this patch changes the OCaml compiler used for testing to 5.3.0 and upgrades the version of `ocaml/setup-ocaml` to version 3, which contains several fixes for the OCaml 5.3 toolchain. 

Probably #1204 needs to land first.