### PR TITLE
Moved dependency chasing to the loader and fixed some tests

### DIFF
--- a/bin/driver.ml
+++ b/bin/driver.ml
@@ -30,6 +30,7 @@ module Phases = struct
           Parse.program
           source_code
       in
+      let program = Chaser.add_dependencies "" program in
       let context' = Context.({ context with source_code = pos_context }) in
       Loader.({ program_ = program; context = context' })
 
@@ -38,6 +39,7 @@ module Phases = struct
       let program, pos_context =
         Parse.Readline.parse ps1
       in
+      let program = Chaser.add_dependencies_sentence program in
       let context' = Context.({ context with source_code = pos_context }) in
       Loader.({ program_ = program; context = context' })
   end

--- a/core/chaser.mli
+++ b/core/chaser.mli
@@ -1,2 +1,2 @@
-val add_dependencies : Sugartypes.program -> Sugartypes.program
+val add_dependencies : string -> Sugartypes.program -> Sugartypes.program
 val add_dependencies_sentence : Sugartypes.sentence -> Sugartypes.sentence

--- a/core/desugarModules.ml
+++ b/core/desugarModules.ml
@@ -535,8 +535,6 @@ let renamer : Epithet.t ref = ref Epithet.empty
 let desugar_program : Sugartypes.program -> Sugartypes.program
   = fun program ->
   let interacting = Basicsettings.System.is_interacting () in
-  (* TODO move to this logic to the loader. *)
-  let program = Chaser.add_dependencies program in
   let program = DesugarAlienBlocks.transform_alien_blocks program in
   (* Printf.fprintf stderr "Before elaboration:\n%s\n%!" (Sugartypes.show_program program); *)
   let renamer', scope' = if interacting then !renamer, !scope else Epithet.empty, Scope.empty in
@@ -549,7 +547,6 @@ let desugar_program : Sugartypes.program -> Sugartypes.program
 
 let desugar_sentence : Sugartypes.sentence -> Sugartypes.sentence
   = fun sentence ->
-  let sentence = Chaser.add_dependencies_sentence sentence in
   let sentence = DesugarAlienBlocks.sentence sentence in
   let visitor = desugar ~toplevel:true !renamer !scope in
   let result = visitor#sentence sentence in

--- a/core/frontend.ml
+++ b/core/frontend.ml
@@ -123,8 +123,7 @@ module Untyped = struct
 
   (* Collection of transformers. *)
   let transformers : transformer array
-    = [| (module ResolvePositions)
-       ; (module CheckXmlQuasiquotes)
+    = [| (module CheckXmlQuasiquotes)
        ; (module DesugarSwitchFuns)
        ; (module DesugarModules)
        ; (module Shunting)

--- a/core/loader.ml
+++ b/core/loader.ml
@@ -4,12 +4,12 @@ type 'a result =
 
 let load : Context.t -> string -> Sugartypes.program result
   = fun context filename ->
+  let root = Filename.dirname filename in
   let program, pos_context =
-    ModuleUtils.try_parse_file filename
+    ModuleUtils.try_parse_file ~root:"" filename
   in
+  let program = (ResolvePositions.resolve_positions pos_context)#program program in
+  let program = Chaser.add_dependencies root program in
   let context' = Context.{ context with source_code = pos_context } in
   { context   = context';
     program_  = program }
-
-
-

--- a/core/moduleUtils.ml
+++ b/core/moduleUtils.ml
@@ -34,7 +34,7 @@ type term_shadow_table = string list stringmap
 type type_shadow_table = string list stringmap
 type shadow_table = string list stringmap
 
-let try_parse_file filename =
+let try_parse_file ~root filename =
   (* First, get the list of directories, with trailing slashes stripped *)
   let check_n_chop path =
     let dir_sep = Filename.dir_sep in
@@ -57,7 +57,7 @@ let try_parse_file filename =
 
   let poss_dirs =
     let paths = Settings.get links_file_paths in
-    "" :: poss_stdlib_dir @ (List.map (check_n_chop) paths)
+    root :: poss_stdlib_dir @ (List.map (check_n_chop) paths)
   in
 
   (* Loop through, trying to open the module with each path *)

--- a/core/moduleUtils.mli
+++ b/core/moduleUtils.mli
@@ -12,7 +12,7 @@ type type_shadow_table = string list stringmap
 type shadow_table = string list stringmap
 
 val module_sep : string
-val try_parse_file : string -> (Sugartypes.program * Scanner.position_context)
+val try_parse_file : root:string -> string -> (Sugartypes.program * Scanner.position_context)
 val contains_modules : Sugartypes.program -> bool
 val separate_modules : Sugartypes.binding list -> (Sugartypes.binding list * Sugartypes.binding list)
 val get_ffi_files : Sugartypes.program -> string list

--- a/core/parser.mly
+++ b/core/parser.mly
@@ -841,6 +841,7 @@ conditional_expression:
 
 case:
 | CASE pattern RARROW case_contents                           { $2, block ~ppos:$loc($4) $4 }
+| CASE OTHERWISE RARROW case_contents                         { any_pat $loc($2), block ~ppos:$loc($4) $4 }
 
 case_expression:
 | SWITCH LPAREN exp RPAREN LBRACE case* RBRACE                 { with_pos $loc (Switch ($3, $6, None)) }

--- a/examples/church.links
+++ b/examples/church.links
@@ -9,13 +9,16 @@ fun succ(n) {fun (z)(s){s(n(z)(s))}}
 sig add : (Nat) {}-> (Nat) {}-> Nat
 fun add(m)(n) {fun (z)(s) {m(n(z)(s))(s)}}
 
+sig coerceToplevel : ((a) {}-> b) -f-> ((a) -e-> b)
+fun coerceToplevel(f) {f : ((a) -e-> b) <- ((a) {}-> b)}
+
 sig two : Nat
-var two = succ(succ(zero));
+var two = coerceToplevel(succ)(coerceToplevel(succ)(zero));
 
 sig four : Nat
-var four = add(two)(two);
+var four = coerceToplevel(coerceToplevel(add)(two))(two);
 
 sig natToInt : (Nat) {}-> Int
 fun natToInt(n) {n(0)(fun (x) {x+1})}
 
-natToInt(four)
+coerceToplevel(natToInt)(four)

--- a/examples/handlers/count_web.links
+++ b/examples/handlers/count_web.links
@@ -1,6 +1,6 @@
 # A port of the simple counting benchmark from Kammar et al. (2013)
 
-sig evalState : (Comp({Get:s ,Put:(s) {}-> ()|e}, a)) -> # Stateful computation
+sig evalState : (Comp(a, {Get:s ,Put:(s) {}-> ()|e})) -> # Stateful computation
                 (s) {Get{_},Put{_} |e}~> a
 fun evalState(m)(st) client {
   var run =
@@ -12,7 +12,7 @@ fun evalState(m)(st) client {
   run(st)
 }
 
-sig count : Comp({Get:Int,Put:(Int) {}-> ()|e}, Int)
+sig count : Comp(Int, {Get:Int,Put:(Int) {}-> ()|e})
 fun count() client {
   var n = do Get;
   if (n == 0) n

--- a/examples/handlers/toggle.links
+++ b/examples/handlers/toggle.links
@@ -8,7 +8,7 @@ sig put : (s) {Put:(s) {}-> () |_}-> ()
 fun put(st) {do Put(st)}
 
 # Stateful computation
-sig toggle : Comp({Get:Bool,Put:(Bool) {}-> () |_}, Bool)
+sig toggle : Comp(Bool, {Get:Bool,Put:(Bool) {}-> () |_})
 fun toggle() client {
   var bit = get();
   put(not(bit));
@@ -16,9 +16,9 @@ fun toggle() client {
 }
 
 # State handler
-sig runState : (Comp({Get:s ,Put:(s) {}-> () |e},  a  )) -> # Stateful computation
-               (s)                                       -> # Initial state
-                Comp({Get{_},Put{_}          |e}, (a,s))    # Stateless computation
+sig runState : (Comp( a   , {Get:s ,Put:(s) {}-> () |e})) -> # Stateful computation
+               (s)                                        -> # Initial state
+                Comp((a,s), {Get{_},Put{_}          |e})     # Stateless computation
 fun runState(m)(st)() client {
   var run = handle(m()) {
     case x      -> fun(ret_st) { (x,ret_st) }

--- a/examples/handlers/toggle_web.links
+++ b/examples/handlers/toggle_web.links
@@ -8,7 +8,7 @@ sig put : (s) {Put:(s) {}-> () |_}-> ()
 fun put(st) {do Put(st)}
 
 # Stateful computation
-sig toggle : Comp({Get:Bool,Put:(Bool) {}-> () |_}, Bool)
+sig toggle : Comp(Bool, {Get:Bool,Put:(Bool) {}-> () |_})
 fun toggle() client {
   var bit = get();
   put(not(bit));
@@ -16,9 +16,9 @@ fun toggle() client {
 }
 
 # State handler
-sig runState : (Comp({Get:s ,Put:(s) {}-> () |e},  a  )) -> # Stateful computation
-               (s)                                       -> # Initial state
-                Comp({Get{_},Put{_}          |e}, (a,s))    # Stateless computation
+sig runState : (Comp( a   , {Get:s ,Put:(s) {}-> () |e})) -> # Stateful computation
+               (s)                                        -> # Initial state
+                Comp((a,s), {Get{_},Put{_}          |e})     # Stateless computation
 fun runState(m)(st)() client {
   var run = handle(m()) {
     case x      -> fun(ret_st) { (x,ret_st) }
@@ -46,7 +46,7 @@ fun stringToBool(s) {
 }
 
 fun enableButton(btn) {
-  domRemoveAttributeFromRef(getNodeById(btn), "disabled");
+  ignore(domRemoveAttributeFromRef(getNodeById(btn), "disabled"))
 }
 
 fun disableButton(btn) {

--- a/examples/webserver/examples-nodb.links
+++ b/examples/webserver/examples-nodb.links
@@ -22,10 +22,10 @@ fun main() {
   addStaticRoute("/examples/", "examples/", [("links", "text/plain")]);
   addStaticRoute("/examplessrc/", "examples/", [("links", "text/plain")]);
 
-  addRoute("/examples/draggable.links", fun(_) {Draggable.main()});
-  addRoute("/examples/progress.links", fun(_) {Progress.main()});
+  addRoute("/examples/draggable.links", fun(_) {Draggable.mainPage((), ())});
+  addRoute("/examples/progress.links", Progress.mainPage);
 
-  addRoute("/examples/buttons.links", fun(_) {Buttons.main()});
+  addRoute("/examples/buttons.links", Buttons.mainpage);
   addRoute("/examples/formsTest.links", fun(_) {FormsTest.main()});
 
   addRoute("/examples/validate.links", fun(_) {Validate.main()});

--- a/examples/webserver/examples.links
+++ b/examples/webserver/examples.links
@@ -34,15 +34,15 @@ fun main() {
   addStaticRoute("/examplessrc/", "examples/", [("links", "text/plain")]);
 
   addRoute("/examples/dictionary/dictSuggestUpdate.links", fun(_){DictSuggestUpdate.main()});
-  addRoute("/examples/draggable.links", fun(_) {Draggable.main()});
-  addRoute("/examples/progress.links", fun(_) {Progress.main()});
+  addRoute("/examples/draggable.links", fun(_) {Draggable.mainPage((), ())});
+  addRoute("/examples/progress.links", Progress.mainPage);
 
   addRoute("/examples/factorial.links", fun(_) {Factorial.main()});
   addRoute("/examples/dictionary/dictSuggest.links", fun(_){DictSuggest.main()});
   addRoute("/examples/dictionary/dictSuggestLite.links", fun(_){DictSuggestLite.main()});
   addRoute("/examples/draggableDb.links", fun(_) {DraggableDb.main()});
 
-  addRoute("/examples/buttons.links", fun(_) {Buttons.main()});
+  addRoute("/examples/buttons.links", Buttons.mainpage);
   addRoute("/examples/formsTest.links", fun(_) {FormsTest.main()});
 
   addRoute("/examples/validate.links", fun(_) {Validate.main()});

--- a/test-harness
+++ b/test-harness
@@ -7,7 +7,7 @@ import concurrent.futures, threading, multiprocessing
 from os import path
 from subprocess import Popen, PIPE
 
-successes = failures = ignored = 0
+successes = failures = skipsuccesses = ignored = 0
 TIMEOUT = 15 # seconds before a test is timed out.
 
 the_lock = threading.Lock()
@@ -71,6 +71,11 @@ def OK(name):
     global successes
     successes+=1
     print(' SUCCESS: %s' % name)
+def OK_skip(name):
+    global successes, skipsuccesses
+    successes+=1
+    skipsuccesses+=1
+    print('?IGNORED: %s (test passed, but marked as skip)' % name)
 
 def parse(stream):
     """Read test information separated by blank lines.  The first line
@@ -180,9 +185,12 @@ def evaluate(name, code, config_file, stdout='', stderr='', exit = '0', env = No
             passed &= check_expected(name, 'stderr', str(proc.stderr.read().decode('ascii')), stderr, errors)
             if passed:
                 with the_lock:
-                    OK(name)
+                    if ignore is None:
+                        OK(name)
+                    else:
+                        OK_skip(name)
             else:
-                if ignore != None:
+                if ignore is not None:
                     global ignored
                     with the_lock:
                         ignored += 1
@@ -274,7 +282,7 @@ def main():
                               "the following exception:\n%s")
                              % (job_name, result.exception()))
 
-    print("%d failures (+%d ignored)\n%d successes\n" % (failures, ignored, successes))
+    print("%d failures (+%d ignored)\n%d successes%s\n" % (failures, ignored, successes, ("" if skipsuccesses == 0 else " (with %d ignored)" % skipsuccesses)))
     if failures > 0:
         sys.exit(1)
     else:

--- a/tests/freezeml.tests
+++ b/tests/freezeml.tests
@@ -210,7 +210,6 @@ Do not infer polymorphic arguments (3)
 tests/freezeml/session1.links
 exit : 1
 stderr : @.*Type error:.*
-ignore : Failing test case, as Mono kinds get converted to Session.
 
 Do not infer polymorphic arguments (4)
 tests/freezeml/session2.links

--- a/tests/tuples.tests
+++ b/tests/tuples.tests
@@ -45,5 +45,4 @@ stdout : (1 = "one") : (1:String)
 
 Quasituples
 (1="foo", 3="bar")
-stdout : (1 = "foo", 3 = "bar") : (1:String, 3:String)
-ignore : The type is currently printed as (String, String). Is this really what we want?
+stdout : (1 = "foo", 3 = "bar") : (1:String,3:String)

--- a/tests/typecheck_examples.tests
+++ b/tests/typecheck_examples.tests
@@ -61,7 +61,6 @@ filemode : true
 Typecheck example file examples/church.links
 examples/church.links
 filemode : true
-ignore : broken example
 
 Typecheck example file examples/citations.links
 examples/citations.links
@@ -459,7 +458,6 @@ filemode : true
 Typecheck example file examples/sessions/counter.links
 examples/sessions/counter.links
 filemode : true
-ignore : broken example
 
 Typecheck example file examples/sessions/draggable-boring.links
 examples/sessions/draggable-boring.links
@@ -663,7 +661,6 @@ filemode : true
 Typecheck example file examples/toggle.links
 examples/toggle.links
 filemode : true
-ignore : broken example
 
 Typecheck example file examples/validate.links
 examples/validate.links
@@ -772,4 +769,3 @@ filemode : true
 Typecheck example file examples/mvu/changePage.links
 examples/mvu/changePage.links
 filemode : true
-


### PR DESCRIPTION
This PR:
- removes some `ignore` lines in the tests file for tests that are now passing;
- fixes some tests;
- moves the dependency chasing to the loader (as the comment suggests) so that we can search for files next to the current one (i.e. while compiling `example/foo.links`, the module `Bar` will be searched in `example/bar.links` instead of `bar.links`);
- adds the `case otherwise ->` construct as an alias to the `case _ ->` construct;
- adds a message to the testing output in case a test that was skipped is now passing.