### PR TITLE
Fix higher-order CPS

### DIFF
--- a/core/irtojs.ml
+++ b/core/irtojs.ml
@@ -706,12 +706,12 @@ module Higher_Order_Continuation : CONTINUATION = struct
            let k = gensym ~prefix:"_kappa" () in
            (fun code -> bs (Bind (k, v, code))), ks, Var k
         | Cons ((Var _) as v, kappas) ->
-           bind bs (fun kappas -> Cons (v, kappas)) kappas
+           bind bs (fun kappas -> ks (Cons (v, kappas))) kappas
         | Cons (v, kappas) ->
            let k = gensym ~prefix:"_kappa" () in
            bind
              (fun code -> bs (Bind (k, v, code)))
-             (fun kappas -> Cons (Var k, kappas)) kappas
+             (fun kappas -> ks (Cons (Var k, kappas))) kappas
   in
   let bs, ks, seed = bind Code.MetaContinuation.identity (fun kappas -> kappas) kappas in
   bs (body (ks (reflect seed)))

--- a/core/irtojs.ml
+++ b/core/irtojs.ml
@@ -712,9 +712,9 @@ module Higher_Order_Continuation : CONTINUATION = struct
            bind
              (fun code -> bs (Bind (k, v, code)))
              (fun kappas -> ks (Cons (Var k, kappas))) kappas
-  in
-  let bs, ks, seed = bind Code.MetaContinuation.identity (fun kappas -> kappas) kappas in
-  bs (body (ks (reflect seed)))
+    in
+    let bs, ks, seed = bind Code.MetaContinuation.identity (fun kappas -> kappas) kappas in
+    bs (body (ks (reflect seed)))
 
   let apply ?(strategy=`Yield) k arg =
     let open Code in

--- a/examples/handlers/count_web.links
+++ b/examples/handlers/count_web.links
@@ -1,20 +1,20 @@
 # A port of the simple counting benchmark from Kammar et al. (2013)
 
-sig evalState : (Comp({Get:s ,Put:(s) {}-> ()|e}, a)) -> # Stateful computation
+sig evalState : (Comp(a, {Get:() => s ,Put:(s) => ()|e})) -> # Stateful computation
                 (s) {Get{_},Put{_} |e}~> a
 fun evalState(m)(st) client {
   var run =
-    handle(m) {
+    handle(m()) {
       case x      -> fun(_) { x }
-      case <Get => resume>     -> fun(st) { resume(st)(st) }
+      case <Get() => resume>     -> fun(st) { resume(st)(st) }
       case <Put(st) => resume> -> fun(s) { resume(())(st) }
     };
   run(st)
 }
 
-sig count : Comp({Get:Int,Put:(Int) {}-> ()|e}, Int)
+sig count : Comp(Int, {Get:() => Int,Put:(Int) => ()|e})
 fun count() client {
-  var n = do Get;
+  var n = do Get();
   if (n == 0) n
   else { do Put(n-1); count() }
 }

--- a/examples/handlers/nim-webversion.links
+++ b/examples/handlers/nim-webversion.links
@@ -823,7 +823,7 @@ fun main_page(_) {
 sig main: () ~> ()
 fun main() {
     addRoute("/", main_page);
-    addStaticRoute("/js", "js", [("js", "text/javascript")]);
+    addStaticRoute("/js", "examples/handlers/js", [("js", "text/javascript")]);
     servePages()
 }
 


### PR DESCRIPTION
This patch fixes a bug in the JavaScript backend wrt. the name generation logic in the higher-order continuation module. Previously, name binding the continuation could inadvertently drop a prefix of the static continuation.

I have manually tested the few web examples that we have, and verified that the test case in #1097 works as expected now.

Resolves #1097