### PR TITLE
Sorting record members first on the length of the key

### DIFF
--- a/core/buildTables.ml
+++ b/core/buildTables.ml
@@ -255,7 +255,7 @@ struct
 
   let bindings tyenv bound_vars cont_vars bs =
     let o = new visitor tyenv bound_vars cont_vars in
-    let _ = o#computation (bs, Return (Extend (StringMap.empty, None))) in ()
+    let _ = o#computation (bs, Return (Extend (Types.FieldEnv.empty, None))) in ()
 
   let program tyenv bound_vars cont_vars e =
     let _ = (new visitor tyenv bound_vars cont_vars)#computation e in ()

--- a/core/channelVarUtils.ml
+++ b/core/channelVarUtils.ml
@@ -14,6 +14,9 @@ let variables_in_computation comp =
   let rec traverse_stringmap : 'a . ('a -> unit) -> 'a stringmap -> unit =
     fun proj_fn smap -> (* (proj_fn: 'a . 'a -> 'b) (smap: 'a stringmap) : unit = *)
       StringMap.fold (fun _ v _ -> proj_fn v) smap ()
+  and traverse_ststringmap : 'a . ('a -> unit) -> 'a st_name_map -> unit =
+    fun proj_fn smap -> (* (proj_fn: 'a . 'a -> 'b) (smap: 'a st_name_map) : unit = *)
+      Types.FieldEnv.fold (fun _ v _ -> proj_fn v) smap ()
   and traverse_value = function
     | Variable v -> add_variable v
     | Closure (_, _, value)
@@ -30,7 +33,7 @@ let variables_in_computation comp =
         traverse_value v;
         List.iter traverse_value vs
     | Extend (v_map, v_opt) ->
-        traverse_stringmap (traverse_value) v_map;
+        traverse_ststringmap (traverse_value) v_map;
         begin match v_opt with | Some v -> traverse_value v | None -> () end
     | Constant _ -> ()
   and traverse_tail_computation = function

--- a/core/closures.ml
+++ b/core/closures.ml
@@ -428,9 +428,9 @@ struct
   let close f zs tyargs =
     Closure (f, tyargs, Extend (List.fold_right
                             (fun (zname, zv) fields ->
-                               StringMap.add zname zv fields)
+                               Types.FieldEnv.add zname zv fields)
                             zs
-                            StringMap.empty, None))
+                            Types.FieldEnv.empty, None))
 
   class visitor tenv fenv =
     object (o : 'self) inherit IrTraversals.Transform.visitor(tenv) as super
@@ -539,8 +539,8 @@ struct
                      (fun fields b ->
                        let x = Var.var_of_binder b in
                        let xt = Var.type_of_binder b in
-                       StringMap.add (string_of_int x) xt fields)
-                     StringMap.empty
+                       Types.FieldEnv.add (string_of_int x) xt fields)
+                     Types.FieldEnv.empty
                      zs)
               in
               (* fresh variable for the closure environment *)
@@ -615,8 +615,8 @@ struct
                               (fun fields b ->
                                 let x = Var.var_of_binder b in
                                 let xt = Var.type_of_binder b in
-                                StringMap.add (string_of_int x) xt fields)
-                              StringMap.empty
+                                Types.FieldEnv.add (string_of_int x) xt fields)
+                              Types.FieldEnv.empty
                               zs)
                        in
                        (* fresh variable for the closure environment *)

--- a/core/desugarCP.ml
+++ b/core/desugarCP.ml
@@ -115,10 +115,10 @@ object (o : 'self_type)
             let (eff_fields, eff_row, eff_closed) =
               Types.flatten_row o#lookup_effects
               |> TypeUtils.extract_row_parts in
-            let eff_fields = StringMap.remove wild_str eff_fields in
+            let eff_fields = Types.FieldEnv.remove wild_str eff_fields in
             let eff_fields =
               if Settings.get Basicsettings.Sessions.exceptions_enabled then
-                StringMap.remove Value.session_exception_operation eff_fields
+                Types.FieldEnv.remove Value.session_exception_operation eff_fields
               else
                 eff_fields in
 
@@ -149,4 +149,3 @@ module Typeable
         let name = "cp"
         let obj env = (desugar_cp env : TransformSugar.transform :> Transform.Typeable.sugar_transformer)
       end)
-

--- a/core/desugarDatatypes.ml
+++ b/core/desugarDatatypes.ml
@@ -282,7 +282,7 @@ module Desugar = struct
         | Closed -> Types.make_empty_closed_row ()
         | Open srv ->
            let rv = SugarTypeVar.get_resolved_row_exn srv in
