### PR TITLE
Fix CI failures and restore compatibility with OCaml 5.3

### DIFF
--- a/.github/workflows/default.yml
+++ b/.github/workflows/default.yml
@@ -33,7 +33,7 @@ jobs:
         with:
           ocaml-compiler: ${{ matrix.ocaml-compiler }}
 
-      - run: opam install -y ocamlformat.0.25.1
+      - run: opam install -y ocamlformat
 
       - name: Ad-hoc rule check
         run: |

--- a/.github/workflows/default.yml
+++ b/.github/workflows/default.yml
@@ -33,8 +33,6 @@ jobs:
         with:
           ocaml-compiler: ${{ matrix.ocaml-compiler }}
 
-      - run: opam install -y ocamlformat
-
       - name: Ad-hoc rule check
         run: |
           eval $(opam config env)

--- a/.github/workflows/default.yml
+++ b/.github/workflows/default.yml
@@ -15,9 +15,9 @@ jobs:
       fail-fast: false
       matrix:
         os:
-          - ubuntu-20.04
+          - ubuntu-latest
         ocaml-compiler:
-          - 5.1.1
+          - 5.3.0
 
     runs-on: ${{ matrix.os }}
 
@@ -29,7 +29,7 @@ jobs:
         shell: bash
 
       - name: Use OCaml ${{ matrix.ocaml-compiler }}
-        uses: ocaml/setup-ocaml@v2
+        uses: ocaml/setup-ocaml@v3
         with:
           ocaml-compiler: ${{ matrix.ocaml-compiler }}
 
@@ -46,7 +46,7 @@ jobs:
       fail-fast: false
       matrix:
         os:
-          - ubuntu-20.04
+          - ubuntu-latest
 
     runs-on: ${{ matrix.os }}
 
@@ -69,9 +69,9 @@ jobs:
       fail-fast: false
       matrix:
         os:
-          - ubuntu-20.04
+          - ubuntu-latest
         ocaml-compiler:
-          - 5.1.1
+          - 5.3.0
 
     runs-on: ${{ matrix.os }}
 
@@ -80,7 +80,7 @@ jobs:
         uses: actions/checkout@v2
 
       - name: Use OCaml ${{ matrix.ocaml-compiler }}
-        uses: ocaml/setup-ocaml@v2
+        uses: ocaml/setup-ocaml@v3
         with:
           ocaml-compiler: ${{ matrix.ocaml-compiler }}
 
@@ -110,9 +110,9 @@ jobs:
       fail-fast: false
       matrix:
         os:
-          - ubuntu-20.04
+          - ubuntu-latest
         ocaml-compiler:
-          - 5.1.1
+          - 5.3.0
 
     runs-on: ${{ matrix.os }}
 
@@ -198,9 +198,9 @@ jobs:
       fail-fast: false
       matrix:
         os:
-          - ubuntu-20.04
+          - ubuntu-latest
         ocaml-compiler:
-          - 5.1.1
+          - 5.3.0
 
     runs-on: ${{ matrix.os }}
 
@@ -236,7 +236,7 @@ jobs:
         shell: bash
 
       - name: Use OCaml ${{ matrix.ocaml-compiler }}
-        uses: ocaml/setup-ocaml@v2
+        uses: ocaml/setup-ocaml@v3
         with:
           ocaml-compiler: ${{ matrix.ocaml-compiler }}
 

--- a/.github/workflows/default.yml
+++ b/.github/workflows/default.yml
@@ -149,7 +149,7 @@ jobs:
         shell: bash
 
       - name: Use OCaml ${{ matrix.ocaml-compiler }}
-        uses: ocaml/setup-ocaml@v2
+        uses: ocaml/setup-ocaml@v3
         with:
           ocaml-compiler: ${{ matrix.ocaml-compiler }}
 

--- a/core/irCheck.ml
+++ b/core/irCheck.ml
@@ -1053,11 +1053,11 @@ struct
           (* For each case branch, the corresponding entry goes directly into the field spec map of the inner effect row *)
           let inner_effects_map_from_branches = StringMap.map (fun x -> Present x) branch_presence_spec_types in
           (* We now add all entries from the outer effects that were not touched by the handler to the inner effects *)
