### PR TITLE
Effects typechecking fixes

### DIFF
--- a/core/parser.mly
+++ b/core/parser.mly
@@ -1400,7 +1400,8 @@ resumable_operation_pattern:
 | operation_pattern FATRARROW pattern
     { with_pos $loc (Pattern.Operation (fst $1, snd $1, $3, DeclaredLinearity.Unl)) }
 | operation_pattern FATLOLLI pattern
-    { with_pos $loc (Pattern.Operation (fst $1, snd $1, $3, DeclaredLinearity.Lin)) }
+    { with_pos $loc (Pattern.Operation (fst $1, snd $1, $3,
+      if lincont_enabled then DeclaredLinearity.Lin else DeclaredLinearity.Unl)) }
 | operation_pattern RARROW pattern
     { with_pos $loc (Pattern.Operation (fst $1, snd $1, $3, DeclaredLinearity.Unl)) }
 | operation_pattern

--- a/core/parser.mly
+++ b/core/parser.mly
@@ -709,7 +709,8 @@ unary_expression:
 | OPERATOR unary_expression                                    { unary_appl ~ppos:$loc (UnaryOp.Name $1)  $2 }
 | postfix_expression | constructor_expression                  { $1 }
 | DOOP CONSTRUCTOR loption(arg_spec)                           { with_pos $loc (DoOperation (with_pos $loc($2) (Operation $2), $3, None, DeclaredLinearity.Unl)) }
-| LINDOOP CONSTRUCTOR loption(arg_spec)                        { with_pos $loc (DoOperation (with_pos $loc($2) (Operation $2), $3, None, DeclaredLinearity.Lin)) }
+| LINDOOP CONSTRUCTOR loption(arg_spec)                        { with_pos $loc (DoOperation (with_pos $loc($2) (Operation $2), $3, None,
+  if lincont_enabled then DeclaredLinearity.Lin else DeclaredLinearity.Unl)) }
 
 infix_appl:
 | unary_expression                                             { $1 }

--- a/core/typeSugar.ml
+++ b/core/typeSugar.ml
@@ -683,16 +683,16 @@ end
                   "while the computation can perform effects" ^ nl() ^
                   tab() ^ code (show_type rt))
 
-    let do_operation ~pos ~t1:(_,lt) ~t2:(rexpr,rt) ~error:_ =
+    let do_operation ~pos ~t1:(resume,lt) ~t2:(_,rt) ~error:_ =
       build_tyvar_names [lt;rt];
-      let dropDoPrefix = Str.substitute_first (Str.regexp "do ") (fun _ -> "") in
-      let operation = dropDoPrefix (code rexpr) in
-      die pos ("Invocation of the operation " ^ nl() ^
-          tab() ^ operation ^ nl() ^
-          "requires an effect context " ^ nl() ^
-          tab() ^ code (show_effectrow (TypeUtils.extract_row rt)) ^ nl() ^
-          "but, the currently allowed effects are" ^ nl()
-               ^ tab() ^ code ( show_effectrow (TypeUtils.extract_row lt)))
+      let dropDoPrefix = Str.substitute_first (Str.regexp {|^\(lin\)?do |}) (fun _ -> "") in
+      let operation = code (dropDoPrefix resume) in
+      die pos ("Invocation of the operation" ^ nli() ^
+          operation ^ nl() ^
+          "requires an effect context" ^ nli() ^
+          code (show_type lt) ^ nl() ^
+          "but, the currently allowed effect is" ^ nli()
+               ^ code (show_type rt))
 
     let try_effect ~pos ~t1:(_,lt) ~t2:(_,rt) ~error:_ =
       build_tyvar_names [lt;rt];
@@ -4592,7 +4592,7 @@ let rec type_check : context -> phrase -> phrase * Types.datatype * Usage.t =
             unify ~handle:Gripers.do_operation
               (term, infer_opt) ;
             unify ~handle:Gripers.do_operation
-              (no_pos (T.Effect context.effect_row), (p, T.Effect row))
+              ((p, T.Effect row), no_pos (T.Effect context.effect_row))
           in
           (* postponed *)
           (* let () = if is_lindo then () *)


### PR DESCRIPTION
This PR fixes two issues:
- If one kind of unification issue related to effects occurs, the old `links` tries to generate an error message but the content of that error message generates an internal error;
- If linearity is not tracked, `lindo` should be parsed exactly the same as `do` and `case <Foo =@ k>` like `case <Foo => k>`.

MWE:
```
sig f : () {A:() =@ Bool|_}~> Bool
fun f() { lindo A() }
```
This MWE generates the error in the old `links` when it is supposed to be correct.
Note that removing the signature of `f` makes it work regardless of the fix, as the type will be automatically inferred with a linear effect before linearity is dropped.

```
sig f : (s) {A:(s) {}-> () |_}-> ()
fun f(st) {do A(st)}
```
This MWE generates an internal error in the old `links`. The proposed fix transforms this internal error into the expected normal error:
```
test.links:2: Type error: Invocation of the operation
    `A(st)'
requires an effect context
    `() => (a) {}-> ()'
but, the currently allowed effect is
    `(a) => (a) {}-> ()'
In expression: do A(st).
```