### PR TITLE
Raise minimum supported OCaml compiler to 5.3.0

### DIFF
--- a/dune-project
+++ b/dune-project
@@ -31,7 +31,7 @@
  (name links)
  (synopsis "The Links Programming Language")
  (description "Links is a functional programming language designed to make web programming easier.")
- (depends (ocaml (>= 5.1.1))
+ (depends (ocaml (>= 5.3.0))
           (dune-configurator (>= 3.8))
            ppx_deriving
           (ppx_deriving_yojson (>= 3.3))

--- a/links.opam
+++ b/links.opam
@@ -23,7 +23,7 @@ doc: "https://links-lang.org/quick-help.html"
 bug-reports: "https://github.com/links-lang/links/issues"
 depends: [
   "dune" {>= "2.7"}
-  "ocaml" {>= "5.1.1"}
+  "ocaml" {>= "5.3.0"}
   "dune-configurator" {>= "3.8"}
   "ppx_deriving"
   "ppx_deriving_yojson" {>= "3.3"}


### PR DESCRIPTION
This patch sets the minimum supported version of the OCaml compiler to 5.3.0. OCaml 5.3.0 introduced new syntax for effect handlers, so we need to set this lower bound if we want to take advantage of the syntax and at the same time distribute Links via OPAM.