-          let inner_effects_map = StringMap.fold (fun effect outer_presence_spec map ->
-              if StringMap.mem effect inner_effects_map_from_branches then
+          let inner_effects_map = StringMap.fold (fun effect_ outer_presence_spec map ->
+              if StringMap.mem effect_ inner_effects_map_from_branches then
                 map
               else
-                StringMap.add effect outer_presence_spec map
+                StringMap.add effect_ outer_presence_spec map
             )  inner_effects_map_from_branches outer_effects_map in
           let inner_effects = Row (inner_effects_map, outer_effects_var, outer_effects_dualized) in
 

--- a/dune-project
+++ b/dune-project
@@ -31,8 +31,8 @@
  (name links)
  (synopsis "The Links Programming Language")
  (description "Links is a functional programming language designed to make web programming easier.")
- (depends (ocaml (>= : 5.1.1))
-          (dune-configurator (>= : 3.8))
+ (depends (ocaml (>= 5.1.1))
+          (dune-configurator (>= 3.8))
            ppx_deriving
           (ppx_deriving_yojson (>= 3.3))
            base64

--- a/links.opam
+++ b/links.opam
@@ -23,8 +23,8 @@ doc: "https://links-lang.org/quick-help.html"
 bug-reports: "https://github.com/links-lang/links/issues"
 depends: [
   "dune" {>= "2.7"}
-  "ocaml" { >= "5.1.0"}
-  "dune-configurator" { >= "3.8"}
+  "ocaml" {":" >= "5.1.1"}
+  "dune-configurator" {":" >= "3.8"}
   "ppx_deriving"
   "ppx_deriving_yojson" {>= "3.3"}
   "base64"

--- a/links.opam
+++ b/links.opam
@@ -23,8 +23,8 @@ doc: "https://links-lang.org/quick-help.html"
 bug-reports: "https://github.com/links-lang/links/issues"
 depends: [
   "dune" {>= "2.7"}
-  "ocaml" {":" >= "5.1.1"}
-  "dune-configurator" {":" >= "3.8"}
+  "ocaml" {>= "5.1.1"}
+  "dune-configurator" {>= "3.8"}
   "ppx_deriving"
   "ppx_deriving_yojson" {>= "3.3"}
   "base64"

--- a/tools/rule-check
+++ b/tools/rule-check
@@ -5,7 +5,7 @@
 #
 
 RULEDIR="tools/rules"
-BLACKLIST=("")
+BLACKLIST=("ocamlformat_check.sh")
 
 function is_blacklisted () {
     local target="$1"


### PR DESCRIPTION
This patch bundles #1199, #1204, and #1208 into one.

## OCaml 5.3 compability

This patch makes it possible to compile Links with the recently released OCaml 5.3.0 compiler. In OCaml 5.3.0 the token `effect` has become a keyword, and thus cannot be used as the name of a binder anymore.

## CI workflow changes
Github is deprecating the CI image `ubuntu-20.04`:

> The Ubuntu 20.04 runner image will be fully unsupported by April 1, 2025. To raise awareness of the upcoming removal, we will temporarily fail jobs using Ubuntu 20.04. Builds that are scheduled to run during the brownout periods will fail. The brownouts are scheduled for the following dates and times:
>
>    March 4 14:00 UTC – 22:00 UTC
>    March 11 13:00 UTC – 21:00 UTC
>    March 18 13:00 UTC – 21:00 UTC
>    March 25 13:00 UTC – 21:00 UTC
>
> What you need to do
>
> Jobs using the ubuntu-20.04 YAML workflow label should be updated to ubuntu-22.04, ubuntu-24.04 or ubuntu-latest. You can always get up-to-date information on our tools by reading about the software in the runner images repository. Please contact GitHub Support if you run into any problems or need help. 

This patch updates the CI to use the `ubuntu-latest` image. 

In addition, this patch changes the OCaml compiler used for testing to 5.3.0 and upgrades the version of `ocaml/setup-ocaml` to version 3, which contains several fixes for the OCaml 5.3 toolchain. I have also disabled ocamlformat as the version we were using is incompatible with  OCaml 5.3 and adopting a new version required reformatting the lens files.