-           Types.Row (StringMap.empty, rv, false)
+           Types.Row (Types.FieldEnv.empty, rv, false)
         | Recursive (stv, r) ->
            let mrv = SugarTypeVar.get_resolved_row_exn stv in
 
@@ -291,7 +291,7 @@ module Desugar = struct
 
            (* Turn mrv into a proper recursive row *)
            Unionfind.change mrv (Types.Recursive (var, sk, r));
-           Types.Row (StringMap.empty, mrv, false)
+           Types.Row (Types.FieldEnv.empty, mrv, false)
 
     in
     let fields = List.map (fun (k, p) -> (k, fieldspec alias_env p node)) fields in
@@ -335,7 +335,7 @@ module Desugar = struct
     let write_row, needed_row =
       match TypeUtils.concrete_type read_type with
       | Record (Row (fields, _, _)) ->
-          StringMap.fold
+          Types.FieldEnv.fold
             (fun label t (write, needed) ->
               match lookup label constraints with
               | Some cs ->

--- a/core/desugarEffects.ml
+++ b/core/desugarEffects.ml
@@ -479,7 +479,7 @@ let gather_mutual_info (tycon_env : simple_tycon_env) =
 
 let gather_operation_of_type tp
   = let open Types in
-    let module FieldEnv = Utility.StringMap in
+    let module FieldEnv = Types.FieldEnv in
     let is_effect_row_kind : Kind.t -> bool
       = fun (primary, (_, restriction)) ->
       primary = PrimaryKind.Row && restriction = Restriction.Effect

--- a/core/desugarFuns.ml
+++ b/core/desugarFuns.ml
@@ -132,7 +132,7 @@ object (o : 'self_type)
         let (fields, rho, _) = TypeUtils.extract_row_parts row in
         let effb, row = fresh_row_quantifier default_effect_subkind in
 
-        let r = Record (Row (StringMap.add name (Present a) fields, rho, false)) in
+        let r = Record (Row (FieldEnv.add name (Present a) fields, rho, false)) in
 
         let f = gensym ~prefix:"_fun_" () in
         let x = gensym ~prefix:"_fun_" () in

--- a/core/desugarProcesses.ml
+++ b/core/desugarProcesses.ml
@@ -81,7 +81,7 @@ object (o : 'self_type)
           Types.(remove_field hear (remove_field wild (Row (fieldenv, rho, false))))
         in
         begin
-          match StringMap.find Types.hear fieldenv with
+          match Types.FieldEnv.find Types.hear fieldenv with
           | (Types.Present mbt) ->
              o#phrasenode
                (Switch (fn_appl "recv" [(Type, mbt); (Row, other_effects)] [],

--- a/core/evalir.ml
+++ b/core/evalir.ml
@@ -167,7 +167,7 @@ struct
           opt_app (value env) (Lwt.return (`Record [])) r >>= fun res ->
           match res with
             | `Record fs ->
-                let fields = StringMap.bindings fields in
+                let fields = Types.FieldEnv.bindings fields in
                 LwtHelpers.foldr_lwt
                    (fun (label, v) (fs: (string * Value.t) list)  ->
                       if List.mem_assoc label fs then
@@ -598,7 +598,7 @@ struct
     let get_fields t =
       match t with
         | `Record fields ->
-            StringMap.to_list (fun name p -> (name, Types.Primitive p)) fields
+            Types.FieldEnv.to_list (fun name p -> (name, Types.Primitive p)) fields
         | _ -> assert false
     in
     let execute_shredded_raw (q, t) =
@@ -783,7 +783,7 @@ struct
                         let r, _ = Types.unwrap_row (TypeUtils.extract_row t) in
                         TypeUtils.extract_row_parts r in
                       let fields =
-                        StringMap.fold
+                        Types.FieldEnv.fold
                           (fun name t fields ->
                             let open Types in
                             match t with
@@ -881,7 +881,7 @@ struct
           | `Table { Value.Table.database = (db, _); name = table;
                      row = (fields, _, _); temporal_fields; _ } ->
               let field_types =
-                StringMap.map
+                Types.FieldEnv.map
                     (function
                        | Types.Present t -> t
                        | _ -> assert false) fields
@@ -919,7 +919,7 @@ struct
             match source with
               | `Table { database = (db, _); name = table; row = (fields, _, _); temporal_fields; _ } ->
                   let field_types =
-                    StringMap.map
+                    Types.FieldEnv.map
                         (function
                            | Types.Present t -> t
                            | _ -> assert false) fields

--- a/core/generalise.ml
+++ b/core/generalise.ml
@@ -78,7 +78,7 @@ let rec get_type_args : gen_kind -> TypeVarSet.t -> datatype -> type_arg list =
         (* Row *)
         | Row (field_env, row_var, _) ->
            let field_vars =
-             StringMap.fold
+             FieldEnv.fold
                (fun _ field_spec vars ->
                  vars @ get_presence_type_args kind bound_vars field_spec
                ) field_env [] in
@@ -149,7 +149,7 @@ let rigidify_type_arg : type_arg -> unit =
   | Type, Meta point -> rigidify_point point
   | Presence, Meta point -> rigidify_point point
   | Row, Row (fields, point, _dual) ->
-     assert (StringMap.is_empty fields);
+     assert (FieldEnv.is_empty fields);
      rigidify_point point
   (* HACK: probably shouldn't happen *)
   | Row, Meta point -> rigidify_point point
@@ -169,7 +169,7 @@ let mono_type_args : type_arg -> unit =
   | Type, Meta point -> check_sk point
   | Presence, Meta point -> check_sk point
   | Row, Row (fields, point, _dual) ->
-     assert (StringMap.is_empty fields);
+     assert (FieldEnv.is_empty fields);
      check_sk point
   (* HACK: probably shouldn't happen *)
   | Row, Meta point -> check_sk point

--- a/core/instantiate.ml
+++ b/core/instantiate.ml
@@ -128,14 +128,14 @@ let instantiates : instantiation_maps -> (datatype -> datatype) * (row -> row) *
         | Closed -> true
         | _ -> false in
 
-    let field_env' = StringMap.fold
+    let field_env' = FieldEnv.fold
       (fun label f field_env' ->
          let rec add =
            function
-             | Present t -> StringMap.add label (Present (inst t)) field_env'
+             | Present t -> FieldEnv.add label (Present (inst t)) field_env'
              | Absent ->
                  if is_closed then field_env'
-                 else StringMap.add label Absent field_env'
+                 else FieldEnv.add label Absent field_env'
              | Meta point ->
                 begin
                  match Unionfind.find point with
@@ -146,7 +146,7 @@ let instantiates : instantiation_maps -> (datatype -> datatype) * (row -> row) *
                          else
                            Meta point
                        in
-                         StringMap.add label f field_env'
+                         FieldEnv.add label f field_env'
                    | f ->
                       add f
                 end
@@ -157,9 +157,9 @@ let instantiates : instantiation_maps -> (datatype -> datatype) * (row -> row) *
          in
            add f)
       field_env
-      StringMap.empty in
+      FieldEnv.empty in
     let field_env'', row_var', dual' = inst_row_var inst_map rec_env row_var dual |> TypeUtils.extract_row_parts in
-    Row (StringMap.fold StringMap.add field_env' field_env'', row_var', dual')
+    Row (FieldEnv.fold FieldEnv.add field_env' field_env'', row_var', dual')
         (* precondition: row_var has been flattened *)
   and inst_row_var : instantiation_maps -> inst_env -> row_var -> bool -> row = fun inst_map rec_env row_var dual ->
     (* HACK: fix the ill-formed rows that are introduced in the
@@ -169,28 +169,28 @@ let instantiates : instantiation_maps -> (datatype -> datatype) * (row -> row) *
     let rowify t =
       match t with
       | Row _ -> t
-      | Meta row_var -> Row (StringMap.empty, row_var, false)
+      | Meta row_var -> Row (FieldEnv.empty, row_var, false)
       | Alias (PrimaryKind.Row, _,row) -> row
       | _ -> assert false in
     let instr = inst_row inst_map rec_env in
     let dual_if = if dual then dual_row else fun x -> x in
     match Unionfind.find row_var with
-    | Closed -> Row (StringMap.empty, row_var, dual)
+    | Closed -> Row (FieldEnv.empty, row_var, dual)
     | Var (var, _, _) ->
         if IntMap.mem var inst_map then
           dual_if (rowify (snd (IntMap.find var inst_map)))
         else
-          Row (StringMap.empty, row_var, dual)
+          Row (FieldEnv.empty, row_var, dual)
     | Recursive (var, kind, rec_row) ->
         if IntMap.mem var rec_env then
-          Row (StringMap.empty, IntMap.find var rec_env, dual)
+          Row (FieldEnv.empty, IntMap.find var rec_env, dual)
         else
           begin
             let var' = Types.fresh_raw_variable () in
             let point' = Unionfind.fresh (Var (var', kind, `Flexible)) in
             let rec_row' = inst_row inst_map (IntMap.add var point' rec_env) rec_row in
             let _ = Unionfind.change point' (Recursive (var', kind, rec_row')) in
-              Row (StringMap.empty, point', dual)
+              Row (FieldEnv.empty, point', dual)
           end
     | row ->
        dual_if (instr row)
@@ -234,7 +234,7 @@ let instantiate_typ : bool -> datatype -> (type_arg list * datatype) = fun rigid
             let open PrimaryKind in
             match Kind.primary_kind kind with
             | (Type | Presence) as pk -> pk, Meta point
-            | Row -> Row, Row (StringMap.empty, point, false) in
+            | Row -> Row, Row (FieldEnv.empty, point, false) in
           IntMap.add var ty inst_env, ty :: tys in
 
         let inst_map, tys =

--- a/core/ir.ml
+++ b/core/ir.ml
@@ -22,6 +22,8 @@ type name_set = Utility.stringset
   [@@deriving show]
 type 'a name_map = 'a Utility.stringmap
   [@@deriving show]
+type 'a st_name_map = 'a Types.field_env
+  [@@deriving show]
 
 type 'a var_map = 'a Utility.intmap
   [@@deriving show]
@@ -35,7 +37,7 @@ type location = CommonTypes.Location.t
 type value =
   | Constant   of Constant.t
   | Variable   of var
-  | Extend     of value name_map * value option
+  | Extend     of value st_name_map * value option
   | Project    of Name.t * value
   | Erase      of name_set * value
   | Inject     of Name.t * value * Types.t
@@ -174,7 +176,7 @@ let rec is_atom =
 
 let with_bindings bs' (bs, tc) = (bs' @ bs, tc)
 
-let unit = Extend (Utility.StringMap.empty, None)
+let unit = Extend (Types.FieldEnv.empty, None)
 let unit_comp = ([], Return unit)
 
 type program = computation

--- a/core/ir.mli
+++ b/core/ir.mli
@@ -22,6 +22,8 @@ type name_set = Utility.stringset
   [@@deriving show]
 type 'a name_map = 'a Utility.stringmap
   [@@deriving show]
+type 'a st_name_map = 'a Types.field_env
+  [@@deriving show]
 
 type 'a var_map = 'a Utility.intmap
   [@@deriving show]
@@ -35,23 +37,23 @@ type location = CommonTypes.Location.t
 (* INVARIANT: all IR binders have unique names *)
 
 type value =
-  | Constant   of Constant.t                      (* constant: c *)
-  | Variable   of var                             (* variable use: x *)
-  | Extend     of value name_map * value option   (* record extension: (l1=v1, ..., lk=vk|r) or (l1=v1, ..., lk=vk) *)
+  | Constant   of Constant.t                        (* constant: c *)
+  | Variable   of var                               (* variable use: x *)
+  | Extend     of value st_name_map * value option  (* record extension: (l1=v1, ..., lk=vk|r) or (l1=v1, ..., lk=vk) *)
   | Project    of Name.t * value                    (* record projection: r.l *)
-  | Erase      of name_set * value                (* erase fields from a record: r\{ls} *)
-  | Inject     of Name.t * value * Types.t   (* variant injection: L(v) *)
+  | Erase      of name_set * value                  (* erase fields from a record: r\{ls} *)
+  | Inject     of Name.t * value * Types.t          (* variant injection: L(v) *)
 
-  | TAbs       of tyvar list * value       (* type abstraction: /\xs.v *)
-  | TApp       of value * tyarg list       (* type application: v ts *)
+  | TAbs       of tyvar list * value                (* type abstraction: /\xs.v *)
+  | TApp       of value * tyarg list                (* type application: v ts *)
 
   | XmlNode    of Name.t * value name_map * value list
-                                       (* XML node construction: <tag attributes>body</tag> *)
-  | ApplyPure  of value * value list   (* non-side-effecting application: v ws *)
+                                                    (* XML node construction: <tag attributes>body</tag> *)
+  | ApplyPure  of value * value list                (* non-side-effecting application: v ws *)
 
-  | Closure    of var * tyarg list * value           (* closure creation: f env *)
+  | Closure    of var * tyarg list * value          (* closure creation: f env *)
 
-  | Coerce     of value * Types.t             (* type coercion: v:A *)
+  | Coerce     of value * Types.t                   (* type coercion: v:A *)
 
 and tail_computation =
   | Return     of value

--- a/core/irTraversals.mli
+++ b/core/irTraversals.mli
@@ -28,6 +28,10 @@ sig
       'a.
       ('self_type -> 'a -> ('self_type * 'a * Types.datatype)) ->
       'a name_map -> 'self_type * 'a name_map * Types.datatype name_map
+    method st_name_map :
+      'a.
+      ('self_type -> 'a -> ('self_type * 'a * Types.datatype)) ->
+      'a st_name_map -> 'self_type * 'a st_name_map * Types.datatype st_name_map
     method var_map :
       'a.
       ('self_type -> 'a -> ('self_type * 'a * Types.datatype)) ->

--- a/core/irtojs.ml
+++ b/core/irtojs.ml
@@ -861,7 +861,7 @@ end = functor (K : CONTINUATION) -> struct
     | Ir.Extend (field_map, rest) ->
        let dict =
          Dict
-           (StringMap.fold
+           (Types.FieldEnv.fold
               (fun name v dict ->
                 (name, gv v) :: dict)
               field_map [])
@@ -1242,8 +1242,8 @@ end = functor (K : CONTINUATION) -> struct
                 let name_map =
                   List.fold_left
                     (fun box (i, _, initial_value) ->
-                      StringMap.add (string_of_int i) initial_value box)
-                    StringMap.empty params
+                      Types.FieldEnv.add (string_of_int i) initial_value box)
+                    Types.FieldEnv.empty params
                 in
                 (Ir.Let (param_ptr_binder, ([], Ir.Return (Ir.Extend (name_map, None)))) :: bs, tc)
               in

--- a/core/lens_ir_conv.ml
+++ b/core/lens_ir_conv.ml
@@ -348,7 +348,7 @@ let lens_sugar_phrase_of_ir p env =
     | I.Extend (ext_fields, r) ->
         let r = Option.map ~f:(links_value env) r in
         Option.value r ~default:(`Record [] |> Result.return) >>= fun r ->
-        let fields = StringMap.to_alist ext_fields in
+        let fields = Types.FieldEnv.to_alist ext_fields in
         List.map_result
           ~f:(fun (k, v) -> links_value env v >>| fun v -> (k, v))
           fields

--- a/core/lens_type_conv.ml
+++ b/core/lens_type_conv.ml
@@ -8,8 +8,8 @@ type 'a die = string -> 'a
 
 let to_links_map m =
   String.Map.fold
-    (fun k v m -> Utility.StringMap.add k v m)
-    m Utility.StringMap.empty
+    (fun k v m -> Types.FieldEnv.add k v m)
+    m Types.FieldEnv.empty
 
 let lookup_alias context ~alias =
   match Env.String.find_opt alias context with
@@ -50,7 +50,7 @@ let rec lens_phrase_type_of_type t =
   | T.Record r -> lens_phrase_type_of_type r
   | T.Row (fields, _, _) ->
       let fields =
-        Utility.StringMap.to_alist fields
+        Types.FieldEnv.to_alist fields
         |> String.Map.from_alist
         |> String.Map.map (fun v ->
                match v with

--- a/core/lib.ml
+++ b/core/lib.ml
@@ -1813,7 +1813,7 @@ let rec function_arity =
   function
     | Function (Record row, _, _) ->
         let (l, _, _) = TypeUtils.extract_row_parts row in
-        (Some (StringMap.size l))
+        (Some (FieldEnv.size l))
     | ForAll (_, t) -> function_arity t
     | _ -> None
 

--- a/core/page.ml
+++ b/core/page.ml
@@ -120,7 +120,7 @@ module Make_RealPage (C : JS_PAGE_COMPILER) (G : JS_CODEGEN) = struct
     let escaped_state_string = `String state_string |> Json.json_to_string in
 
     let printed_code =
-      let _venv, code = C.generate_program venv ([], Ir.Return (Ir.Extend (StringMap.empty, None))) in
+      let _venv, code = C.generate_program venv ([], Ir.Return (Ir.Extend (Types.FieldEnv.empty, None))) in
       let code = f code in
       let code =
         code |> (C.generate_stubs valenv defs) |> C.wrap_with_server_lib_stubs

--- a/core/query/evalQuery.ml
+++ b/core/query/evalQuery.ml
@@ -106,7 +106,7 @@ struct
         let field_types = QL.table_field_types t in
         let tyx = Types.make_record_type field_types in
         List.rev
-            (StringMap.fold
+            (Types.FieldEnv.fold
                (fun name _t es ->
                  QL.Project (QL.Var (x, tyx), name) :: es
                ) field_types [])
@@ -262,7 +262,7 @@ struct
         | []      -> fields
         | o :: os ->
           add_indexes
-            (StringMap.add ("order_" ^ string_of_int i) o fields)
+            (Types.FieldEnv.add ("order_" ^ string_of_int i) o fields)
             (i+1)
             os in
     let rec order =

--- a/core/query/mixingQuery.mli
+++ b/core/query/mixingQuery.mli
@@ -13,7 +13,7 @@ open CommonTypes
 
 val flatfield : string -> string -> string
 val flattened_pair : QueryLang.t -> QueryLang.t -> QueryLang.t
-val flattened_pair_ft : QueryLang.t -> QueryLang.t -> Types.datatype stringmap
+val flattened_pair_ft : QueryLang.t -> QueryLang.t -> Types.datatype Types.field_env
 val type_of_for_var : QueryLang.genkind -> QueryLang.t -> Types.datatype
 
 val reduce_where_then : QueryLang.t * QueryLang.t -> QueryLang.t
@@ -29,7 +29,7 @@ sig
 end
 
 val compile_update : Value.database -> Value.env ->
-  ((Ir.var * string * Types.datatype StringMap.t) * Ir.computation option * Ir.computation) -> Sql.query
+  ((Ir.var * string * Types.datatype Types.FieldEnv.t) * Ir.computation option * Ir.computation) -> Sql.query
 
 val compile_delete : Value.database -> Value.env ->
-  ((Ir.var * string * Types.datatype StringMap.t) * Ir.computation option) -> Sql.query
+  ((Ir.var * string * Types.datatype Types.FieldEnv.t) * Ir.computation option) -> Sql.query

--- a/core/query/query.mli
+++ b/core/query/query.mli
@@ -1,4 +1,3 @@
-open Utility
 open CommonTypes
 
 val reduce_and : QueryLang.t * QueryLang.t -> QueryLang.t
@@ -17,7 +16,7 @@ sig
 end
 
 val compile_update : Value.database -> Value.env ->
-  ((Ir.var * string * Types.datatype StringMap.t) * Ir.computation option * Ir.computation) -> Sql.query
+  ((Ir.var * string * Types.datatype Types.FieldEnv.t) * Ir.computation option * Ir.computation) -> Sql.query
 
 val compile_delete : Value.database -> Value.env ->
-  ((Ir.var * string * Types.datatype StringMap.t) * Ir.computation option) -> Sql.query
+  ((Ir.var * string * Types.datatype Types.FieldEnv.t) * Ir.computation option) -> Sql.query

--- a/core/query/queryLang.mli
+++ b/core/query/queryLang.mli
@@ -31,9 +31,9 @@ type t =
     | Dedup     of t
     | Prom      of t
     | GroupBy   of (Var.var * t) * t
-    | AggBy     of (t * string) StringMap.t * t
+    | AggBy     of (t * string) Types.FieldEnv.t * t
     | Lookup    of t * t
-    | Record    of t StringMap.t
+    | Record    of t Types.FieldEnv.t
     | Project   of t * string
     | Erase     of t * StringSet.t
     | Variant   of string * t
@@ -59,7 +59,7 @@ val expression_of_base_value : Value.t -> t
 
 val check_policies_compatible : CommonTypes.QueryPolicy.t -> CommonTypes.QueryPolicy.t -> unit
 
-val field_types_of_row : Types.datatype -> Types.datatype StringMap.t
+val field_types_of_row : Types.datatype -> Types.datatype Types.FieldEnv.t
 
 val unbox_xml : t -> Value.xmlitem
 
@@ -69,13 +69,13 @@ val unbox_list : t -> t list
 
 val unbox_pair : t -> t * t
 
-val unbox_record : t -> t StringMap.t
+val unbox_record : t -> t Types.FieldEnv.t
 
 val used_database : t -> Value.database option
 
 val string_of_t : t -> string
 
-val recdty_field_types : Types.datatype -> Types.datatype StringMap.t
+val recdty_field_types : Types.datatype -> Types.datatype Types.FieldEnv.t
 
 val env_of_value_env : CommonTypes.QueryPolicy.t ->  Value.env -> env
 
@@ -97,8 +97,8 @@ val default_of_base_type : Primitive.t -> t
 
 val value_of_expression : t -> Value.t
 
-val labels_of_field_types : 'a Utility.StringMap.t -> Utility.StringSet.t
-val table_field_types : Value.table -> Types.typ Utility.StringMap.t
+val labels_of_field_types : 'a Types.FieldEnv.t -> Utility.StringSet.t
+val table_field_types : Value.table -> Types.typ Types.FieldEnv.t
 val is_list : t -> bool
 
 val likeify : t -> t option

--- a/core/sugartoir.ml
+++ b/core/sugartoir.ml
@@ -429,8 +429,8 @@ struct
   let record (fields, r) =
     let field_types =
       List.fold_left
-        (fun field_types (name, s) -> StringMap.add name (sem_type s) field_types)
-        StringMap.empty
+        (fun field_types (name, s) -> Types.FieldEnv.add name (sem_type s) field_types)
+        Types.FieldEnv.empty
         fields in
     let s' = lift_alist fields in
       match r with
@@ -438,13 +438,13 @@ struct
             let t = Types.make_record_type field_types in
               M.bind s'
                 (fun fields ->
-                   lift (Extend (StringMap.from_alist fields, None), t))
+                   lift (Extend (Types.FieldEnv.from_alist fields, None), t))
         | Some s ->
             let t = Types.Record (Types.extend_row field_types (TypeUtils.extract_row (sem_type s))) in
               bind s
                 (fun r ->
                    M.bind s'
-                     (fun fields -> lift (Extend (StringMap.from_alist fields, Some r), t)))
+                     (fun fields -> lift (Extend (Types.FieldEnv.from_alist fields, Some r), t)))
 
   let project (s, name) =
     let t = TypeUtils.project_type name (sem_type s) in

--- a/core/transformSugar.ml
+++ b/core/transformSugar.ml
@@ -24,7 +24,7 @@ let type_section env =
       let (fields, rho, _) = TypeUtils.extract_row_parts row in
       let eb, e = Types.fresh_row_quantifier default_effect_subkind in
 
-      let r = Record (Row (StringMap.add label (Present a) fields, rho, false)) in
+      let r = Record (Row (FieldEnv.add label (Present a) fields, rho, false)) in
         ForAll ([ab; rhob; eb],
                 Function (Types.make_tuple_type [r], e, a))
   | Name var -> TyEnv.find var env
@@ -432,13 +432,13 @@ class transform (env : Types.typing_environment) =
           let (o, fields, field_types) =
             let rec list o =
               function
-                | [] -> (o, [], StringMap.empty)
+                | [] -> (o, [], FieldEnv.empty)
                 | (name, e)::fields ->
                     let (o, e, t) = o#phrase e in
                     let (o, fields, field_types) = list o fields in
                       (o,
                        (name, e)::fields,
-                       StringMap.add name t field_types)
+                       FieldEnv.add name t field_types)
             in
               list o fields in
           let (o, base, base_type) = option o (fun o -> o#phrase) base in
@@ -471,7 +471,7 @@ class transform (env : Types.typing_environment) =
                let  ( fs, rv, closed ) =
                  Types.flatten_row row |> TypeUtils.extract_row_parts
                in
-               let fs = List.fold_left2 (fun fs (name, _) t -> StringMap.add name (Present t) fs) fs fields ts in
+               let fs = List.fold_left2 (fun fs (name, _) t -> FieldEnv.add name (Present t) fs) fs fields ts in
                Record (Row (fs, rv, closed))
             | _ -> t
           in

--- a/core/typeUtils.mli
+++ b/core/typeUtils.mli
@@ -44,7 +44,7 @@ val choice_at : string -> Types.datatype -> Types.datatype
 val primary_kind_of_type : Types.datatype -> PrimaryKind.t
 val check_type_wellformedness : PrimaryKind.t option -> Types.datatype -> unit
 
-val row_present_types : Types.datatype -> Types.datatype Utility.StringMap.t
+val row_present_types : Types.datatype -> Types.datatype Types.FieldEnv.t
 
 val pack_types : Types.datatype list -> Types.datatype
 

--- a/core/types.mli
+++ b/core/types.mli
@@ -2,8 +2,9 @@
 open CommonTypes
 
 (* field environments *)
+module FieldEnv : Utility.Map.S with type key = string
 type 'a stringmap = 'a Utility.StringMap.t [@@deriving show]
-type 'a field_env = 'a stringmap [@@deriving show]
+type 'a field_env = 'a FieldEnv.t [@@deriving show]
 
 (* type var sets *)
 module TypeVarSet : sig
@@ -164,7 +165,7 @@ and session_type = typ
 and datatype = typ
 and type_arg = PrimaryKind.t * typ
 and field_spec = typ
-and field_spec_map = field_spec Utility.StringMap.t
+and field_spec_map = field_spec field_env
 and meta_type_var = typ point
 and meta_row_var = row point
 and meta_presence_var = typ point

--- a/core/typevarcheck.ml
+++ b/core/typevarcheck.ml
@@ -1,8 +1,6 @@
 open Utility
 open Types
 
-module FieldEnv = Utility.StringMap
-
 (* TODO
 
    - Actually make use of the bool argument to is_guarded_row.  We
@@ -93,7 +91,7 @@ let rec is_guarded : TypeVarSet.t -> StringSet.t -> int -> datatype -> bool =
         | Row (fields, row_var, _dual) ->
            let check_fields = false in
            (if check_fields then
-              (StringMap.fold
+              (FieldEnv.fold
                  (fun _ f b -> b && isg f)
                  fields
                  true)

--- a/core/utility.ml
+++ b/core/utility.ml
@@ -962,14 +962,15 @@ struct
         | fa, fal ->
             Some (from_option a fa::from_option al fal)
 
-  let map_tryPick f m =
-    StringMap.fold
+  let unk_map_tryPick fold f m =
+    fold
       (fun k v acc -> lazy (match f k v with
         | None -> Lazy.force acc
         | y -> y))
       m
       (lazy None)
     |> Lazy.force
+  let map_tryPick f m = unk_map_tryPick StringMap.fold f m
 
   let rec list_tryPick f = function
     | [] -> None

--- a/tests/handlers.tests
+++ b/tests/handlers.tests
@@ -231,7 +231,7 @@ args : --enable-handlers
 
 Operation parameter pattern-matching (7)
 fun(m) { handle(m()) { case <Move(Alice)> -> 'A' case <Move(Bob)> -> 'B' case <Move(_)> -> 'U' case x -> x } }
-stdout : fun : (() {Move:([|Alice|Bob|_|]) => _::Any|c}~> Char) {Move{_}|c}~> Char
+stdout : fun : (() {Move:([|Bob|Alice|_|]) => _::Any|c}~> Char) {Move{_}|c}~> Char
 args : --enable-handlers
 
 Operation parameter pattern-matching (8)

--- a/tests/handlers_with_cfl_on.tests
+++ b/tests/handlers_with_cfl_on.tests
@@ -235,7 +235,7 @@ args : --enable-handlers
 
 Operation parameter pattern-matching (7)
 fun(m) { handle(m()) { case <Move(Alice)> -> 'A' case <Move(Bob)> -> 'B' case <Move(_)> -> 'U' case x -> x } }
-stdout : fun : (() {Move:([|Alice|Bob|_|]) => _::Any|c}~> Char) {Move{_}|c}~> Char
+stdout : fun : (() {Move:([|Bob|Alice|_|]) => _::Any|c}~> Char) {Move{_}|c}~> Char
 args : --enable-handlers
 
 Operation parameter pattern-matching (8)

--- a/tests/patterns.tests
+++ b/tests/patterns.tests
@@ -148,7 +148,7 @@ stdout : Quux : [|Bar-|Baz-|Foo-|Quux|_|]
 
 Negative pattern [12]
 (fun(x) { switch(x) { case (-(Foo, Bar, Baz) as x) -> x case _ -> Quux }})(FooBar)
-stdout : FooBar : [|Bar-|Baz-|Foo-|FooBar|Quux|_|]
+stdout : FooBar : [|Bar-|Baz-|Foo-|Quux|FooBar|_|]
 
 Presence polymorphism 1 [13]
 (fun (x : [|Foo| Bar{p}|]) { switch(x) {case Foo -> 1 case _ -> 2  }} )

--- a/tests/records.tests
+++ b/tests/records.tests
@@ -4,7 +4,7 @@ stdout : (x = 1, y = "two") : (x:Int,y:String)
 
 Quote record labels that are also keywords
 ("client"=5, "fun"=7)
-stdout : ("client" = 5, "fun" = 7) : (client:Int,fun:Int)
+stdout : ("client" = 5, "fun" = 7) : (fun:Int,client:Int)
 
 Record comparisons
 (x=1, y="two") == (y="two", x=1)


### PR DESCRIPTION
This PR fixes #1210 and the order of the `fn_params` member of the function descriptor.

The implementation of this fix adds a string map which has a different `compare` function: it first sorts keys on length, then on the content. This way, the string `10` is sorted after the string `2`. This map is then used in `Row` types.